### PR TITLE
fix(triples): robust extraction + retry queue, no silent drops (#28)

### DIFF
--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -302,6 +302,21 @@ CREATE TABLE IF NOT EXISTS entity_cooccurrence (
 
 CREATE INDEX IF NOT EXISTS idx_cooccurrence_a ON entity_cooccurrence(entity_a);
 CREATE INDEX IF NOT EXISTS idx_cooccurrence_b ON entity_cooccurrence(entity_b);
+
+-- Notes whose triple extraction failed to parse (issue #28). A row here marks a
+-- note for retry with exponential backoff; the row is deleted once extraction
+-- succeeds. Distinct from a note that legitimately yields zero triples (no row).
+CREATE TABLE IF NOT EXISTS triple_extraction_failed (
+    note_path TEXT PRIMARY KEY REFERENCES notes(path) ON DELETE CASCADE,
+    content_hash TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    last_attempt_at TEXT,
+    next_retry_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_triple_failed_retry
+    ON triple_extraction_failed(next_retry_at);
 """
 
 # Migration from v1 to v2: add triples tables
@@ -555,6 +570,22 @@ CREATE TABLE IF NOT EXISTS community_level_stats (
 MIGRATION_V15 = """
 -- Columns dropped dynamically in _run_migrations so fresh installs
 -- (which never created them) don't error.
+"""
+
+
+# Migration from v15 to v16: triple-extraction failure / retry queue (issue #28)
+MIGRATION_V16 = """
+CREATE TABLE IF NOT EXISTS triple_extraction_failed (
+    note_path TEXT PRIMARY KEY REFERENCES notes(path) ON DELETE CASCADE,
+    content_hash TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    last_attempt_at TEXT,
+    next_retry_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_triple_failed_retry
+    ON triple_extraction_failed(next_retry_at);
 """
 
 
@@ -822,6 +853,19 @@ def _run_migrations(conn: sqlite3.Connection):
         )
         conn.commit()
         log.info("Migration to v15 complete.")
+
+    if current < 16:
+        log.info(
+            "Migrating schema v15 -> v16: "
+            "adding triple-extraction retry queue..."
+        )
+        conn.executescript(MIGRATION_V16)
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version"
+            " VALUES (16)"
+        )
+        conn.commit()
+        log.info("Migration to v16 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/triples.py
+++ b/src/neurostack/triples.py
@@ -22,6 +22,18 @@ DEFAULT_SUMMARIZE_URL = _cfg.llm_url
 TRIPLE_MODEL = _cfg.llm_model
 _LLM_HEADERS = _auth_headers(_cfg.llm_api_key)
 
+
+class TripleExtractionError(Exception):
+    """Raised when triple extraction fails after retry.
+
+    Distinguishes a hard failure (the LLM returned output that could not be
+    parsed into triples even after a retry) from the legitimate case of a note
+    that simply yields no triples (which returns an empty list). Callers use
+    this to schedule a retry instead of silently recording zero triples — see
+    issue #28.
+    """
+
+
 TRIPLE_PROMPT = """Extract knowledge graph triples from this note. \
 Each triple is a (subject, predicate, object) fact.
 
@@ -36,60 +48,79 @@ not abbreviations (e.g. "PostgreSQL" not "pg.conf")
 - Include relationships about: configurations, dependencies, \
 connections, purposes, locations, states
 - Skip trivial or redundant triples
-- Return ONLY valid JSON array, no other text
+- Return ONLY a JSON object, no other text
 
 Note title: {title}
 ---
 {content}
 ---
 
-Return JSON array of triples:
-[{{"s": "subject", "p": "predicate", "o": "object"}}]"""
+Return a JSON object of this exact shape (an empty list if there are no facts):
+{{"triples": [{{"s": "subject", "p": "predicate", "o": "object"}}]}}"""
+
+_RETRY_SUFFIX = (
+    "\n\nYour previous reply could not be parsed. Reply with ONLY the JSON "
+    'object {"triples": [...]} — no prose, no markdown fences.'
+)
 
 
-def extract_triples(
-    title: str,
-    content: str,
-    base_url: str = DEFAULT_SUMMARIZE_URL,
-    model: str = TRIPLE_MODEL,
-) -> list[dict]:
-    """Extract SPO triples from note content via Ollama.
-
-    Returns list of {"s": str, "p": str, "o": str} dicts.
-    """
-    if len(content) > 4000:
-        content = content[:4000] + "\n[... truncated]"
-
-    prompt = TRIPLE_PROMPT.format(title=title, content=content)
-
+def _call_triple_llm(prompt: str, base_url: str, model: str, json_mode: bool) -> str:
+    """Single LLM call returning the raw assistant message content."""
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "reasoning_effort": "none",
+        "temperature": 0.2,
+        "max_tokens": 2048,
+    }
+    if json_mode:
+        # Ask the endpoint to constrain output to a JSON object. Supported by
+        # Ollama and OpenAI-compatible servers; the retry drops it in case a
+        # given backend rejects the field.
+        body["response_format"] = {"type": "json_object"}
     resp = httpx.post(
         f"{base_url}/v1/chat/completions",
         headers=_LLM_HEADERS,
-        json={
-            "model": model,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": False,
-            "reasoning_effort": "none",
-            "temperature": 0.2,
-            "max_tokens": 2048,
-        },
+        json=body,
         timeout=180.0,
     )
     resp.raise_for_status()
-    data = resp.json()
-    raw = data["choices"][0]["message"]["content"].strip()
-    # Strip markdown fences if present
+    return resp.json()["choices"][0]["message"]["content"].strip()
+
+
+def _extract_json_blob(raw: str) -> str:
+    """Best-effort: isolate the first JSON object/array in a noisy response."""
+    raw = raw.strip()
     if raw.startswith("```"):
         raw = re.sub(r"^```\w*\n?", "", raw)
         raw = re.sub(r"\n?```$", "", raw).strip()
+    starts = [i for i in (raw.find("{"), raw.find("[")) if i != -1]
+    if not starts:
+        return raw
+    start = min(starts)
+    end = max(raw.rfind("}"), raw.rfind("]"))
+    if end > start:
+        return raw[start : end + 1]
+    return raw
 
-    try:
-        triples = json.loads(raw)
-    except json.JSONDecodeError as e:
-        log.warning(f"JSON parse error for '{title}': {e}")
-        return []
 
-    # Validate structure
+def _parse_triples(raw: str) -> list:
+    """Parse raw LLM output into a list of triple candidates.
+
+    Accepts a bare JSON array, a ``{"triples": [...]}`` object, or those forms
+    embedded in surrounding prose / markdown fences. Raises on unparseable input.
+    """
+    data = json.loads(_extract_json_blob(raw))
+    if isinstance(data, dict):
+        data = data.get("triples", data.get("facts", []))
+    if not isinstance(data, list):
+        raise ValueError("expected a JSON array of triples or {'triples': [...]}")
+    return data
+
+
+def _validate(triples: list) -> list[dict]:
+    """Keep only well-formed {s, p, o} triples with non-empty values."""
     valid = []
     for t in triples:
         if isinstance(t, dict) and "s" in t and "p" in t and "o" in t:
@@ -98,8 +129,46 @@ def extract_triples(
             o = str(t["o"]).strip()
             if s and p and o:
                 valid.append({"s": s, "p": p, "o": o})
-
     return valid
+
+
+def extract_triples(
+    title: str,
+    content: str,
+    base_url: str = DEFAULT_SUMMARIZE_URL,
+    model: str = TRIPLE_MODEL,
+) -> list[dict]:
+    """Extract SPO triples from note content via an OpenAI-compatible LLM.
+
+    Returns a list of {"s", "p", "o"} dicts (possibly empty if the note has no
+    extractable facts). Raises :class:`TripleExtractionError` if the LLM output
+    cannot be parsed even after one retry, so the caller can schedule a retry
+    rather than silently recording zero triples (issue #28).
+    """
+    if len(content) > 4000:
+        content = content[:4000] + "\n[... truncated]"
+
+    prompt = TRIPLE_PROMPT.format(title=title, content=content)
+    last_err: Exception | None = None
+
+    # Attempt 0: JSON-object mode. Attempt 1: stricter prompt, no response_format.
+    for attempt in range(2):
+        try:
+            raw = _call_triple_llm(
+                prompt if attempt == 0 else prompt + _RETRY_SUFFIX,
+                base_url, model, json_mode=(attempt == 0),
+            )
+            return _validate(_parse_triples(raw))
+        except (json.JSONDecodeError, ValueError) as e:
+            last_err = e
+            log.warning(
+                "Triple JSON parse failed for '%s' (attempt %d/2): %s",
+                title, attempt + 1, e,
+            )
+
+    raise TripleExtractionError(
+        f"could not parse triples for '{title}' after 2 attempts: {last_err}"
+    )
 
 
 def triple_to_text(t: dict) -> str:

--- a/src/neurostack/watcher.py
+++ b/src/neurostack/watcher.py
@@ -7,7 +7,7 @@ import json
 import logging
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock, Timer
 
@@ -20,7 +20,7 @@ from .embedder import HAS_NUMPY, build_chunk_context, embedding_to_blob, get_emb
 from .graph import build_graph, compute_pagerank
 from .schema import DB_PATH, get_db
 from .summarizer import summarize_note
-from .triples import extract_triples, triple_to_text
+from .triples import TripleExtractionError, extract_triples, triple_to_text
 from .vecindex import (
     delete_chunk_vecs,
     delete_triple_vecs,
@@ -257,6 +257,58 @@ def index_single_note(
     conn.commit()
 
 
+# Hours to wait before the Nth triple-extraction retry. After the list is
+# exhausted the final value (a week) repeats — a note that keeps failing is
+# retried weekly rather than abandoned (issue #28).
+_TRIPLE_RETRY_BACKOFF_HOURS = [1, 6, 24, 72, 168]
+
+
+def _record_triple_failure(conn, note_path: str, content_hash: str, error: str) -> None:
+    """Upsert a triple-extraction failure row with exponential backoff.
+
+    Non-blocking: never lets bookkeeping disrupt indexing.
+    """
+    try:
+        row = conn.execute(
+            "SELECT attempts FROM triple_extraction_failed WHERE note_path = ?",
+            (note_path,),
+        ).fetchone()
+        attempts = (row["attempts"] if row else 0) + 1
+        idx = min(attempts, len(_TRIPLE_RETRY_BACKOFF_HOURS)) - 1
+        hours = _TRIPLE_RETRY_BACKOFF_HOURS[idx]
+        now_dt = datetime.now(timezone.utc)
+        next_retry = (now_dt + timedelta(hours=hours)).isoformat()
+        conn.execute(
+            "INSERT INTO triple_extraction_failed"
+            " (note_path, content_hash, attempts, last_error,"
+            "  last_attempt_at, next_retry_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(note_path) DO UPDATE SET"
+            "  content_hash=excluded.content_hash, attempts=excluded.attempts,"
+            "  last_error=excluded.last_error,"
+            "  last_attempt_at=excluded.last_attempt_at,"
+            "  next_retry_at=excluded.next_retry_at",
+            (note_path, content_hash, attempts, error[:500],
+             now_dt.isoformat(), next_retry),
+        )
+        log.warning(
+            "Triple extraction failed for %s (attempt %d); retry after %s",
+            note_path, attempts, next_retry,
+        )
+    except Exception:
+        log.debug("Could not record triple failure for %s", note_path, exc_info=True)
+
+
+def _clear_triple_failure(conn, note_path: str) -> None:
+    """Drop a note's retry row once extraction succeeds. Non-blocking."""
+    try:
+        conn.execute(
+            "DELETE FROM triple_extraction_failed WHERE note_path = ?", (note_path,)
+        )
+    except Exception:
+        pass
+
+
 def _index_triples_for_note(
     note_path: str,
     title: str,
@@ -274,7 +326,15 @@ def _index_triples_for_note(
         delete_triple_vecs(conn, note_path)
     conn.execute("DELETE FROM triples WHERE note_path = ?", (note_path,))
 
-    triples = extract_triples(title, content, base_url=summarize_url)
+    try:
+        triples = extract_triples(title, content, base_url=summarize_url)
+    except TripleExtractionError as e:
+        # Hard parse failure — queue for retry instead of silently dropping (#28).
+        _record_triple_failure(conn, note_path, content_hash, str(e))
+        return
+
+    # Extraction succeeded (possibly with zero triples) — clear any retry row.
+    _clear_triple_failure(conn, note_path)
     if not triples:
         return
 
@@ -360,23 +420,28 @@ def _prepare_note(
             log.warning(f"Embedding failed for {parsed.path}: {e}")
             chunk_embeddings = [None] * len(texts)
 
-    # Extract triples (LLM call)
+    # Extract triples (LLM call). A hard parse failure is captured (not swallowed)
+    # so the main thread can queue the note for retry — see issue #28.
     triples = []
     triple_embeddings = []
-    if not skip_triples and full_content:
+    triple_error = None
+    triple_attempted = not skip_triples and bool(full_content)
+    if triple_attempted:
         try:
             triples = extract_triples(parsed.title, full_content, base_url=summarize_url)
-            if triples and HAS_NUMPY:
-                triple_texts = [triple_to_text(t) for t in triples]
-                try:
-                    triple_embeddings = get_embeddings_batch(triple_texts, base_url=embed_url)
-                except Exception as e:
-                    log.warning(f"Triple embedding failed for {parsed.path}: {e}")
-                    triple_embeddings = [None] * len(triples)
-            else:
-                triple_embeddings = [None] * len(triples)
+        except TripleExtractionError as e:
+            triple_error = str(e)
         except Exception as e:
             log.warning(f"Triple extraction failed for {parsed.path}: {e}")
+        if triples and HAS_NUMPY:
+            triple_texts = [triple_to_text(t) for t in triples]
+            try:
+                triple_embeddings = get_embeddings_batch(triple_texts, base_url=embed_url)
+            except Exception as e:
+                log.warning(f"Triple embedding failed for {parsed.path}: {e}")
+                triple_embeddings = [None] * len(triples)
+        else:
+            triple_embeddings = [None] * len(triples)
 
     return {
         "parsed": parsed,
@@ -386,6 +451,8 @@ def _prepare_note(
         "chunk_embeddings": chunk_embeddings,
         "triples": triples,
         "triple_embeddings": triple_embeddings,
+        "triple_error": triple_error,
+        "triple_attempted": triple_attempted,
     }
 
 
@@ -486,6 +553,16 @@ def _write_note_results(conn, result: dict, _has_vec: bool) -> None:
                 upsert_triple_vec(conn, triple_id, emb_blob)
 
         upsert_cooccurrence_for_note(conn, parsed.path)
+
+    # Record or clear the triple-extraction retry row (#28). Only when extraction
+    # was actually attempted, so skip_triples runs don't erase a pending retry.
+    if result.get("triple_attempted"):
+        if result.get("triple_error"):
+            _record_triple_failure(
+                conn, parsed.path, parsed.content_hash, result["triple_error"]
+            )
+        else:
+            _clear_triple_failure(conn, parsed.path)
 
     conn.commit()
 
@@ -798,11 +875,18 @@ def backfill_triples(
     embed_url = embed_url or get_config().embed_url
     summarize_url = summarize_url or get_config().llm_url
     conn = get_db(DB_PATH)
-    # Find notes without triples
+    now_iso = datetime.now(timezone.utc).isoformat()
+    # Notes without triples, excluding those still in retry backoff (#28): a note
+    # queued for a later retry is skipped until its next_retry_at comes due.
     rows = conn.execute(
         """SELECT n.path, n.title, n.content_hash FROM notes n
            LEFT JOIN (SELECT DISTINCT note_path FROM triples) t ON n.path = t.note_path
-           WHERE t.note_path IS NULL"""
+           LEFT JOIN triple_extraction_failed f ON n.path = f.note_path
+           WHERE t.note_path IS NULL
+             AND (f.note_path IS NULL
+                  OR f.next_retry_at IS NULL
+                  OR f.next_retry_at <= ?)""",
+        (now_iso,),
     ).fetchall()
 
     total = len(rows)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -226,7 +226,7 @@ def test_migration_v11_to_v12(in_memory_db):
 
     # Version bumped
     row = conn.execute("SELECT MAX(version) as v FROM schema_version").fetchone()
-    assert row["v"] == 15
+    assert row["v"] == SCHEMA_VERSION
 
 
 def test_migration_v12_idempotent(in_memory_db):
@@ -247,4 +247,4 @@ def test_migration_v12_idempotent(in_memory_db):
     _run_migrations(conn)
 
     row = conn.execute("SELECT MAX(version) as v FROM schema_version").fetchone()
-    assert row["v"] == 15
+    assert row["v"] == SCHEMA_VERSION

--- a/tests/test_triples.py
+++ b/tests/test_triples.py
@@ -3,7 +3,13 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from neurostack.triples import extract_triples, triple_to_text
+import pytest
+
+from neurostack.triples import (
+    TripleExtractionError,
+    extract_triples,
+    triple_to_text,
+)
 
 
 def _mock_response(content: str) -> MagicMock:
@@ -88,20 +94,77 @@ class TestExtractTriplesMarkdownFences:
 
 class TestExtractTriplesJsonError:
     @patch("neurostack.triples.httpx.post")
-    def test_invalid_json_returns_empty(self, mock_post):
+    def test_invalid_json_raises_after_retry(self, mock_post):
+        # Unparseable on both the initial attempt and the retry -> hard failure
+        # (issue #28: no longer silently swallowed as an empty result).
         mock_post.return_value = _mock_response("this is not json at all")
 
-        result = extract_triples("Note", "content")
+        with pytest.raises(TripleExtractionError):
+            extract_triples("Note", "content")
 
-        assert result == []
+        assert mock_post.call_count == 2  # initial attempt + one retry
 
     @patch("neurostack.triples.httpx.post")
-    def test_partial_json_returns_empty(self, mock_post):
+    def test_partial_json_raises(self, mock_post):
         mock_post.return_value = _mock_response('[{"s": "A", "p": "b"')
+
+        with pytest.raises(TripleExtractionError):
+            extract_triples("Note", "content")
+
+
+class TestExtractTriplesRobustness:
+    @patch("neurostack.triples.httpx.post")
+    def test_object_form_parsed(self, mock_post):
+        raw = json.dumps({"triples": [{"s": "A", "p": "b", "o": "C"}]})
+        mock_post.return_value = _mock_response(raw)
+
+        result = extract_triples("Note", "content")
+
+        assert result == [{"s": "A", "p": "b", "o": "C"}]
+
+    @patch("neurostack.triples.httpx.post")
+    def test_salvages_json_embedded_in_prose(self, mock_post):
+        raw = 'Sure! Here are the triples:\n[{"s": "A", "p": "b", "o": "C"}]\nHope that helps.'
+        mock_post.return_value = _mock_response(raw)
+
+        result = extract_triples("Note", "content")
+
+        assert result == [{"s": "A", "p": "b", "o": "C"}]
+
+    @patch("neurostack.triples.httpx.post")
+    def test_retry_succeeds_after_first_failure(self, mock_post):
+        mock_post.side_effect = [
+            _mock_response("garbage, no json here"),
+            _mock_response('{"triples": [{"s": "A", "p": "b", "o": "C"}]}'),
+        ]
+
+        result = extract_triples("Note", "content")
+
+        assert result == [{"s": "A", "p": "b", "o": "C"}]
+        assert mock_post.call_count == 2
+
+    @patch("neurostack.triples.httpx.post")
+    def test_empty_result_is_not_a_failure(self, mock_post):
+        mock_post.return_value = _mock_response('{"triples": []}')
 
         result = extract_triples("Note", "content")
 
         assert result == []
+        assert mock_post.call_count == 1  # genuine-empty must not raise or retry
+
+    @patch("neurostack.triples.httpx.post")
+    def test_json_mode_first_attempt_only(self, mock_post):
+        mock_post.side_effect = [
+            _mock_response("garbage"),
+            _mock_response("[]"),
+        ]
+
+        extract_triples("Note", "content")
+
+        first = mock_post.call_args_list[0][1]["json"]
+        second = mock_post.call_args_list[1][1]["json"]
+        assert first.get("response_format") == {"type": "json_object"}
+        assert "response_format" not in second
 
 
 class TestExtractTriplesValidation:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -113,3 +113,89 @@ class TestOnAnyEvent:
         handler.on_any_event(event)
 
         MockTimer.assert_not_called()
+
+
+def _raise_triple_error(*a, **k):
+    from neurostack.triples import TripleExtractionError
+    raise TripleExtractionError("unparseable")
+
+
+class TestTripleRetryQueue:
+    """Triple-extraction failure / retry-queue bookkeeping (issue #28)."""
+
+    def _note(self, conn, path="notes/a.md", content_hash="h1"):
+        conn.execute(
+            "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?,?,?,?)",
+            (path, "A", content_hash, "2026-01-01"),
+        )
+        conn.commit()
+
+    def test_record_then_clear(self, in_memory_db):
+        from neurostack.watcher import _clear_triple_failure, _record_triple_failure
+        conn = in_memory_db
+        self._note(conn)
+        _record_triple_failure(conn, "notes/a.md", "h1", "boom")
+        row = conn.execute(
+            "SELECT attempts, next_retry_at FROM triple_extraction_failed WHERE note_path=?",
+            ("notes/a.md",),
+        ).fetchone()
+        assert row["attempts"] == 1
+        assert row["next_retry_at"] is not None
+        _clear_triple_failure(conn, "notes/a.md")
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM triple_extraction_failed"
+        ).fetchone()["c"] == 0
+
+    def test_attempts_increment(self, in_memory_db):
+        from neurostack.watcher import _record_triple_failure
+        conn = in_memory_db
+        self._note(conn)
+        _record_triple_failure(conn, "notes/a.md", "h1", "e1")
+        _record_triple_failure(conn, "notes/a.md", "h1", "e2")
+        row = conn.execute(
+            "SELECT attempts FROM triple_extraction_failed WHERE note_path=?",
+            ("notes/a.md",),
+        ).fetchone()
+        assert row["attempts"] == 2
+
+    def test_index_records_failure_on_parse_error(self, in_memory_db, monkeypatch):
+        import neurostack.watcher as watcher_mod
+        conn = in_memory_db
+        self._note(conn)
+        monkeypatch.setattr(watcher_mod, "extract_triples", _raise_triple_error)
+        watcher_mod._index_triples_for_note(
+            "notes/a.md", "A", "content", "h1", "2026-01-01",
+            conn, "http://e", "http://l",
+        )
+        row = conn.execute(
+            "SELECT attempts FROM triple_extraction_failed WHERE note_path=?",
+            ("notes/a.md",),
+        ).fetchone()
+        assert row is not None and row["attempts"] == 1
+        # No triples written for a failed extraction.
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM triples WHERE note_path=?", ("notes/a.md",)
+        ).fetchone()["c"] == 0
+
+    def test_index_clears_failure_on_success(self, in_memory_db, monkeypatch):
+        import neurostack.watcher as watcher_mod
+        from neurostack.watcher import _record_triple_failure
+        conn = in_memory_db
+        self._note(conn)
+        _record_triple_failure(conn, "notes/a.md", "h1", "old failure")
+        monkeypatch.setattr(
+            watcher_mod, "extract_triples",
+            lambda *a, **k: [{"s": "A", "p": "b", "o": "C"}],
+        )
+        monkeypatch.setattr(watcher_mod, "HAS_NUMPY", False)
+        watcher_mod._index_triples_for_note(
+            "notes/a.md", "A", "content", "h1", "2026-01-01",
+            conn, "http://e", "http://l",
+        )
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM triple_extraction_failed WHERE note_path=?",
+            ("notes/a.md",),
+        ).fetchone()["c"] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM triples WHERE note_path=?", ("notes/a.md",)
+        ).fetchone()["c"] == 1


### PR DESCRIPTION
## Problem (#28)

Triple extraction silently returned `[]` on malformed LLM JSON — indistinguishable in the DB from a note that legitimately yields no triples. A parse failure left the note at zero triples *permanently* unless someone ran `backfill` by hand. The vault had 25 zero-triple notes, 5 of them substantive.

## Fix

**`triples.py` — robust extraction:**
- Request a JSON object via `response_format: {"type": "json_object"}`.
- Salvage JSON embedded in prose / markdown fences (`_extract_json_blob`); accept a bare array or `{"triples": [...]}`.
- Retry once with a stricter prompt and no json-mode (in case a backend rejects the field).
- On a hard parse failure after the retry, **raise `TripleExtractionError`** instead of returning `[]`. A genuinely empty result is still a normal `[]`.

**`watcher.py` — retry queue:**
- Both extraction paths (`_index_triples_for_note` and the threaded `full_index` path) record a `TripleExtractionError` into a new `triple_extraction_failed` table with exponential backoff (1h → 6h → 24h → 72h → weekly), and clear the row on success.
- `backfill_triples` retries rows whose `next_retry_at` is due and skips notes still in backoff — failures self-heal on the next backfill/index instead of a manual sweep.

**`schema.py` — v16 migration:** additive `triple_extraction_failed` table (FK to `notes`, `ON DELETE CASCADE`).

## Validation on the live vault (LXC 122, prod-DB copy)

- v15→v16 migration ran clean: `schema_version=16`, table created, `notes=550` intact.
- `backfill triples` with robust extraction: **zero-triple notes 16 → 2, queued failures 0**. 14 of 16 healed in one run; the remaining 2 are legitimate stubs. No hard parse failures — json-object mode + salvage held.

## Tests

- `test_triples.py`: unparseable input now raises after retry; salvage from prose; `{"triples": […]}` form; retry-then-success; empty result is not an error; json-mode only on the first attempt.
- `test_watcher.py` `TestTripleRetryQueue`: failure row recorded with backoff + attempts increment; cleared on success; `_index_triples_for_note` records on `TripleExtractionError` and writes no triples.

473 passing. Package version unchanged (0.15.0); `SCHEMA_VERSION` 15 → 16.

Closes #28