### PR TITLE
Auto-run excitability decay; make vault_stats read-only; two-way status (closes #31)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -567,13 +567,17 @@ def main():
     p.set_defaults(func=cmd_record_usage)
 
     # hooks
-    p = sub.add_parser("hooks", help="Manage automation hooks (harvest timer)")
+    p = sub.add_parser("hooks", help="Manage automation hooks (harvest + decay timers)")
     hooks_sub = p.add_subparsers(dest="hooks_command")
     hp = hooks_sub.add_parser("install", help="Install automation hooks")
     hp.add_argument("--type", default="harvest-timer",
+                    choices=["harvest-timer", "decay-timer"],
                     help="Hook type (default: harvest-timer)")
     hooks_sub.add_parser("status", help="Show hook status")
-    hooks_sub.add_parser("remove", help="Remove automation hooks")
+    rp = hooks_sub.add_parser("remove", help="Remove automation hooks")
+    rp.add_argument("--type", default="harvest-timer",
+                    choices=["harvest-timer", "decay-timer"],
+                    help="Hook type to remove (default: harvest-timer)")
     p.set_defaults(func=cmd_hooks)
 
     # context

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -694,6 +694,9 @@ def cmd_decay(args):
             print(f"\n  Demoted {result['demoted']} notes to dormant status")
             for p in result["paths"]:
                 print(f"    {p}")
+            print(f"  Promoted {result['promoted']} notes back to active status")
+            for p in result["promoted_paths"]:
+                print(f"    {p}")
         return
 
     report = get_dormancy_report(

--- a/src/neurostack/cli/sessions.py
+++ b/src/neurostack/cli/sessions.py
@@ -210,6 +210,73 @@ def cmd_harvest(args):
     print(f"\n  Total: {n_saved} saved, {n_skip} skipped ({total} found)")
 
 
+_DECAY_TIMER = {
+    "unit": "neurostack-decay",
+    "service_desc": "NeuroStack excitability decay - sync note hotness status",
+    "exec": "%h/.local/bin/neurostack decay --demote",
+    "timer_desc": "Run neurostack excitability decay daily",
+    "on_calendar": "*-*-* 03:00:00",
+}
+
+
+def _install_user_timer(spec):
+    """Write and enable a systemd --user timer/service pair; return the timer path."""
+    import subprocess
+
+    timer_dir = Path.home() / ".config" / "systemd" / "user"
+    timer_dir.mkdir(parents=True, exist_ok=True)
+    (timer_dir / f"{spec['unit']}.service").write_text(
+        f"""[Unit]
+Description={spec['service_desc']}
+
+[Service]
+Type=oneshot
+ExecStart={spec['exec']}
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin
+"""
+    )
+    (timer_dir / f"{spec['unit']}.timer").write_text(
+        f"""[Unit]
+Description={spec['timer_desc']}
+
+[Timer]
+OnCalendar={spec['on_calendar']}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+"""
+    )
+    subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        check=False, capture_output=True,
+    )
+    subprocess.run(
+        ["systemctl", "--user", "enable", "--now", f"{spec['unit']}.timer"],
+        check=False, capture_output=True,
+    )
+    return timer_dir / f"{spec['unit']}.timer"
+
+
+def _remove_user_timer(unit):
+    """Disable and delete a systemd --user timer/service pair."""
+    import subprocess
+
+    subprocess.run(
+        ["systemctl", "--user", "disable", "--now", f"{unit}.timer"],
+        check=False, capture_output=True,
+    )
+    timer_dir = Path.home() / ".config" / "systemd" / "user"
+    for fname in (f"{unit}.service", f"{unit}.timer"):
+        p = timer_dir / fname
+        if p.exists():
+            p.unlink()
+    subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        check=False, capture_output=True,
+    )
+
+
 def cmd_hooks(args):
     """Manage neurostack automation hooks."""
     subcmd = getattr(args, "hooks_command", None)
@@ -260,6 +327,14 @@ def cmd_hooks(args):
                 print(f"  \033[32m\u2713\033[0m Installed {hook_type}")
                 print(f"    Timer: {timer_dir / 'neurostack-harvest.timer'}")
                 print("    Check: systemctl --user status neurostack-harvest.timer")
