### PR TITLE
harvest: route credential/endpoint prefilter hits to context (#30 p3)

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -485,7 +485,10 @@ _PREFILTER: dict[str, list[re.Pattern]] = {
         r"|the reason is|key finding|it.s actually|didn.t know"
         r"|wasn.t aware|interesting)\b", re.I,
     )],
-    "observation": [re.compile(
+    # Credentials, endpoints, URLs and current-state facts go stale quickly —
+    # default them to ephemeral 'context' (168h TTL). The LLM still overrides
+    # per-item to 'observation' when a match is genuinely durable (issue #30).
+    "context": [re.compile(
         r"\b(credential|api.?key|endpoint|connection.?string"
         r"|host(name)?:|port:|url:|stored at|located at"
         r"|config\.toml|\.env\b)\b", re.I,

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -114,9 +114,10 @@ class TestPrefilterClassify:
         text = "I discovered that the API rate limit resets every 60 seconds not 30."
         assert _prefilter_classify(text, "assistant") == "learning"
 
-    def test_observation_pattern(self):
+    def test_context_pattern(self):
+        # Credentials/endpoints/URLs default to ephemeral 'context' (issue #30 p3).
         text = "The API key is stored at /etc/myapp/credentials and rotated weekly."
-        assert _prefilter_classify(text, "assistant") == "observation"
+        assert _prefilter_classify(text, "assistant") == "context"
 
     def test_short_text_rejected(self):
         assert _prefilter_classify("root cause", "assistant") is None


### PR DESCRIPTION
The `_PREFILTER` bucket matching credentials, API keys, endpoints, connection strings, hosts/ports/URLs and config-file paths was keyed `observation`. When the LLM classifier is unavailable (fails, disabled, or returns an unrecognised type), harvest falls back to this prefilter type — so these session-scoped facts were saved as durable memories with no TTL.

These are exactly the "ephemeral session-scoped facts (credentials, endpoints, URLs, current-state notes that go stale quickly)" the classifier prompt already frames as the `context` category. This renames the bucket key to `context`, so the regex fallback defaults them to a 168h TTL (the existing `ttl = 168.0 if etype == "context"` branch). The LLM still overrides per-item to `observation` when a match is genuinely durable.

Follow-up to #30 (part 3 — the deferred prefilter follow-up).

## Test
- Renamed `test_observation_pattern` → `test_context_pattern`, asserts the credential sample now prefilters to `context`.
- Full suite: 478 passed.