### PR TITLE
Record note usage in vault_summary (closes #32)

### DIFF
--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -204,7 +204,7 @@ def vault_summary(path_or_query: str) -> dict:
     import json
 
     from ..schema import DB_PATH, get_db
-    from ..search import hybrid_search
+    from ..search import _record_note_usage, hybrid_search
 
     _, embed_url = _cfg()
     conn = get_db(DB_PATH)
@@ -229,6 +229,8 @@ def vault_summary(path_or_query: str) -> dict:
 
     if not row:
         return {"error": "Note not found"}
+
+    _record_note_usage(conn, [row["path"]])
 
     return {
         "path": row["path"],


### PR DESCRIPTION
## Summary

`vault_graph` and `vault_related` were wired into `_record_note_usage` in 6cf45e2, but `vault_summary` was missed. A direct-path summary fetch (`search_tools.py:195`) returned without recording a usage event, so notes surfaced only via `vault_summary` stayed cold in the excitability report — the last gap from #32.

## Change

- Call the existing `_record_note_usage(conn, [path])` helper on the resolved note before returning, matching graph/related/triples/ask.
- Reuses the deduped, non-blocking helper — no new machinery.

## Verification

- ruff clean, 446 tests pass
- Helper already unit-tested (`test_record_note_usage_helper`); parity with graph/related which wired the same helper.

Closes #32.