### PR TITLE
fix(memories): flag + backfill failed memory embeddings (#29)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -485,7 +485,8 @@ def main():
     # backfill
     p = sub.add_parser("backfill", help="Backfill missing summaries and/or triples")
     p.add_argument(
-        "target", choices=["summaries", "triples", "cooccurrence", "all"],
+        "target",
+        choices=["summaries", "triples", "cooccurrence", "memories", "all"],
         default="all", nargs="?",
     )
     p.set_defaults(func=cmd_backfill)

--- a/src/neurostack/cli/index.py
+++ b/src/neurostack/cli/index.py
@@ -59,6 +59,12 @@ def cmd_backfill(args):
         conn = get_db(DB_PATH)
         n = persist_cooccurrence(conn)
         print(f"Co-occurrence backfill: {n} entity pairs populated.")
+    if args.target in ("memories", "all"):
+        from ..memories import backfill_memory_embeddings
+        from ..schema import DB_PATH, get_db
+        conn = get_db(DB_PATH)
+        n = backfill_memory_embeddings(conn, embed_url=args.embed_url)
+        print(f"Memory embedding backfill: {n} memories (re-)embedded.")
 
 
 def cmd_watch(args):

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -166,8 +166,10 @@ def save_memory(
             datetime.now(timezone.utc) + timedelta(hours=ttl_hours)
         ).strftime("%Y-%m-%d %H:%M:%S")
 
-    # Try to embed
+    # Try to embed. On failure, flag the row for backfill instead of silently
+    # storing a NULL embedding that stays invisible to semantic search (issue #29).
     embedding_blob = None
+    embed_pending = 0
     try:
         from .config import get_config
         from .embedder import embedding_to_blob, get_embedding
@@ -176,7 +178,8 @@ def save_memory(
         emb = get_embedding(content, base_url=url)
         embedding_blob = embedding_to_blob(emb)
     except Exception as exc:
-        log.debug("Could not embed memory (non-fatal): %s", exc)
+        embed_pending = 1
+        log.warning("Could not embed memory; flagged for backfill: %s", exc)
 
     tags_json = json.dumps(tags or [])
     memory_uuid = str(uuid.uuid4())
@@ -186,12 +189,12 @@ def save_memory(
         INSERT INTO memories (content, tags, entity_type,
                               source_agent, workspace,
                               embedding, expires_at,
-                              session_id, uuid)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                              session_id, uuid, embed_pending)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (content, tags_json, entity_type, source_agent,
          workspace, embedding_blob, expires_at,
-         session_id, memory_uuid),
+         session_id, memory_uuid, embed_pending),
     )
     conn.commit()
 
