### PR TITLE
fix(ask): pass full chunk + note summary to synthesis (#40)

### DIFF
--- a/src/neurostack/ask.py
+++ b/src/neurostack/ask.py
@@ -11,10 +11,22 @@ import httpx
 from .config import _auth_headers, get_config
 from .search import hybrid_search
 
+# Upper bound on per-source excerpt text passed to synthesis. A chunk is at most
+# MAX_CHUNK_CHARS (2000); this passes the whole matched chunk rather than the
+# 300-char display snippet, so a fact further down the chunk is still visible (#40).
+MAX_SOURCE_CHARS = 2000
+
 ASK_PROMPT = """You are a knowledge assistant answering questions \
 using the provided vault notes.
-Use ONLY the information from the sources below to answer. \
-If the answer is not in the sources, say so.
+Each source gives a note's summary and the most relevant excerpt from it.
+
+Answer using ONLY the information in the sources below:
+- If a source contains the answer, give it and cite the note with [[note-title]], \
+quoting the relevant line.
+- If the sources discuss the topic but none contains the specific detail asked for, \
+say the retrieved notes did not include that detail. Do NOT assert that the fact is \
+false or does not exist — you are only seeing excerpts, not the whole vault.
+
 Cite sources inline using [[note-title]] format.
 
 Sources:
@@ -54,15 +66,22 @@ def ask_vault(
     if not results:
         return {"answer": "No relevant notes found in the vault.", "sources": []}
 
-    # Build source context
+    # Build source context. Pass the note summary plus the full matched chunk
+    # (not the 300-char display snippet) so a fact below char 300 — or in the
+    # note's summary rather than the top-scoring chunk — is still seen (#40).
     source_blocks = []
     seen_notes = {}
+    source_excerpts = {}
     for r in results:
         if r.note_path not in seen_notes:
             seen_notes[r.note_path] = r.title
-        source_blocks.append(
-            f"[{r.title}] ({r.note_path}):\n{r.snippet[:500]}"
-        )
+        excerpt = (r.chunk_content or r.snippet)[:MAX_SOURCE_CHARS]
+        source_excerpts.setdefault(r.note_path, excerpt)
+        block = f"[{r.title}] ({r.note_path}):"
+        if r.summary:
+            block += f"\nSummary: {r.summary}"
+        block += f"\nExcerpt: {excerpt}"
+        source_blocks.append(block)
 
     sources_text = "\n\n---\n\n".join(source_blocks)
     prompt = ASK_PROMPT.format(sources=sources_text, question=question)
@@ -87,9 +106,10 @@ def ask_vault(
     # Strip think tags if model includes them
     answer = re.sub(r"<think>.*?</think>", "", answer, flags=re.DOTALL).strip()
 
-    # Build sources list
+    # Build sources list. Return the excerpt actually passed to synthesis so a
+    # caller can see what the answer was grounded in (issue #40).
     sources = [
-        {"path": path, "title": title}
+        {"path": path, "title": title, "excerpt": source_excerpts.get(path, "")}
         for path, title in seen_notes.items()
     ]
 

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -111,6 +111,10 @@ class SearchResult:
     score: float
     summary: str = ""
     title: str = ""
+    # Full text of the matched chunk (untruncated). `snippet` is the 300-char
+    # display form; consumers that synthesise answers (vault_ask) need the whole
+    # chunk so a fact past char 300 isn't invisible — see issue #40.
+    chunk_content: str = ""
     # Per-component score breakdown, populated only when hybrid_search(explain=True).
     explain: dict | None = None
 
@@ -1054,6 +1058,7 @@ def _to_search_results(conn: sqlite3.Connection, results: list[dict]) -> list[Se
             score=r.get("score", 0.0),
             summary=summary,
             title=title,
+            chunk_content=r.get("content", "") or "",
             explain=explain,
         ))
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,99 @@
+"""Tests for neurostack.ask — RAG synthesis context construction (issue #40)."""
+
+import neurostack.ask as ask_mod
+from neurostack.ask import ask_vault
+from neurostack.search import SearchResult
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self._content = content
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"choices": [{"message": {"content": self._content}}]}
+
+
+def _patch(monkeypatch, results, answer="ok [[Widget]]"):
+    """Patch hybrid_search to return `results` and capture the synthesis prompt."""
+    captured = {}
+    monkeypatch.setattr(ask_mod, "hybrid_search", lambda *a, **k: results)
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["prompt"] = json["messages"][0]["content"]
+        return _FakeResp(answer)
+
+    monkeypatch.setattr(ask_mod.httpx, "post", fake_post)
+    return captured
+
+
+def test_full_chunk_passed_not_just_snippet(monkeypatch):
+    """The fix: a fact past char 300 of the matched chunk reaches synthesis (#40)."""
+    filler = "preamble text. " * 30  # ~450 chars of lead-in
+    fact = "The widget service is deployed on host alpha-07."
+    chunk = filler + fact
+    sr = SearchResult(
+        note_path="notes/widget.md",
+        heading_path="## Deployment",
+        snippet=chunk[:300],          # display snippet — fact is NOT in here
+        score=0.9,
+        summary="Covers widget deployment.",
+        title="Widget",
+        chunk_content=chunk,          # full chunk — fact IS in here
+    )
+    captured = _patch(monkeypatch, [sr])
+
+    result = ask_vault("where is the widget service deployed?")
+
+    # Before the fix only snippet[:300] was passed, so `fact` never reached the LLM.
+    assert fact in captured["prompt"]
+    # sources[] now carries the excerpt actually synthesised.
+    assert result["sources"][0]["excerpt"].endswith(fact)
+
+
+def test_summary_included_in_context(monkeypatch):
+    """The note summary (which often states the fact) is passed to synthesis."""
+    sr = SearchResult(
+        note_path="notes/x.md",
+        heading_path="## Misc",
+        snippet="unrelated lead paragraph",
+        score=0.8,
+        summary="X is NOT deployed — verified 2026-06-11.",
+        title="X",
+        chunk_content="unrelated lead paragraph about something else entirely",
+    )
+    captured = _patch(monkeypatch, [sr])
+
+    ask_vault("is X deployed?")
+
+    assert "X is NOT deployed — verified 2026-06-11." in captured["prompt"]
+
+
+def test_prompt_distinguishes_absent_from_unspecific(monkeypatch):
+    """The prompt must not instruct a blunt 'say it's absent' on thin context."""
+    sr = SearchResult(
+        note_path="notes/x.md", heading_path="## A", snippet="s",
+        score=0.5, summary="", title="X", chunk_content="some content",
+    )
+    captured = _patch(monkeypatch, [sr])
+    ask_vault("q?")
+    prompt = captured["prompt"]
+    assert "did not include that detail" in prompt
+    assert "Do NOT assert" in prompt
+
+
+def test_no_results_short_circuits(monkeypatch):
+    """Empty retrieval returns the no-notes message without calling the LLM."""
+    called = {"post": False}
+    monkeypatch.setattr(ask_mod, "hybrid_search", lambda *a, **k: [])
+
+    def fake_post(*a, **k):
+        called["post"] = True
+        return _FakeResp("x")
+
+    monkeypatch.setattr(ask_mod.httpx, "post", fake_post)
+    result = ask_vault("q?")
+    assert result["sources"] == []
+    assert called["post"] is False


### PR DESCRIPTION
## Problem (#40)

`vault_ask` answered *"the provided sources do not contain information about X"* / `[[no source]]` even when the cited note held the answer. `ask_vault` built the synthesis context from `r.snippet` — the **300-char display snippet** of the single top-scoring chunk per note (`hybrid_search` dedups to one chunk/note). A fact below char 300, or in a different section than the top-scoring chunk, never reached the LLM, so it correctly reported the fact absent from the text it was actually given. Broader phrasings worked because a different chunk ranked top and its snippet happened to contain the fact.

## Fix

- `ask_vault` now builds each source block from the **note summary + the full matched chunk** (capped at `MAX_SOURCE_CHARS=2000`) instead of the 300-char snippet.
- `sources[]` now returns the `excerpt` actually synthesised, so a caller can see what the answer was grounded in.
- The synthesis prompt distinguishes *"the retrieved notes did not include that detail"* from asserting the fact is false — the model only ever sees excerpts, not the whole vault.
- `SearchResult` gains a `chunk_content` field (untruncated matched chunk); `snippet` stays the 300-char display form, so search display is unchanged.

## Validation on the live vault (LXC 122, DB copy, A/B main vs branch)

Question: *"What OnCalendar time does the NeuroStack decay timer run at on LXC 122?"*
- **main:** "The provided notes do not specify an `OnCalendar` time…" (the bug — note was in `sources[]`, detail past char 300).
- **branch:** "runs at `OnCalendar=*-*-* 03:00:00` on LXC 122 [[v0.15.0…]]" — correct and cited.

A second question whose answer lives only in a memory (not a note chunk) confirmed the prompt-softening half: the branch says "the notes do not include the specific … IP" with a citation rather than flatly denying.

## Tests

New `tests/test_ask.py` (mocks `hybrid_search` + the LLM call, asserts on the synthesis prompt): full chunk reaches synthesis when the fact is past char 300; the note summary is included; the prompt avoids a blunt "say it's absent"; empty retrieval short-circuits without an LLM call.

464 passing.

Closes #40