+        elif hook_type == "decay-timer":
+            timer_path = _install_user_timer(_DECAY_TIMER)
+            if args.json:
+                print(json.dumps({"installed": True, "type": hook_type}))
+            else:
+                print(f"  \033[32m✓\033[0m Installed {hook_type}")
+                print(f"    Timer: {timer_path}")
+                print("    Check: systemctl --user status neurostack-decay.timer")
         else:
             print(f"  Unknown hook type: {hook_type}")
 
@@ -271,14 +346,33 @@ def cmd_hooks(args):
             capture_output=True, text=True,
         )
         active = result.stdout.strip() == "active"
+        decay = subprocess.run(
+            ["systemctl", "--user", "is-active", "neurostack-decay.timer"],
+            capture_output=True, text=True,
+        )
+        decay_active = decay.stdout.strip() == "active"
         if args.json:
-            print(json.dumps({"harvest_timer": "active" if active else "inactive"}))
+            print(json.dumps({
+                "harvest_timer": "active" if active else "inactive",
+                "decay_timer": "active" if decay_active else "inactive",
+            }))
         else:
             status = "\033[32mactive\033[0m" if active else "\033[31minactive\033[0m"
+            d_status = "\033[32mactive\033[0m" if decay_active else "\033[31minactive\033[0m"
             print(f"  harvest-timer: {status}")
+            print(f"  decay-timer: {d_status}")
 
     elif subcmd == "remove":
         import subprocess
