### PR TITLE
Let harvest emit 'context' memories (closes #30)

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -595,10 +595,16 @@ def _llm_classify(
             "genuinely useful insight worth remembering long-term. "
             "Insights include: architectural decisions, bug root causes, "
             "tool configurations, user corrections/preferences, "
-            "discovered facts about infrastructure.\n\n"
+            "discovered facts about infrastructure, and ephemeral "
+            "session-scoped facts (credentials, endpoints, URLs, "
+            "current-state notes that go stale quickly).\n\n"
             "Skip boilerplate, status updates, and routine tool output.\n\n"
+            "Type guide: bug=root cause/fix, decision=choice made, "
+            "convention=rule to always follow, learning=discovered fact, "
+            "observation=durable infrastructure fact, "
+            "context=ephemeral/short-lived fact kept only short-term.\n\n"
             "For each message, respond with EXACTLY one line:\n"
-            "[N] KEEP type=<bug|decision|convention|learning|observation> "
+            "[N] KEEP type=<bug|decision|convention|learning|observation|context> "
             "summary=<one sentence summary>\n"
             "OR:\n"
             "[N] SKIP\n\n"
@@ -644,7 +650,7 @@ def _llm_classify(
             if 0 <= idx < len(batch):
                 c = batch[idx].copy()
                 etype = m.group(2).strip()
-                valid = {"bug", "decision", "convention", "learning", "observation"}
+                valid = {"bug", "decision", "convention", "learning", "observation", "context"}
                 if etype in valid:
                     c["entity_type"] = etype
                 else:

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,6 +1,7 @@
 """Tests for neurostack.harvest — session transcript insight extraction."""
 
 import json
+from types import SimpleNamespace
 
 from neurostack.harvest import (
     AiderProvider,
@@ -10,6 +11,7 @@ from neurostack.harvest import (
     _extract_gemini_content,
     _extract_tags,
     _extract_text_claude,
+    _llm_classify,
     _load_harvest_state,
     _make_summary,
     _parse_jsonl,
@@ -485,3 +487,54 @@ class TestHarvestState:
         _save_harvest_state({"second": 2.0})
         loaded = _load_harvest_state()
         assert loaded == {"second": 2.0}
+
+
+# ---------------------------------------------------------------------------
+# _llm_classify — type validation (regression for #30)
+# ---------------------------------------------------------------------------
+
+class TestLlmClassify:
+    """The LLM classifier's valid-type set gates which entity types harvest emits."""
+
+    @staticmethod
+    def _stub_llm(monkeypatch, content):
+        """Make _llm_classify see a fixed LLM response, with no real config/network."""
+        import httpx
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": content}}]}
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp())
+        cfg = SimpleNamespace(llm_api_key=None)
+        monkeypatch.setattr("neurostack.config.get_config", lambda: cfg)
+        monkeypatch.setattr("neurostack.config._auth_headers", lambda _key: {})
+
+    def test_context_type_accepted(self, monkeypatch):
+        # context is a real memory type (TTL-168h branch) but was missing from the
+        # classifier's valid set, so harvest could never emit it — see issue #30.
+        self._stub_llm(
+            monkeypatch,
+            "[1] KEEP type=context summary=Vault LXC token expires Friday, rotate before then",
+        )
+        candidates = [{
+            "text": "The vault LXC token expires Friday — rotate it before then.",
+            "role": "assistant",
+            "prefilter_type": "observation",
+        }]
+        out = _llm_classify(candidates, "http://llm.test", "model")
+        assert len(out) == 1
+        assert out[0]["entity_type"] == "context"
+
+    def test_unknown_type_falls_back_to_prefilter(self, monkeypatch):
+        self._stub_llm(monkeypatch, "[1] KEEP type=banana summary=nonsense label")
+        candidates = [{
+            "text": "Some candidate insight text long enough to be considered.",
+            "role": "assistant",
+            "prefilter_type": "observation",
+        }]
+        out = _llm_classify(candidates, "http://llm.test", "model")
+        assert out[0]["entity_type"] == "observation"


### PR DESCRIPTION
## Summary

`context` is a supported memory type with a TTL-168h branch in `harvest.py`, but it was missing from `_llm_classify`'s valid set (`harvest.py:647`) and from the classifier prompt (`harvest.py:601`). So the harvester could **never** emit it — the TTL path was dead code, and every `context` memory had to be hand-written via `vault_remember`, skewing the type distribution (~38% observation vs ~2% context).

## Change

- Add `"context"` to the `_llm_classify` valid set.
- Add `context` to the prompt's type enum and a short definition (ephemeral / session-scoped facts: credentials, endpoints, URLs, current-state notes that go stale quickly), plus a one-line type guide for all types.
- Regression tests for `_llm_classify` (previously untested): `context` is accepted; an unknown type falls back to the prefilter type.

## Scope note

The optional prefilter rerouting of credential-pattern matches to `context` (part 3 of the issue) is intentionally **left as a follow-up** — it changes existing `observation` capture behaviour and isn't required to unblock context emission. Happy to do it separately if wanted.

## Verification

- ruff clean, 448 tests pass (446 + 2 new)
- The new `test_context_type_accepted` fails on `main` (context falls back to `observation`), confirming it guards the fix.

Closes #30.