### PR TITLE
doctor: warn when excitability decay last ran >48h ago (#31 p4)

### DIFF
--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -689,12 +689,14 @@ def cmd_decay(args):
     conn = get_db(DB_PATH)
 
     if getattr(args, "demote", False):
-        from ..search import run_excitability_demotion
+        from ..search import record_decay_run, run_excitability_demotion
         result = run_excitability_demotion(
             conn,
             threshold=args.threshold,
             half_life_days=args.half_life,
         )
+        # Stamp the run so `neurostack doctor` can flag a stalled decay timer.
+        record_decay_run(result["demoted"], result["promoted"])
         if args.json:
             print(json.dumps(result, indent=2))
         else:

--- a/src/neurostack/cli/setup.py
+++ b/src/neurostack/cli/setup.py
@@ -1637,6 +1637,28 @@ def cmd_doctor(args):
             " pip install neurostack[full])",
         ))
 
+    # Check excitability decay liveness — a stalled scheduled timer means
+    # dormancy reconciliation silently stops. Only meaningful with an index.
+    if cfg.db_path.exists():
+        from ..search import DECAY_STALE_HOURS, decay_hours_since
+        hours = decay_hours_since()
+        if hours is None:
+            checks.append((
+                "Decay", "WARN",
+                "never run. Install the scheduled timer to keep dormancy"
+                " in sync (neurostack-decay.timer running"
+                " 'neurostack decay --demote')",
+            ))
+        elif hours > DECAY_STALE_HOURS:
+            checks.append((
+                "Decay", "WARN",
+                f"last run {hours:.0f}h ago (> {DECAY_STALE_HOURS:.0f}h stale)."
+                " The decay timer may have stopped"
+                " — check neurostack-decay.timer",
+            ))
+        else:
+            checks.append(("Decay", "OK", f"last run {hours:.1f}h ago"))
+
     # Print results
     if args.json:
         output = {

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -594,6 +594,76 @@ def run_excitability_demotion(
     }
 
 
+# ---------------------------------------------------------------------------
+# Decay run tracking — last-run timestamp so `neurostack doctor` can warn
+# when the scheduled decay timer has stopped firing (excitability would
+# silently stop reconciling). State lives beside the DB, like harvest_state.
+# ---------------------------------------------------------------------------
+
+DECAY_STALE_HOURS = 48.0
+
+
+def _decay_state_path():
+    """Path to the JSON file recording the last excitability-decay run."""
+    return get_config().db_dir / "decay_state.json"
+
+
+def record_decay_run(demoted: int, promoted: int, when: str | None = None) -> None:
+    """Record that an excitability-decay pass just ran.
+
+    Written on every ``neurostack decay --demote`` (the scheduled-timer entry
+    point). A run that demotes nothing still counts — the signal is liveness,
+    not churn. Persisted atomically (temp file + os.replace), like harvest.
+    """
+    import os
+    import tempfile
+    from datetime import datetime, timezone
+
+    ts = when or datetime.now(timezone.utc).isoformat()
+    path = _decay_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps({"last_run": ts, "demoted": demoted, "promoted": promoted})
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def get_decay_last_run():
+    """Return the last decay run as a tz-aware datetime, or None if unrecorded."""
+    from datetime import datetime, timezone
+
+    path = _decay_state_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        last = datetime.fromisoformat(data["last_run"])
+    except (json.JSONDecodeError, OSError, KeyError, ValueError, TypeError):
+        return None
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=timezone.utc)
+    return last
+
+
+def decay_hours_since(now=None) -> float | None:
+    """Hours since the last decay run, or None if never recorded."""
+    from datetime import datetime, timezone
+
+    last = get_decay_last_run()
+    if last is None:
+        return None
+    current = now or datetime.now(timezone.utc)
+    return (current - last).total_seconds() / 3600.0
+
+
 def hybrid_search(
     query: str,
     top_k: int = 5,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,12 +4,16 @@ import struct
 
 from neurostack.config import Config
 from neurostack.search import (
+    DECAY_STALE_HOURS,
     PREDICTION_ERROR_SIM_THRESHOLD,
     _record_note_usage,
+    decay_hours_since,
     fts_search,
+    get_decay_last_run,
     hotness_score,
     hybrid_search,
     log_prediction_error,
+    record_decay_run,
     run_excitability_demotion,
 )
 
@@ -323,6 +327,65 @@ class TestExcitabilityDemotion:
             ("renewed.md",),
         ).fetchone()["status"]
         assert status == "active"
