### PR TITLE
fix: auto-router depth=auto performs a real triple+summary merge (#58)

### DIFF
--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -58,6 +58,11 @@ class Config:
     link_section_penalty: float = 0.5     # score multiplier for link-list chunk matches
     link_density_threshold: float = 0.5   # chunk is a "link section" when this fraction
                                           # or more of its characters are wiki-link markup
+    # Auto-router merge (issue #58): depth="auto" merges the triple ranking with
+    # an independent summary search instead of returning triple order with summary
+    # text attached. This is the weight given to the (normalized) summary score in
+    # the blended note ranking; the triple score gets (1 - auto_summary_weight).
+    auto_summary_weight: float = 0.5      # 0.0 = triples only, 1.0 = summaries only
 
     @property
     def db_path(self) -> Path:
@@ -96,6 +101,8 @@ def load_config() -> Config:
             cfg.link_section_penalty = float(data["link_section_penalty"])
         if "link_density_threshold" in data:
             cfg.link_density_threshold = float(data["link_density_threshold"])
+        if "auto_summary_weight" in data:
+            cfg.auto_summary_weight = float(data["auto_summary_weight"])
 
     # Env var overrides (NEUROSTACK_ prefix)
     env_map = {
@@ -116,6 +123,7 @@ def load_config() -> Config:
         "NEUROSTACK_COOCCURRENCE_BOOST": ("cooccurrence_boost_weight", float),
         "NEUROSTACK_LINK_SECTION_PENALTY": ("link_section_penalty", float),
         "NEUROSTACK_LINK_DENSITY_THRESHOLD": ("link_density_threshold", float),
+        "NEUROSTACK_AUTO_SUMMARY_WEIGHT": ("auto_summary_weight", float),
     }
 
     for env_key, (attr, typ) in env_map.items():

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -1356,6 +1356,25 @@ def _to_triple_results(conn: sqlite3.Connection, results: list[dict]) -> list[Tr
 # ---------------------------------------------------------------------------
 
 
+def _normalize_scores(scores: dict[str, float]) -> dict[str, float]:
+    """Scale a {key: score} map into [0, 1] by dividing by the max.
+
+    Used to put triple scores and summary/chunk scores on a common scale before
+    merging them in the auto-router. Unlike min-max, this preserves relative
+    magnitude: the second-best note keeps its real fraction of the best rather than
+    collapsing to 0.0. That matters because the gate fires at the minimum of two
+    triple notes, where min-max would always zero out the lower note regardless of
+    how relevant it was. An empty map yields an empty map; a non-positive max (no
+    usable signal) yields all 0.0; negatives are clamped to 0.0.
+    """
+    if not scores:
+        return {}
+    hi = max(scores.values())
+    if hi <= 0:
+        return {k: 0.0 for k in scores}
+    return {k: max(0.0, v / hi) for k, v in scores.items()}
+
+
 def tiered_search(
     query: str,
     top_k: int = 5,
@@ -1372,8 +1391,11 @@ def tiered_search(
     - "triples": Return only triples (~10-20 tokens per fact). Cheapest.
     - "summaries": Return note summaries (~50-100 tokens per note). Medium.
     - "full": Return full chunk snippets + summaries (~200-500 tokens). Current behavior.
-    - "auto": Start with triples, include summaries for top matches,
-              full chunks only if triple coverage is low.
+    - "auto": Start with triples; when coverage is good, blend the triple
+              ranking with an independent summary search (normalized + merged
+              per note, weighted by config.auto_summary_weight) and return the
+              merged note ranking. Falls back to full chunks if triple coverage
+              is low.
 
     Returns dict with keys: triples, summaries, chunks (each may be empty
     depending on depth).
@@ -1448,22 +1470,85 @@ def tiered_search(
     triple_notes = {t.note_path for t in triples}
     triple_confidence = max((t.score for t in triples), default=0.0)
 
-    # If triples have good coverage and high scores, just add summaries for top notes
+    # If triples have good coverage and high scores, merge the triple ranking with
+    # an independent summary search. (Issue #58: the old code returned triple order
+    # with summary text attached — no rescore, no merge — so depth="auto" was a
+    # byte-for-byte alias of depth="triples" whenever this gate fired.)
     if len(triple_notes) >= 2 and triple_confidence > 0.4:
-        # Add summaries for the top-scoring note paths
-        top_notes = list(dict.fromkeys(t.note_path for t in triples))[:top_k]
-        for np_ in top_notes:
-            summary_row = conn.execute(
-                "SELECT s.summary_text, n.title FROM summaries s "
-                "JOIN notes n ON n.path = s.note_path WHERE s.note_path = ?",
-                (np_,),
-            ).fetchone()
-            if summary_row:
-                result["summaries"].append({
-                    "note": np_, "title": summary_row["title"],
-                    "summary": summary_row["summary_text"],
-                })
-        result["depth_used"] = "auto:triples+summaries"
+        # Independent summary ranking for the same query (best chunk per note).
+        summary_results = hybrid_search(
+            query, top_k=top_k * 3, mode=mode,
+            embed_url=embed_url, db_path=db_path,
+            context=context, workspace=workspace,
+        )
+        summary_scores: dict[str, float] = {}
+        summary_meta: dict[str, tuple[str, str]] = {}
+        for r in summary_results:
+            if r.note_path not in summary_scores:
+                summary_scores[r.note_path] = r.score
+                summary_meta[r.note_path] = (r.title, r.summary or "")
+
+        # Best triple score per note, plus a title fallback.
+        triple_scores: dict[str, float] = {}
+        triple_titles: dict[str, str] = {}
+        for t in triples:
+            if t.score > triple_scores.get(t.note_path, float("-inf")):
+                triple_scores[t.note_path] = t.score
+            triple_titles.setdefault(t.note_path, t.title)
+
+        # Normalize both sets to [0, 1] and blend per note.
+        norm_triple = _normalize_scores(triple_scores)
+        norm_summary = _normalize_scores(summary_scores)
+        summary_weight = get_config().auto_summary_weight
+        triple_weight = 1.0 - summary_weight
+        merged_scores: dict[str, float] = {}
+        for np_ in set(norm_triple) | set(norm_summary):
+            merged_scores[np_] = (
+                triple_weight * norm_triple.get(np_, 0.0)
+                + summary_weight * norm_summary.get(np_, 0.0)
+            )
+        # Score descending, note_path ascending as a deterministic tie-break
+        # (merged_scores was built by iterating a set, whose order isn't stable).
+        ranked_notes = sorted(
+            merged_scores, key=lambda n: (-merged_scores[n], n)
+        )[:top_k]
+
+        # Summaries in merged order (fetch text for notes the summary search missed,
+        # e.g. a zero-chunk note that only surfaced via triples).
+        for np_ in ranked_notes:
+            if np_ in summary_meta:
+                title, summary_text = summary_meta[np_]
+            else:
+                row = conn.execute(
+                    "SELECT s.summary_text, n.title FROM summaries s "
+                    "JOIN notes n ON n.path = s.note_path WHERE s.note_path = ?",
+                    (np_,),
+                ).fetchone()
+                title = row["title"] if row else triple_titles.get(np_, np_)
+                summary_text = row["summary_text"] if row else ""
+            result["summaries"].append({
+                "note": np_, "title": title,
+                "summary": summary_text or "",
+                "score": round(merged_scores[np_], 4),
+            })
+
+        # Re-order the raw triple facts to follow the merged note ranking (stable
+        # sort keeps every fact; notes outside the top_k keep their relative order).
+        rank_index = {np_: i for i, np_ in enumerate(ranked_notes)}
+        result["triples"].sort(
+            key=lambda tr: rank_index.get(tr["note"], len(ranked_notes))
+        )
+
+        result["merged_ranking"] = [
+            {"note": np_, "score": round(merged_scores[np_], 4)}
+            for np_ in ranked_notes
+        ]
+        # Be honest about which signals actually contributed: if the summary
+        # search returned nothing (e.g. embedding backend down, or no chunk hit),
+        # the ranking is triple-only — don't label it a merge.
+        result["depth_used"] = (
+            "auto:triples+summaries" if summary_scores else "auto:triples"
+        )
         return result
 
     # Low triple coverage — fall back to full chunk search

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,6 +6,9 @@ from neurostack.config import Config
 from neurostack.search import (
     DECAY_STALE_HOURS,
     PREDICTION_ERROR_SIM_THRESHOLD,
+    SearchResult,
+    TripleResult,
+    _normalize_scores,
     _record_note_usage,
     decay_hours_since,
     fts_search,
@@ -15,6 +18,7 @@ from neurostack.search import (
     log_prediction_error,
     record_decay_run,
     run_excitability_demotion,
+    tiered_search,
 )
 
 
@@ -999,3 +1003,176 @@ class TestLinkSectionDownweight:
         assert linky.explain["after_link"] < linky.explain["base"]
         canon = next(r for r in results if r.note_path == "canonical.md")
         assert canon.explain["link_section"] is False
+
+
+class TestNormalizeScores:
+    """Tests for the _normalize_scores helper (max-normalization) used by the merge."""
+
+    def test_empty(self):
+        assert _normalize_scores({}) == {}
+
+    def test_equal_values_all_one(self):
+        # No spread -> everything is equally "the best".
+        assert _normalize_scores({"a": 0.5, "b": 0.5}) == {"a": 1.0, "b": 1.0}
+
+    def test_divides_by_max(self):
+        out = _normalize_scores({"a": 1.0, "b": 0.5, "c": 0.0})
+        assert out["a"] == 1.0
+        assert abs(out["b"] - 0.5) < 1e-9
+        assert out["c"] == 0.0
+
+    def test_preserves_magnitude_unlike_minmax(self):
+        # The defining difference from min-max: the lower note keeps its real
+        # fraction of the max (0.4/0.8 = 0.5) instead of collapsing to 0.0.
+        out = _normalize_scores({"a": 0.8, "b": 0.4})
+        assert out["a"] == 1.0
+        assert abs(out["b"] - 0.5) < 1e-9
+
+    def test_nonpositive_max_yields_zeros(self):
+        # No usable signal -> all 0.0, no division by zero.
+        assert _normalize_scores({"a": 0.0, "b": 0.0}) == {"a": 0.0, "b": 0.0}
+
+    def test_negatives_clamped(self):
+        out = _normalize_scores({"a": 1.0, "b": -0.5})
+        assert out["a"] == 1.0
+        assert out["b"] == 0.0
+
+
+class TestTieredAutoMerge:
+    """Tests for tiered_search(depth='auto') — the real triple+summary merge (issue #58).
+
+    The merge logic is isolated from embeddings/DB by patching search_triples and
+    hybrid_search at the module level; get_db returns the in-memory fixture so the
+    summary-fetch fallback for triple-only notes can hit a real table.
+    """
+
+    def _run_auto(self, monkeypatch, conn, triples, summary_hits, top_k=3):
+        import neurostack.config as config_mod
+        import neurostack.search as search_mod
+
+        monkeypatch.setattr(search_mod, "search_triples", lambda *a, **k: triples)
+        monkeypatch.setattr(search_mod, "hybrid_search", lambda *a, **k: summary_hits)
+        monkeypatch.setattr(search_mod, "get_db", lambda path: conn)
+
+        original = config_mod._config
+        try:
+            config_mod._config = Config()  # auto_summary_weight defaults to 0.5
+            return tiered_search(
+                "q", top_k=top_k, depth="auto", embed_url="http://fake"
+            )
+        finally:
+            config_mod._config = original
+
+    def test_summary_signal_reorders_triple_ranking(self, in_memory_db, monkeypatch):
+        """A note that triples rank low but summaries rank top must rise in auto.
+
+        Pre-fix this returned pure triple order; the regression is that the
+        summary search never influenced the ranking.
+        """
+        triples = [
+            TripleResult("a.md", "A", "x", "y", 0.90, "A"),
+            TripleResult("b.md", "B", "x", "y", 0.70, "B"),
+            TripleResult("c.md", "C", "x", "y", 0.50, "C"),
+        ]
+        # c is the strongest summary hit, a the weakest — the inverse of triples.
+        summary_hits = [
+            SearchResult("c.md", "h", "snip", 0.95, summary="C sum", title="C"),
+            SearchResult("b.md", "h", "snip", 0.50, summary="B sum", title="B"),
+            SearchResult("a.md", "h", "snip", 0.10, summary="A sum", title="A"),
+        ]
+        result = self._run_auto(monkeypatch, in_memory_db, triples, summary_hits)
+
+        assert result["depth_used"] == "auto:triples+summaries"
+        order = [s["note"] for s in result["summaries"]]
+        # Triples alone put b (0.70) above c (0.50); the summary signal flips it.
+        assert order.index("c.md") < order.index("b.md")
+        # merged_ranking is the canonical order and matches the summaries list.
+        assert [m["note"] for m in result["merged_ranking"]] == order
+        # Every surfaced summary carries a numeric merged score.
+        assert all(isinstance(s["score"], float) for s in result["summaries"])
+
+    def test_auto_order_differs_from_triples_only(self, in_memory_db, monkeypatch):
+        """depth='auto' must not be a byte-for-byte alias of depth='triples'."""
+        triples = [
+            TripleResult("a.md", "A", "x", "y", 0.90, "A"),
+            TripleResult("b.md", "B", "x", "y", 0.70, "B"),
+            TripleResult("c.md", "C", "x", "y", 0.50, "C"),
+        ]
+        summary_hits = [
+            SearchResult("c.md", "h", "snip", 0.95, summary="C sum", title="C"),
+            SearchResult("b.md", "h", "snip", 0.50, summary="B sum", title="B"),
+            SearchResult("a.md", "h", "snip", 0.10, summary="A sum", title="A"),
+        ]
+        auto = self._run_auto(monkeypatch, in_memory_db, triples, summary_hits)
+        auto_order = [s["note"] for s in auto["summaries"]]
+        triple_only_order = ["a.md", "b.md", "c.md"]  # pure descending triple score
+        assert auto_order != triple_only_order
+
+    def test_triple_only_note_gets_summary_from_db(self, in_memory_db, monkeypatch):
+        """A note that surfaces only via triples (no chunk hit) still gets its
+        summary fetched from the DB and appears in the merged output."""
+        conn = in_memory_db
+        conn.execute(
+            "INSERT INTO notes (path, title, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("x.md", "Note X", "hx", "2026-01-01"),
+        )
+        conn.execute(
+            "INSERT INTO summaries (note_path, summary_text, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("x.md", "Summary of X from the DB", "hx", "2026-01-01"),
+        )
+        conn.commit()
+
+        triples = [
+            TripleResult("x.md", "X", "p", "o", 0.85, "Note X"),
+            TripleResult("y.md", "Y", "p", "o", 0.60, "Note Y"),
+        ]
+        # hybrid_search returns y only — x never appears as a chunk hit.
+        summary_hits = [
+            SearchResult("y.md", "h", "snip", 0.70, summary="Y sum", title="Note Y"),
+        ]
+        result = self._run_auto(monkeypatch, conn, triples, summary_hits)
+
+        surfaced = {s["note"]: s for s in result["summaries"]}
+        assert "x.md" in surfaced
+        assert surfaced["x.md"]["summary"] == "Summary of X from the DB"
+        assert "x.md" in {m["note"] for m in result["merged_ranking"]}
+
+    def test_empty_summary_search_labels_triples_only(self, in_memory_db, monkeypatch):
+        """Gate fires but the summary search returns nothing -> the ranking is
+        triple-only, and depth_used must say so rather than claim a merge."""
+        triples = [
+            TripleResult("a.md", "A", "p", "o", 0.90, "A"),
+            TripleResult("b.md", "B", "p", "o", 0.70, "B"),
+        ]
+        result = self._run_auto(monkeypatch, in_memory_db, triples, [])
+        assert result["depth_used"] == "auto:triples"
+        # Still produces a ranking (triple order), just honestly labeled.
+        assert [m["note"] for m in result["merged_ranking"]] == ["a.md", "b.md"]
+
+    def test_low_coverage_falls_back_to_chunks(self, in_memory_db, monkeypatch):
+        """Fewer than two triple notes -> gate not fired -> full chunk fallback."""
+        triples = [TripleResult("only.md", "O", "p", "o", 0.90, "Only")]
+        chunk_hits = [
+            SearchResult("z.md", "## H", "a snippet", 0.80, summary="Z", title="Z"),
+        ]
+        result = self._run_auto(monkeypatch, in_memory_db, triples, chunk_hits)
+
+        assert result["depth_used"] == "auto:full"
+        assert result["summaries"] == []
+        assert [c["note"] for c in result["chunks"]] == ["z.md"]
+
+    def test_low_confidence_falls_back_to_chunks(self, in_memory_db, monkeypatch):
+        """Two notes but max triple score <= 0.4 -> gate not fired -> chunk fallback."""
+        triples = [
+            TripleResult("a.md", "A", "p", "o", 0.30, "A"),
+            TripleResult("b.md", "B", "p", "o", 0.20, "B"),
+        ]
+        chunk_hits = [
+            SearchResult("z.md", "## H", "a snippet", 0.80, summary="Z", title="Z"),
+        ]
+        result = self._run_auto(monkeypatch, in_memory_db, triples, chunk_hits)
+
+        assert result["depth_used"] == "auto:full"
+        assert result["chunks"]


### PR DESCRIPTION
## What

`tiered_search(depth="auto")` advertised a triple+summary merge but never performed one — it attached summary text to notes already ranked by triple score and returned. The note ordering came back byte-identical to `depth="triples"`, so the **default** retrieval path (the `vault_search` MCP tool, `neurostack tiered`) silently ignored the summary signal whenever triple coverage cleared the `triple_confidence > 0.4` gate. #41 only touched the `depth="full"` path, which the auto branch skips once the gate fires.

## How

When the gate fires, the auto branch now:

- runs an **independent** summary search (`hybrid_search`) for the query;
- **max-normalizes** triple and summary scores to [0, 1] (divide by max). Max-normalization over min-max is deliberate: the gate fires at the minimum of *two* triple notes, where min-max would force the lower note to a hard 0.0 regardless of its real relevance. Max-norm keeps its relative magnitude;
- blends per note with `auto_summary_weight` (new config knob, default 0.5; `NEUROSTACK_AUTO_SUMMARY_WEIGHT`) and re-ranks;
- returns the merged order via `summaries` + a new `merged_ranking` key; raw triple facts are re-sorted to follow it.

Notes that surface only via triples still get their summary fetched from the DB. If the summary search returns nothing (backend down, no chunk hit), the result is honestly labeled `auto:triples` instead of claiming a merge.

## Validation

Against a `/tmp` copy of the LXC 122 prod DB (548 notes, schema v17), with live embeddings:

| query | `auto` == `triples` (before → after) | merge effect |
|---|---|---|
| NBSE disaster recovery | identical → **differs** | surfaces `nbse-dr-test-official-report`, `infra-dr-test` (absent from triples-only) |
| neurostack hebbian | identical → **differs** | lifts `hebbian-gradient-transition`, `pc-vault-oracle`; drops `research/index` noise |
| azure consolidation | identical → **differs** | lifts `azure-networking` |

## Tests

`tiered_search` had **no** prior coverage. Adds `TestTieredAutoMerge` (6 tests: summary signal reorders ranking, auto ≠ triples-only, triple-only note gets its DB summary, honest `auto:triples` label on empty summary search, two gate-not-fired fallbacks) and `TestNormalizeScores` (6 tests incl. the max-norm-vs-min-max distinction, non-positive max, negative clamp). Suite 485 → 497, all green; ruff clean.

Closes #58