+
+        hook_type = getattr(args, "type", None) or "harvest-timer"
+        if hook_type == "decay-timer":
+            _remove_user_timer("neurostack-decay")
+            if args.json:
+                print(json.dumps({"removed": True, "type": hook_type}))
+            else:
+                print(f"  \033[32m✓\033[0m Removed {hook_type}")
+            return
 
         subprocess.run(
             ["systemctl", "--user", "disable", "--now", "neurostack-harvest.timer"],

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -467,12 +467,16 @@ def run_excitability_demotion(
     threshold: float = 0.05,
     half_life_days: float = 30.0,
 ) -> dict:
-    """Demote notes with decayed hotness below threshold from active to dormant.
+    """Reconcile note_metadata.status with live hotness in both directions.
 
-    Updates note_metadata.status — vault files are NEVER modified.
-    Also demotes never-used notes older than 90 days.
+    Demotes active notes whose decayed hotness fell below threshold (and
+    never-used notes older than 90 days) to dormant, and re-promotes dormant
+    notes whose hotness has risen back above threshold to active. Keeps the
+    status cache — which drives the ×1.15 search boost — in sync with the
+    note_usage signal. Updates note_metadata.status only; vault files are
+    NEVER modified.
 
-    Returns {"demoted": N, "paths": [...]}.
+    Returns {"demoted": N, "paths": [...], "promoted": M, "promoted_paths": [...]}.
     """
     demoted_paths = []
 
@@ -513,10 +517,29 @@ def run_excitability_demotion(
             if changed:
                 demoted_paths.append(path)
 
-    if demoted_paths:
+    # Re-promote dormant notes whose hotness has risen back above threshold.
+    # Without this, dormant is a one-way trap: a renewed note keeps its dormant
+    # status (and loses the active search boost) despite fresh usage.
+    promoted_paths = []
+    for entry in report["active"]:
+        path = entry["path"]
+        changed = conn.execute(
+            "UPDATE note_metadata SET status = 'active'"
+            " WHERE note_path = ? AND status = 'dormant'",
+            (path,),
+        ).rowcount
+        if changed:
+            promoted_paths.append(path)
+
+    if demoted_paths or promoted_paths:
         conn.commit()
 
-    return {"demoted": len(demoted_paths), "paths": demoted_paths}
+    return {
+        "demoted": len(demoted_paths),
+        "paths": demoted_paths,
+        "promoted": len(promoted_paths),
+        "promoted_paths": promoted_paths,
+    }
 
 
 def hybrid_search(

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -382,7 +382,7 @@ def vault_stats() -> dict:
     from ..cooccurrence import get_cooccurrence_stats
     from ..memories import get_memory_stats
     from ..schema import DB_PATH, get_db
-    from ..search import get_dormancy_report, run_excitability_demotion
+    from ..search import get_dormancy_report
 
     conn = get_db(DB_PATH)
 
@@ -411,12 +411,6 @@ def vault_stats() -> dict:
     dormancy = get_dormancy_report(conn, threshold=0.05, limit=0)
     cooc_stats = get_cooccurrence_stats(conn)
     mem_stats = get_memory_stats(conn)
-
-    demotion_result = None
-    try:
-        demotion_result = run_excitability_demotion(conn)
-    except Exception as exc:
-        log.debug("Excitability demotion failed: %s", exc)
 
     result = {
         "notes": notes,
@@ -450,8 +444,6 @@ def vault_stats() -> dict:
         "cooccurrence_total_weight": cooc_stats["total_weight"],
         "memories": mem_stats,
     }
-    if demotion_result and demotion_result["demoted"] > 0:
-        result["demotion"] = demotion_result
     return result
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -295,6 +295,35 @@ class TestExcitabilityDemotion:
         result = run_excitability_demotion(conn)
         assert "dormant.md" not in result["paths"]
 
+    def test_repromotes_renewed_dormant_notes(self, in_memory_db):
+        """A dormant note with fresh usage is promoted back to active (issue #31)."""
+        conn = in_memory_db
+        conn.execute(
+            "INSERT INTO notes (path, title, content_hash, updated_at)"
+            " VALUES (?, ?, ?, ?)",
+            ("renewed.md", "Renewed", "h", "2026-01-01"),
+        )
+        conn.execute(
+            "INSERT INTO note_metadata (note_path, status) VALUES (?, ?)",
+            ("renewed.md", "dormant"),
+        )
+        # Fresh usage pushes hotness back above threshold
+        conn.execute(
+            "INSERT INTO note_usage (note_path, used_at) VALUES (?, datetime('now'))",
+            ("renewed.md",),
+        )
+        conn.commit()
+
+        result = run_excitability_demotion(conn)
+        assert result["promoted"] >= 1
+        assert "renewed.md" in result["promoted_paths"]
+
+        status = conn.execute(
+            "SELECT status FROM note_metadata WHERE note_path = ?",
+            ("renewed.md",),
+        ).fetchone()["status"]
+        assert status == "active"
+
 
 class TestExcitabilityBoost:
     def test_active_notes_boost_fts_results(self, in_memory_db):


### PR DESCRIPTION
## Problem

Decay (`#19`) was implemented but **never scheduled**, the only trigger was a **hidden write inside the read-only `vault_stats` endpoint**, and `dormant` was a **one-way trap** — a renewed note kept its dormant status (losing the ×1.15 search boost) despite fresh usage. Result in a 458-note vault: `dormant=0`, 48% `never_used`, and the active boost never discriminated.

## Changes

**1. Scheduling** — add a `decay-timer` type to `neurostack hooks`, mirroring the existing `harvest-timer` pattern. `neurostack hooks install --type decay-timer` writes + enables a systemd `--user` timer/service that runs `neurostack decay --demote` daily at 03:00. `install`/`status`/`remove` and argparse all handle both timers; the systemd unit write/remove is factored into shared helpers.

**2. Read-only stats** — drop the `run_excitability_demotion` call and the `result["demotion"]` block from `vault_stats`. Stats no longer mutate the DB.

**3. Two-way reconcile** — `run_excitability_demotion` now **re-promotes** dormant notes whose hotness rose back above threshold to `active`, keeping `note_metadata.status` in sync with `note_usage` in both directions. `neurostack decay --demote` reports promoted counts.

## Scope note

Issue **part 4** (a `neurostack doctor` warning if the last decay run is >48h ago) is left as a **follow-up** — it needs last-run-time persistence, which decay doesn't currently record. Happy to do it separately.

## Verification

- ruff clean, **449 tests pass** (448 + new re-promotion regression test)
- Smoke-tested `neurostack hooks status` (JSON + text) reporting both timers; argparse accepts `decay-timer` and rejects unknown types.

Closes #31.