### PR TITLE
ci: stop masking npm publish failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,18 @@ jobs:
           cd npm
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Publish to npm
-        run: npm publish || echo "Version already published — skipping"
+        # Skip only when this version is genuinely already on the registry
+        # (idempotent re-runs). Any other failure — bad token, network — must
+        # fail the job loudly instead of being swallowed by `|| echo`.
+        run: |
+          if npm view "neurostack@${TAG#v}" version >/dev/null 2>&1; then
+            echo "neurostack@${TAG#v} already published — skipping"
+          else
+            npm publish
+          fi
         working-directory: npm
         env:
+          TAG: ${{ github.ref_name }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-mcpb:


### PR DESCRIPTION
## Problem

The npm publish step ran `npm publish || echo "Version already published — skipping"`, which swallows **every** failure as success. Consequences:

- The v0.16.0 release run reported green while npm publishing was failing on an expired `NPM_TOKEN` (`404 Not Found - PUT .../neurostack`). PyPI + the GitHub release shipped; npm silently did not, until the token was rotated and the run re-run.
- 0.14.0 and 0.15.0 never reaching npm went unnoticed for the same reason (those were never tagged, but the masking is what would have hidden any failed attempt).

## Fix

Skip only when the version is genuinely already on the registry (so idempotent re-runs still no-op); any other failure — bad token, network, registry error — now fails the job loudly.

```yaml
run: |
  if npm view "neurostack@${TAG#v}" version >/dev/null 2>&1; then
    echo "neurostack@${TAG#v} already published — skipping"
  else
    npm publish
  fi
env:
  TAG: ${{ github.ref_name }}
  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

PyPI already uses `skip-existing: true` (proper idempotency without masking), so it's unchanged.

## Note

`publish.yml` only runs on `v*` tag pushes, so this change isn't exercised by PR CI — it's validated at the next release. YAML parse verified locally.