@@ -281,7 +284,7 @@ def update_memory(
         set_clauses.append("content = ?")
         params.append(content)
 
-        # Re-embed synchronously
+        # Re-embed synchronously; flag for backfill on failure (#29).
         try:
             from .config import get_config
             from .embedder import embedding_to_blob, get_embedding
@@ -291,8 +294,10 @@ def update_memory(
             embedding_blob = embedding_to_blob(emb)
             set_clauses.append("embedding = ?")
             params.append(embedding_blob)
+            set_clauses.append("embed_pending = 0")
         except Exception as exc:
-            log.debug("Could not re-embed memory (non-fatal): %s", exc)
+            set_clauses.append("embed_pending = 1")
+            log.warning("Could not re-embed memory; flagged for backfill: %s", exc)
 
     # Tags: replace, add, remove (processed in order)
     existing_tags_raw = row.get("tags")
@@ -535,8 +540,9 @@ def merge_memories(
     s_merge = source.get("merge_count") or 0
     new_merge_count = t_merge + s_merge + 1
 
-    # Re-embed
+    # Re-embed the merged content; flag for backfill on failure (#29).
     embedding_blob = target.get("embedding")
+    embed_pending = 0
     try:
         from .config import get_config
         from .embedder import embedding_to_blob, get_embedding
@@ -545,20 +551,21 @@ def merge_memories(
         emb = get_embedding(merged_content, base_url=url)
         embedding_blob = embedding_to_blob(emb)
     except Exception as exc:
-        log.debug("Could not re-embed merged memory (non-fatal): %s", exc)
+        embed_pending = 1
+        log.warning("Could not re-embed merged memory; flagged for backfill: %s", exc)
 
     conn.execute(
         """
         UPDATE memories
         SET content = ?, tags = ?, entity_type = ?, embedding = ?,
-            merge_count = ?, merged_from = ?,
+            merge_count = ?, merged_from = ?, embed_pending = ?,
             updated_at = datetime('now'), revision_count = revision_count + 1
         WHERE memory_id = ?
         """,
         (
             merged_content, json.dumps(merged_tags), merged_type,
             embedding_blob, new_merge_count, json.dumps(existing_merged),
-            target_id,
+            embed_pending, target_id,
         ),
     )
 
@@ -1096,3 +1103,48 @@ def _row_to_memory(row: dict | sqlite3.Row, score: float = 0.0) -> Memory:
         file_path=row.get("file_path"),
         score=score,
     )
+
+
+def backfill_memory_embeddings(
+    conn: sqlite3.Connection,
+    embed_url: str | None = None,
+) -> int:
+    """Re-embed memories whose embedding is missing or flagged pending (issue #29).
+
+    Targets rows with ``embedding IS NULL`` or ``embed_pending = 1`` — including
+    those written during a past embedding-service outage. Returns the count
+    successfully (re-)embedded; rows that still fail keep ``embed_pending = 1``
+    and are retried on the next call.
+    """
+    from .config import get_config
+    from .embedder import embedding_to_blob, get_embedding
+
+    url = embed_url or get_config().embed_url
+    rows = conn.execute(
+        "SELECT memory_id, content FROM memories"
+        " WHERE embedding IS NULL OR embed_pending = 1"
+    ).fetchall()
+    if not rows:
+        return 0
+
+    healed = 0
+    failed = 0
+    for r in rows:
+        try:
+            blob = embedding_to_blob(get_embedding(r["content"], base_url=url))
+        except Exception as exc:
+            failed += 1
+            log.warning("Memory %s still cannot embed: %s", r["memory_id"], exc)
+            continue
+        conn.execute(
+            "UPDATE memories SET embedding = ?, embed_pending = 0 WHERE memory_id = ?",
+            (blob, r["memory_id"]),
+        )
+        healed += 1
+    conn.commit()
+    if healed or failed:
+        log.info(
+            "Memory embedding backfill: %d embedded, %d still failing.",
+            healed, failed,
+        )
+    return healed

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -230,7 +230,11 @@ CREATE TABLE IF NOT EXISTS memories (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     expires_at TEXT,
     uuid TEXT,
-    file_path TEXT
+    file_path TEXT,
+    -- Set to 1 when content embedding failed (e.g. embedding service down) so the
+    -- row can be re-embedded by `neurostack backfill memories` instead of being
+    -- silently invisible to semantic search forever — see issue #29.
+    embed_pending INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(entity_type);
@@ -241,6 +245,8 @@ CREATE INDEX IF NOT EXISTS idx_memories_session
     ON memories(session_id) WHERE session_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memories_embedded ON memories(memory_id)
     WHERE embedding IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_memories_embed_pending ON memories(memory_id)
+    WHERE embed_pending = 1;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_uuid ON memories(uuid);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
@@ -866,6 +872,35 @@ def _run_migrations(conn: sqlite3.Connection):
         )
         conn.commit()
         log.info("Migration to v16 complete.")
+
+    if current < 17:
+        log.info(
+            "Migrating schema v16 -> v17: "
+            "adding memories.embed_pending column..."
+        )
+        # ALTER TABLE doesn't support IF NOT EXISTS - check column existence.
+        cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(memories)").fetchall()
+        }
+        if "embed_pending" not in cols:
+            conn.execute(
+                "ALTER TABLE memories ADD COLUMN"
+                " embed_pending INTEGER NOT NULL DEFAULT 0"
+            )
+        # Flag existing rows with no embedding so backfill picks them up (#29).
+        conn.execute(
+            "UPDATE memories SET embed_pending = 1 WHERE embedding IS NULL"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memories_embed_pending"
+            " ON memories(memory_id) WHERE embed_pending = 1"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version"
+            " VALUES (17)"
+        )
+        conn.commit()
+        log.info("Migration to v17 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/watcher.py
+++ b/src/neurostack/watcher.py
@@ -642,6 +642,7 @@ def full_index(
     summarize_url = summarize_url or get_config().llm_url
 
     # Pre-flight: check Ollama before starting a long indexing run
+    embeddings_ok = True
     if not skip_summary or not skip_triples:
         from .preflight import check_ollama, preflight_report
         result = check_ollama(
@@ -650,6 +651,7 @@ def full_index(
             llm_url=summarize_url,
             llm_model=get_config().llm_model,
         )
+        embeddings_ok = result.embed_ok
         report = preflight_report(result)
         if report:
             print(report)
@@ -741,6 +743,15 @@ def full_index(
         n_chunks = populate_vec_chunks(conn)
         n_triples = populate_vec_triples(conn)
         log.info(f"Vector index: {n_chunks} chunks, {n_triples} triples.")
+
+    # Self-heal memory embeddings flagged during a past embedding-service
+    # outage (#29). Only when embeddings are reachable this run; non-blocking.
+    if embeddings_ok:
+        try:
+            from .memories import backfill_memory_embeddings
+            backfill_memory_embeddings(conn, embed_url=embed_url)
+        except Exception as e:
+            log.warning(f"Memory embedding backfill skipped: {e}")
 
     log.info("Index complete.")
     return pruned

--- a/tests/test_memories.py
+++ b/tests/test_memories.py
@@ -457,3 +457,72 @@ class TestMemorySchemaIntegration:
             ("updated_token_abc",),
         ).fetchall()
         assert len(new) == 1
+
+
+def _embed_down(*a, **k):
+    raise ConnectionError("embedding service unavailable")
+
+
+def _fake_embed(*a, **k):
+    import numpy as np
+    return np.array([0.1] * 768, dtype=np.float32)
+
+
+class TestMemoryEmbeddingBackfill:
+    """Memory embeddings flag + backfill path (issue #29)."""
+
+    def test_save_flags_pending_on_embed_failure(self, in_memory_db, monkeypatch):
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(embedder_mod, "get_embedding", _embed_down)
+        m = save_memory(in_memory_db, content="no embed available", dedup=False)
+        row = in_memory_db.execute(
+            "SELECT embedding, embed_pending FROM memories WHERE memory_id=?",
+            (m.memory_id,),
+        ).fetchone()
+        assert row["embedding"] is None
+        assert row["embed_pending"] == 1
+
+    def test_save_not_pending_on_success(self, in_memory_db, monkeypatch):
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(embedder_mod, "get_embedding", _fake_embed)
+        m = save_memory(in_memory_db, content="embed ok", dedup=False)
+        row = in_memory_db.execute(
+            "SELECT embedding, embed_pending FROM memories WHERE memory_id=?",
+            (m.memory_id,),
+        ).fetchone()
+        assert row["embedding"] is not None
+        assert row["embed_pending"] == 0
+
+    def test_backfill_heals_pending(self, in_memory_db, monkeypatch):
+        import neurostack.embedder as embedder_mod
+        from neurostack.memories import backfill_memory_embeddings
+        # Saved during an outage -> pending
+        monkeypatch.setattr(embedder_mod, "get_embedding", _embed_down)
+        m = save_memory(in_memory_db, content="heal me later", dedup=False)
+        # Service recovers
+        monkeypatch.setattr(embedder_mod, "get_embedding", _fake_embed)
+        healed = backfill_memory_embeddings(in_memory_db)
+        assert healed == 1
+        row = in_memory_db.execute(
+            "SELECT embedding, embed_pending FROM memories WHERE memory_id=?",
+            (m.memory_id,),
+        ).fetchone()
+        assert row["embedding"] is not None
+        assert row["embed_pending"] == 0
+
+    def test_backfill_noop_when_all_embedded(self, in_memory_db, monkeypatch):
+        import neurostack.embedder as embedder_mod
+        from neurostack.memories import backfill_memory_embeddings
+        monkeypatch.setattr(embedder_mod, "get_embedding", _fake_embed)
+        save_memory(in_memory_db, content="already embedded", dedup=False)
+        assert backfill_memory_embeddings(in_memory_db) == 0
+
+    def test_backfill_leaves_pending_on_repeat_failure(self, in_memory_db, monkeypatch):
+        import neurostack.embedder as embedder_mod
+        from neurostack.memories import backfill_memory_embeddings
+        monkeypatch.setattr(embedder_mod, "get_embedding", _embed_down)
+        m = save_memory(in_memory_db, content="still down", dedup=False)
+        assert backfill_memory_embeddings(in_memory_db) == 0
+        assert in_memory_db.execute(
+            "SELECT embed_pending FROM memories WHERE memory_id=?", (m.memory_id,)
+        ).fetchone()["embed_pending"] == 1


### PR DESCRIPTION
## Problem (#29)

A memory whose content embedding failed (e.g. during an embedding-service outage) was committed with a NULL embedding and only a DEBUG log line — leaving it permanently invisible to semantic reranking and dedup, with no retry or backfill path. `_hybrid_memory_search` and `find_similar_memories` filter on `if r.get("embedding")`, so these rows only ever surfaced via FTS5 keyword match.

## Fix

**`memories.py`:**
- `save_memory` / `update_memory` / `merge_memories` set a new `embed_pending` flag and log at **WARNING** when embedding fails; clear it on success.
- New `backfill_memory_embeddings()` re-embeds rows where `embedding IS NULL OR embed_pending = 1` and clears the flag; rows that still fail stay pending and are retried next call.

**`cli/index.py`:** `neurostack backfill memories` (and `backfill all`) run the pass.

**`watcher.py`:** `full_index` runs the backfill at the end when embeddings are reachable this run, so failures self-heal on the next index cycle.

**`schema.py` — v17 migration:** adds `memories.embed_pending` and flags existing NULL-embedding rows so backfill picks them up. Additive; no data loss.

## Validation on the live vault (LXC 122, prod-DB copy)

- v16→v17 migration ran clean: `schema_version=17`, `embed_pending` column present, 896 memories intact.
- Migration flagged all **98** NULL-embedding memories as pending (the issue's 56 plus ones accrued since).
- `backfill memories`: **null_embedding 98 → 0, pending 98 → 0** — every orphaned memory re-embedded.

## Tests

`test_memories.py` `TestMemoryEmbeddingBackfill`: save flags pending on embed failure / not on success; backfill heals pending rows and clears the flag; no-op when all embedded; leaves rows pending when the service is still down.

478 passing. Package version unchanged (0.15.0); `SCHEMA_VERSION` 16 → 17.

Closes #29