+
+
+class TestDecayRunTracking:
+    """Last-run stamp that lets `neurostack doctor` flag a stalled decay timer (issue #31 p4)."""
+
+    def _patch_db_dir(self, monkeypatch, tmp_path):
+        from types import SimpleNamespace
+        monkeypatch.setattr(
+            "neurostack.search.get_config",
+            lambda: SimpleNamespace(db_dir=tmp_path),
+        )
+
+    def test_no_state_returns_none(self, monkeypatch, tmp_path):
+        self._patch_db_dir(monkeypatch, tmp_path)
+        assert get_decay_last_run() is None
+        assert decay_hours_since() is None
+
+    def test_record_and_read_roundtrip(self, monkeypatch, tmp_path):
+        self._patch_db_dir(monkeypatch, tmp_path)
+        from datetime import datetime, timezone
+        when = datetime(2026, 6, 12, 3, 0, tzinfo=timezone.utc).isoformat()
+        record_decay_run(demoted=2, promoted=1, when=when)
+        assert (tmp_path / "decay_state.json").exists()
+        last = get_decay_last_run()
+        assert last is not None and last.isoformat() == when
+
+    def test_zero_run_still_records(self, monkeypatch, tmp_path):
+        # A run that demotes/promotes nothing still proves the timer fired.
+        self._patch_db_dir(monkeypatch, tmp_path)
+        record_decay_run(0, 0)
+        assert get_decay_last_run() is not None
+
+    def test_hours_since_fresh(self, monkeypatch, tmp_path):
+        self._patch_db_dir(monkeypatch, tmp_path)
+        from datetime import datetime, timedelta, timezone
+        now = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+        record_decay_run(0, 0, when=(now - timedelta(hours=1)).isoformat())
+        assert 0.9 < decay_hours_since(now=now) < 1.1
+
+    def test_hours_since_stale(self, monkeypatch, tmp_path):
+        self._patch_db_dir(monkeypatch, tmp_path)
+        from datetime import datetime, timedelta, timezone
+        now = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+        record_decay_run(0, 0, when=(now - timedelta(hours=72)).isoformat())
+        assert decay_hours_since(now=now) > DECAY_STALE_HOURS
+
+    def test_naive_timestamp_treated_as_utc(self, monkeypatch, tmp_path):
+        # A stored naive ISO string must not raise on the tz-aware subtraction.
+        self._patch_db_dir(monkeypatch, tmp_path)
+        record_decay_run(0, 0, when="2026-06-12T03:00:00")
+        from datetime import datetime, timezone
+        now = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+        assert decay_hours_since(now=now) == 9.0
+
+    def test_corrupt_state_returns_none(self, monkeypatch, tmp_path):
+        self._patch_db_dir(monkeypatch, tmp_path)
+        (tmp_path / "decay_state.json").write_text("{not valid json")
+        assert get_decay_last_run() is None
+        assert decay_hours_since() is None
 
 
 class TestExcitabilityBoost:


### PR DESCRIPTION
The `decay` command never recorded when it last ran, so a stalled scheduled timer (`neurostack-decay.timer`) would silently stop reconciling dormancy with no visible signal — exactly the failure mode from the original #31 deploy, where the timer was first installed as a `systemctl --user` unit that never fired for root.

## What this does
- **Persist a last-run stamp** on every `neurostack decay --demote` (the timer's entry point) to `decay_state.json` beside the DB, written atomically (temp file + `os.replace`) like `harvest_state.json`. A run that demotes/promotes nothing still counts — the signal is liveness, not churn.
- **`neurostack doctor` reads it** and adds a `Decay` check:
  - `WARN` — never run (timer likely not installed)
  - `WARN` — last run > 48h ago (one missed daily run of slack; timer may have stopped)
  - `OK` — last run within 48h
  - skipped entirely when no index exists (decay is meaningless without one)

New helpers in `search.py`: `record_decay_run`, `get_decay_last_run`, `decay_hours_since`, `DECAY_STALE_HOURS`.

Follow-up to #31 (part 4 — the deferred doctor staleness warning).

## Test
- 7 new tests in `TestDecayRunTracking`: no-state, record/read round-trip, zero-run still records, fresh vs stale hours-since, naive-timestamp handling, corrupt-state fallback.
- Full suite: 485 passed.
- Smoke-tested `neurostack --json doctor` locally: emits the `Decay` "never run" WARN as expected.