### PR TITLE
fix(search): down-weight link-section chunk matches (#41)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -389,6 +389,12 @@ def main():
         help="Project/domain context for result boosting",
     )
     p.add_argument(
+        "--explain", action="store_true",
+        help="Show the per-component score breakdown for each result "
+        "(base, link-section penalty, convergence, context, hotness, "
+        "co-occurrence, excitability, prediction-error, inhibition)",
+    )
+    p.add_argument(
         "--workspace", "-w", default=None,
         help="Restrict results to vault subdirectory "
         "(e.g. 'work/acme-cloud'). "

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -11,6 +11,7 @@ from .utils import _get_workspace
 
 def cmd_search(args):
     from ..search import hybrid_search
+    explain = getattr(args, "explain", False)
     results = hybrid_search(
         query=args.query,
         top_k=args.top_k,
@@ -18,6 +19,7 @@ def cmd_search(args):
         embed_url=args.embed_url,
         context=args.context,
         workspace=_get_workspace(args),
+        explain=explain,
     )
     if args.json:
         output = []
@@ -31,6 +33,8 @@ def cmd_search(args):
             }
             if r.summary:
                 entry["summary"] = r.summary
+            if explain and r.explain is not None:
+                entry["explain"] = r.explain
             output.append(entry)
         print(json.dumps(output, indent=2, default=str))
         return
@@ -55,6 +59,9 @@ def cmd_search(args):
         print(f"\U0001f4c4 {r.title} ({r.note_path})")
         print(f"   Section: {r.heading_path}")
         print(f"   Score: {r.score:.4f}")
+        if explain and r.explain is not None:
+            parts = ", ".join(f"{k}={v}" for k, v in r.explain.items())
+            print(f"   Explain: {parts}")
         if r.summary:
             print(f"   Summary: {r.summary}")
         print(f"   Snippet: {r.snippet[:200]}")

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -51,6 +51,13 @@ class Config:
     api_port: int = 8000
     api_key: str = ""
     cooccurrence_boost_weight: float = 0.1
+    # Link-section down-weighting (issue #41): a chunk that is mostly wiki-link
+    # markup — ## Related blocks, index / map-of-content notes — is navigational,
+    # not substantive. Matches there are penalized so a tangential note whose only
+    # hit is a dense link block can't outrank a note whose body covers the query.
+    link_section_penalty: float = 0.5     # score multiplier for link-list chunk matches
+    link_density_threshold: float = 0.5   # chunk is a "link section" when this fraction
+                                          # or more of its characters are wiki-link markup
 
     @property
     def db_path(self) -> Path:
@@ -85,6 +92,10 @@ def load_config() -> Config:
             cfg.api_port = int(data["api_port"])
         if "cooccurrence_boost_weight" in data:
             cfg.cooccurrence_boost_weight = float(data["cooccurrence_boost_weight"])
+        if "link_section_penalty" in data:
+            cfg.link_section_penalty = float(data["link_section_penalty"])
+        if "link_density_threshold" in data:
+            cfg.link_density_threshold = float(data["link_density_threshold"])
 
     # Env var overrides (NEUROSTACK_ prefix)
     env_map = {
@@ -103,6 +114,8 @@ def load_config() -> Config:
         "NEUROSTACK_API_PORT": ("api_port", int),
         "NEUROSTACK_API_KEY": ("api_key", str),
         "NEUROSTACK_COOCCURRENCE_BOOST": ("cooccurrence_boost_weight", float),
+        "NEUROSTACK_LINK_SECTION_PENALTY": ("link_section_penalty", float),
+        "NEUROSTACK_LINK_DENSITY_THRESHOLD": ("link_density_threshold", float),
     }
 
     for env_key, (attr, typ) in env_map.items():

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 from dataclasses import dataclass
 
@@ -110,6 +111,8 @@ class SearchResult:
     score: float
     summary: str = ""
     title: str = ""
+    # Per-component score breakdown, populated only when hybrid_search(explain=True).
+    explain: dict | None = None
 
 
 @dataclass
@@ -128,6 +131,51 @@ def _normalize_workspace(workspace: str | None) -> str | None:
         return None
     workspace = workspace.strip("/")
     return workspace if workspace else None
+
+
+# Wiki-link markup, e.g. [[note-title]] or [[note-title|alias]].
+_WIKI_LINK_RE = re.compile(r"\[\[[^\]]+\]\]")
+
+# Leaf-heading prefixes that mark a chunk as a navigational link list rather than
+# substantive prose. Matched case-insensitively against the start of the deepest
+# heading, so "Related Notes" / "See also (2026)" / "Backlinks" all qualify.
+_LINK_SECTION_PREFIXES = (
+    "related", "see also", "see-also", "backlinks", "links",
+    "references", "index", "contents", "table of contents", "moc",
+)
+
+# A heading-named link section is only penalised when it actually carries links.
+# Real "## Related" blocks in the vault sit around 0.15–0.40 link density, while a
+# prose "## Related Work" section is ~0.0 — this floor keeps the latter untouched.
+_LINK_SECTION_HEADING_MIN_DENSITY = 0.1
+
+
+def _link_density(content: str) -> float:
+    """Fraction of a chunk's characters that are wiki-link markup (0.0–1.0)."""
+    if not content:
+        return 0.0
+    link_chars = sum(len(m.group(0)) for m in _WIKI_LINK_RE.finditer(content))
+    return link_chars / len(content)
+
+
+def _is_link_section(heading_path: str, content: str, density_threshold: float) -> bool:
+    """Return True if a chunk is a navigational link list / index section.
+
+    A chunk qualifies when EITHER wiki-link markup makes up at least
+    ``density_threshold`` of its characters (a dense link dump under any heading),
+    OR its leaf heading names a link section (## Related, ## See also, ## Backlinks,
+    …) AND the chunk carries a non-trivial fraction of links. Such chunks repeat a
+    note's topic terms via link titles, inflating keyword/semantic scores without
+    the body actually covering the query — see issue #41.
+    """
+    density = _link_density(content)
+    if density >= density_threshold:
+        return True
+    if heading_path and density >= _LINK_SECTION_HEADING_MIN_DENSITY:
+        leaf = heading_path.split(">")[-1].lstrip("# ").strip().lower()
+        if any(leaf.startswith(prefix) for prefix in _LINK_SECTION_PREFIXES):
+            return True
+    return False
 
 
 def fts_search(
@@ -550,6 +598,7 @@ def hybrid_search(
     db_path=None,
     context: str = None,
     workspace: str | None = None,
+    explain: bool = False,
 ) -> list[SearchResult]:
     """
     Hybrid search combining FTS5 and semantic similarity.
@@ -558,11 +607,24 @@ def hybrid_search(
     - "hybrid": FTS5 pre-filters top 50, then cosine-reranks
     - "semantic": Pure embedding search
     - "keyword": Pure FTS5 search
+
+    When ``explain`` is True, each returned SearchResult carries an ``explain``
+    dict recording the per-stage score breakdown (base, link-section penalty,
+    convergence, context, hotness, co-occurrence, excitability, prediction-error,
+    lateral inhibition) — used to diagnose ranking (issue #41).
     """
     from .schema import DB_PATH
 
-    embed_url = embed_url or get_config().embed_url
+    cfg = get_config()
+    embed_url = embed_url or cfg.embed_url
     conn = get_db(db_path or DB_PATH)
+    link_section_penalty = cfg.link_section_penalty
+    link_density_threshold = cfg.link_density_threshold
+
+    def _rec(r: dict, **fields) -> None:
+        """Record a per-stage score breakdown onto a result when explain is on."""
+        if explain and "_explain" in r:
+            r["_explain"].update(fields)
 
     workspace = _normalize_workspace(workspace)
 
@@ -614,6 +676,30 @@ def hybrid_search(
         raw_cosine = float(scores[i])
         r["cosine_sim"] = raw_cosine
         r["score"] = 0.3 * fts_score + 0.7 * raw_cosine
+        if explain:
+            r["_explain"] = {
+                "fts": round(fts_score, 4),
+                "cosine": round(raw_cosine, 4),
+                "base": round(r["score"], 4),
+                "heading": r.get("heading_path", ""),
+            }
+
+        # ── Link-section down-weight (issue #41) ──
+        # A matched chunk that is mostly wiki-link markup (## Related blocks,
+        # index/MOC notes) is navigational: its link titles repeat the note's
+        # topic terms and inflate keyword + semantic scores even when the note's
+        # body does not cover the query. Penalize the chunk score *before* the
+        # per-note dedup so a note's substantive body chunk, if any, wins instead.
+        density = _link_density(r.get("content", "") or "")
+        is_link_section = _is_link_section(
+            r.get("heading_path", ""), r.get("content", "") or "", link_density_threshold
+        )
+        if is_link_section:
+            r["score"] *= link_section_penalty
+        if explain:
+            r["_explain"]["link_density"] = round(density, 3)
+            r["_explain"]["link_section"] = is_link_section
+            r["_explain"]["after_link"] = round(r["score"], 4)
 
     # ── Energy landscape convergence confidence ──
     # Measures how representative the matched chunk is of its note's overall
@@ -660,6 +746,7 @@ def hybrid_search(
             convergence = centroid_sim / (1.0 + sigma)
             # Blend: keep 70% of existing score, add 30% convergence influence
             r["score"] = 0.7 * r["score"] + 0.3 * convergence
+            _rec(r, convergence=round(convergence, 4), after_convergence=round(r["score"], 4))
 
     # Apply context boost; track which notes are in-context for mismatch detection
     in_context_notes: set[str] = set()
@@ -670,8 +757,10 @@ def hybrid_search(
             note_path = r["note_path"]
             if note_path in direct_ctx:
                 r["score"] *= 1.4
+                _rec(r, context_boost=1.4, after_context=round(r["score"], 4))
             elif note_path in neighbor_ctx:
                 r["score"] *= 1.2
+                _rec(r, context_boost=1.2, after_context=round(r["score"], 4))
 
     # Apply hotness blend: final_score = 0.8 * semantic + 0.2 * hotness
     hotness_map = batch_hotness_scores(conn, [r["note_path"] for r in valid_results])
@@ -679,9 +768,9 @@ def hybrid_search(
         h = hotness_map.get(r["note_path"], 0.0)
         if h > 0.0:
             r["score"] = 0.8 * r["score"] + 0.2 * h
+            _rec(r, hotness=round(h, 4), after_hotness=round(r["score"], 4))
 
     # Extract query-matched entities (used for co-occurrence boost AND reinforcement)
-    cfg = get_config()
     query_words = [w.lower() for w in query.split() if len(w) > 2]
     query_entities: set[str] = set()
     if query_words:
@@ -742,6 +831,8 @@ def hybrid_search(
                                 normalized = raw_boost / (raw_boost + max_cooc_weight)
                                 boost = 1.0 + (cooc_weight * normalized)
                                 r["score"] *= boost
+                                _rec(r, cooccurrence_boost=round(boost, 4),
+                                     after_cooccurrence=round(r["score"], 4))
 
     # Excitability boost: notes with status=active get a 1.15x boost
     # Mirrors CREB-mediated excitability windows where recently active
@@ -775,6 +866,7 @@ def hybrid_search(
                     pass
         if status == "active":
             r["score"] *= 1.15
+            _rec(r, excitability_boost=1.15, after_excitability=round(r["score"], 4))
 
     # ── Prediction error demotion ──
     # Notes with unresolved prediction errors have previously "surprised" on
@@ -802,6 +894,8 @@ def hybrid_search(
                 ec = error_counts.get(r["note_path"], 0)
                 if ec > 0:
                     r["score"] *= 1.0 / (1.0 + 0.1 * ec)
+                    _rec(r, prediction_error_count=ec,
+                         after_prediction_error=round(r["score"], 4))
         except Exception:
             pass  # Never let error demotion disrupt search
 
@@ -864,6 +958,8 @@ def hybrid_search(
             if max_sim > INHIBITION_THRESHOLD:
                 penalty = 1.0 - INHIBITION_STRENGTH * max_sim
                 deduped[i]["score"] *= penalty
+                _rec(deduped[i], inhibition=round(penalty, 4),
+                     after_inhibition=round(deduped[i]["score"], 4))
 
         # Re-sort after inhibition — suppressed results may drop below
         # previously lower-ranked diverse results
@@ -948,6 +1044,9 @@ def _to_search_results(conn: sqlite3.Connection, results: list[dict]) -> list[Se
         if len(r["content"]) > 300:
             snippet += "..."
 
+        explain = r.get("_explain")
+        if explain is not None:
+            explain = {**explain, "final": round(r.get("score", 0.0), 4)}
         search_results.append(SearchResult(
             note_path=note_path,
             heading_path=r.get("heading_path", ""),
@@ -955,6 +1054,7 @@ def _to_search_results(conn: sqlite3.Connection, results: list[dict]) -> list[Se
             score=r.get("score", 0.0),
             summary=summary,
             title=title,
+            explain=explain,
         ))
 
     return search_results

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -794,3 +794,145 @@ class TestReinforcementFromSearch:
             "SELECT COUNT(*) as c FROM entity_cooccurrence"
         ).fetchone()["c"]
         assert count == 0, "No reinforcement should occur when query matches no entities"
+
+
+class TestLinkSectionHelpers:
+    """Unit tests for the link-section detection helpers (issue #41)."""
+
+    def test_link_density_pure_links(self):
+        from neurostack.search import _link_density
+        content = "[[azure consolidation]] [[azure networking]] [[azure dr]]"
+        assert _link_density(content) > 0.8
+
+    def test_link_density_prose(self):
+        from neurostack.search import _link_density
+        content = "Azure consolidation moves prod and staging into one subscription."
+        assert _link_density(content) == 0.0
+
+    def test_link_density_empty(self):
+        from neurostack.search import _link_density
+        assert _link_density("") == 0.0
+
+    def test_is_link_section_by_heading_with_links(self):
+        from neurostack.search import _is_link_section
+        # A named link section below the density threshold still qualifies when it
+        # carries a non-trivial fraction of links (density ~0.36 here, < 0.5).
+        body = "Background: [[note-a]] and [[note-b]] both cover this topic well."
+        assert _is_link_section("## Architecture > ### See also", body, 0.5) is True
+
+    def test_is_link_section_heading_variants(self):
+        from neurostack.search import _is_link_section
+        # Prefix matching catches "Related Notes", "Backlinks", etc.
+        links = "[[a]] [[b]] [[c]] notes here"
+        assert _is_link_section("## Related Notes", links, 0.5) is True
+        assert _is_link_section("## Backlinks", links, 0.5) is True
+
+    def test_link_heading_prose_not_penalised(self):
+        from neurostack.search import _is_link_section
+        # A "Related Work" heading with no links is prose, not a link list.
+        prose = "Related work in this area focuses on hierarchical inference models."
+        assert _is_link_section("## Related Work", prose, 0.5) is False
+
+    def test_is_link_section_by_density(self):
+        from neurostack.search import _is_link_section
+        dense = "[[a]] [[b]] [[c]] [[d]]"
+        assert _is_link_section("## Notes", dense, 0.5) is True
+
+    def test_not_link_section_for_body(self):
+        from neurostack.search import _is_link_section
+        body = "Azure consolidation environments: prod, staging and dev."
+        assert _is_link_section("## Environments", body, 0.5) is False
+
+
+class TestLinkSectionDownweight:
+    """hybrid_search must not let a link-block match outrank a body match (#41)."""
+
+    def _setup(self, conn):
+        """Two notes matching the same query:
+
+        - canonical.md: a substantive '## Environments' body chunk (no links),
+          moderately similar to the query (cosine 0.7).
+        - linky.md: a '## Related' chunk that is a dense wiki-link block whose
+          link titles repeat the query terms, more similar to the query
+          (cosine 0.9). Without the penalty its higher cosine wins.
+
+        Embeddings are crafted so the two notes' mutual cosine is 0.63 (below the
+        0.65 lateral-inhibition threshold) and each note is single-chunk (so the
+        convergence stage is skipped) — isolating the link-section penalty.
+        """
+        import math
+        import struct
+
+        def blob(vec, dim=768):
+            full = list(vec) + [0.0] * (dim - len(vec))
+            return struct.pack(f"{dim}f", *full)
+
+        # query = e0; linky cos 0.9 (in e0/e1 plane); canonical cos 0.7 (e0/e2 plane)
+        linky_vec = [0.9, math.sqrt(1 - 0.81), 0.0]
+        canon_vec = [0.7, 0.0, math.sqrt(1 - 0.49)]
+
+        for path, title, heading, content, vec in [
+            ("canonical.md", "Canonical", "## Environments",
+             "azure consolidation environments", canon_vec),
+            ("linky.md", "Linky", "## Related",
+             "[[azure consolidation environments]]", linky_vec),
+        ]:
+            conn.execute(
+                "INSERT INTO notes (path, title, content_hash, updated_at) "
+                "VALUES (?, ?, ?, ?)",
+                (path, title, "h", "2026-01-01"),
+            )
+            conn.execute(
+                "INSERT INTO chunks (note_path, heading_path, content, "
+                "content_hash, position, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+                (path, heading, content, f"h_{path}", 0, blob(vec)),
+            )
+        conn.commit()
+
+    def _run(self, conn, monkeypatch, penalty):
+        import numpy as np
+
+        import neurostack.config as config_mod
+        import neurostack.search as search_mod
+
+        monkeypatch.setattr(search_mod, "get_db", lambda path: conn)
+        query_emb = np.array([1.0, 0.0, 0.0] + [0.0] * 765, dtype=np.float32)
+        monkeypatch.setattr(
+            search_mod, "get_embedding", lambda q, base_url=None: query_emb
+        )
+
+        original = config_mod._config
+        try:
+            cfg = Config()
+            cfg.cooccurrence_boost_weight = 0.0
+            cfg.link_section_penalty = penalty
+            config_mod._config = cfg
+            return hybrid_search("azure consolidation environments",
+                                 top_k=5, embed_url="http://fake", explain=True)
+        finally:
+            config_mod._config = original
+
+    def test_penalty_off_reproduces_bug(self, in_memory_db, monkeypatch):
+        self._setup(in_memory_db)
+        results = self._run(in_memory_db, monkeypatch, penalty=1.0)
+        # Without the penalty the link block (higher cosine) wins — the #41 bug.
+        assert results[0].note_path == "linky.md"
+
+    def test_penalty_on_promotes_body_note(self, in_memory_db, monkeypatch):
+        self._setup(in_memory_db)
+        results = self._run(in_memory_db, monkeypatch, penalty=0.5)
+        # With the penalty the substantive body note ranks first.
+        assert results[0].note_path == "canonical.md"
+        scores = {r.note_path: r.score for r in results}
+        assert scores["canonical.md"] > scores["linky.md"]
+
+    def test_explain_breakdown_present(self, in_memory_db, monkeypatch):
+        self._setup(in_memory_db)
+        results = self._run(in_memory_db, monkeypatch, penalty=0.5)
+        linky = next(r for r in results if r.note_path == "linky.md")
+        assert linky.explain is not None
+        assert linky.explain["link_section"] is True
+        # The link block's score is penalised: post-penalty below the base.
+        assert linky.explain["after_link"] < linky.explain["base"]
+        canon = next(r for r in results if r.note_path == "canonical.md")
+        assert canon.explain["link_section"] is False


### PR DESCRIPTION
## Problem (#41)

`vault_search` let a tangentially-related note outrank the on-topic note when the tangential note's only match was a dense `## Related` / index wiki-link block. Those chunks repeat the query's topic terms through link titles, inflating both the keyword (FTS) and semantic (cosine) components even though the note body never covers the query.

## Fix

`hybrid_search` now detects link-list chunks and multiplies their score by a configurable penalty, applied **before** the per-note dedup — so a note's substantive body chunk wins the dedup instead of its link block.

A chunk is a link section when **either**:
- wiki-link markup is ≥ `link_density_threshold` of its characters (a dense link dump under any heading), **or**
- its leaf heading names a link section (`Related`, `See also`, `Backlinks`, `References`, `Index`, … — prefix-matched, so `Related Notes` counts) **and** it carries a non-trivial link fraction (≥ 0.1, so a prose `## Related Work` section is left untouched).

Knobs (config.toml / env), defaults `0.5` / `0.5`:
- `link_section_penalty` / `NEUROSTACK_LINK_SECTION_PENALTY`
- `link_density_threshold` / `NEUROSTACK_LINK_DENSITY_THRESHOLD`

## Diagnostic

Adds `hybrid_search(explain=True)` and a `neurostack search --explain` flag that surface the per-component score breakdown (base, link penalty, convergence, context, hotness, co-occurrence, excitability, prediction-error, lateral inhibition) per result — the breakdown the issue asked for. Zero behaviour change when off.

## Validation on the live vault (LXC 122, DB copy)

- `azure vwan routing intent bastion`: two `## Related` blocks (`ld≈0.38`, `0.32`) sat at ranks 4 & 6 with the penalty off; with it on they drop out of the top-8, replaced by substantive content. Rank 1 unchanged.
- `video essay production pipeline V3`: `## Related Notes` (`ld=0.36`) and `## Related` (`ld=0.44`) blocks demoted — and **the same notes resurface via their `## Query` / `## Overview` body chunks**, confirming the per-chunk-before-dedup design picks a better-representative chunk rather than dropping the note.

## Tests

- `TestLinkSectionHelpers` — density + heading detection, including the prose guard.
- `TestLinkSectionDownweight` — reproduces the inversion (penalty off → link block wins) and the fix (penalty on → body note wins); asserts the `explain` breakdown.

460 passing (was 449).

Closes #41