### PR TITLE
feat: opt-in vault write-back, persist memories as markdown (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack record-usage "path1" "path2"` | Record note usage for hotness scoring |
 | `neurostack decay` | Report note excitability and dormancy |
 | `neurostack prediction-errors` | Show notes flagged as poor retrieval fit |
+| `neurostack migrate write-back` | Export qualifying memories to markdown files (issue #20). `--dry-run` to preview |
+| `neurostack sync` | Reconcile write-back files against the DB (DB wins on conflict) |
 
 ### Setup & Diagnostics
 | Command | Description |
@@ -178,6 +180,18 @@ File: `~/.config/neurostack/config.toml`
 | `api_host` | `127.0.0.1` | `NEUROSTACK_API_HOST` |
 | `api_port` | `8000` | `NEUROSTACK_API_PORT` |
 | `api_key` | (none) | `NEUROSTACK_API_KEY` |
+
+### Memory write-back (issue #20, opt-in)
+
+Persist qualifying memories as markdown files under a quarantined dir. Configured under a `[writeback]` table:
+
+| Key | Default | Env Override |
+|-----|---------|-------------|
+| `writeback.enabled` | `false` | `NEUROSTACK_WRITEBACK_ENABLED` |
+| `writeback.path` | `.neurostack` | `NEUROSTACK_WRITEBACK_PATH` |
+| `writeback.include_observations` | `false` | `NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS` |
+
+Writes only inside `{vault_root}/<path>/memories/<type>/<YYYY-MM>/<uuid>.md`. Only persistent (no-TTL) `decision`/`convention`/`learning`/`bug` are written by default; `observation`/`context` need `include_observations`. The DB stays source of truth; `vault_writer.py` owns all file IO (it deliberately does **not** reuse `vault_write_file`, which commits to git). The dir self-ignores via its own `.gitignore`; NeuroStack never commits.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,23 @@ The index updates as you write. Stale detection runs continuously. You don't mai
 
 NeuroStack reads your vault. By default, it writes nothing back — all index data lives in its own SQLite databases. The opt-in MCP write tools (`vault_write_file` / `vault_delete_file`) are the one exception: they create or edit `.md` files in the vault and commit + push the change to your git remote on the spot.
 
+### Memory write-back (opt-in)
+
+Memories live in SQLite by default, so they're invisible in Obsidian and vanish if the database is lost. Turn on write-back to persist qualifying memories as markdown files you own:
+
+```toml
+[writeback]
+enabled = true                 # opt-in; default false
+path = ".neurostack"           # quarantine dir, relative to vault_root
+include_observations = false   # also write the noisier observation/context types
+```
+
+- Files land under `{vault_root}/.neurostack/memories/<type>/<YYYY-MM>/<uuid>.md`. NeuroStack only ever writes inside that one directory — your notes are never touched.
+- Only persistent (no-TTL) `decision` / `convention` / `learning` / `bug` memories are written; ephemeral (TTL) memories never are.
+- The database stays the source of truth; files are readable exports. `vault_remember` / `vault_update_memory` / `vault_forget` / `vault_merge` keep the files in step automatically.
+- The directory self-ignores via its own `.gitignore` so memories stay out of git until you opt in (delete that file to version them). NeuroStack never commits on your behalf.
+- `neurostack migrate write-back [--dry-run]` exports existing memories; `neurostack sync` reconciles files against the DB (the DB wins on conflict).
+
 ---
 
 <details>
@@ -408,7 +425,7 @@ Full citations: [docs/neuroscience-appendix.md](docs/neuroscience-appendix.md)
 
 ## FAQ
 
-**Does it modify my vault files?** Not by default. Indexing, search, summaries, and every read tool leave your files untouched — all index data lives in NeuroStack's own SQLite databases. Four opt-in MCP write tools (`vault_write_file`, `vault_delete_file`, plus `vault_read_file` / `vault_list_files`) let an AI client author and edit notes; every write commits and pushes to your git remote, so changes are tracked and revertable. If your vault is not a git repo, the file is still written to disk but the commit step is skipped.
+**Does it modify my vault files?** Not by default. Indexing, search, summaries, and every read tool leave your files untouched — all index data lives in NeuroStack's own SQLite databases. Four opt-in MCP write tools (`vault_write_file`, `vault_delete_file`, plus `vault_read_file` / `vault_list_files`) let an AI client author and edit notes; every write commits and pushes to your git remote, so changes are tracked and revertable. If your vault is not a git repo, the file is still written to disk but the commit step is skipped. Separately, opt-in [memory write-back](#memory-write-back-opt-in) persists memories as markdown, but only ever inside the quarantined `.neurostack/` directory — never alongside your own notes.
 
 **Do I need a GPU?** No. Lite mode has zero ML dependencies. Full mode runs on CPU but summarization is slow without a GPU.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neurostack",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Build, maintain, and search your knowledge vault with AI",
   "bin": {
     "neurostack": "bin/neurostack.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurostack"
-version = "0.16.0"
+version = "0.17.0"
 description = "Build, maintain, and search your knowledge vault. CLI + MCP server with stale note detection, semantic search, and neuroscience-grounded memory."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/neurostack/__init__.py
+++ b/src/neurostack/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2024-2026 Raphael Southall
 """NeuroStack — AI-provider-agnostic, neuroscience-grounded knowledge management."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -45,6 +45,7 @@ from .setup import (
     cmd_update,
 )
 from .utils import _handle_error
+from .writeback import cmd_migrate, cmd_sync
 
 
 def main():
@@ -642,6 +643,26 @@ def main():
     # watch
     p = sub.add_parser("watch", help="Watch vault for changes")
     p.set_defaults(func=cmd_watch)
+
+    # migrate (issue #20: vault write-back)
+    p = sub.add_parser("migrate", help="One-off data migrations")
+    migrate_sub = p.add_subparsers(dest="migrate_command")
+    mwb = migrate_sub.add_parser(
+        "write-back",
+        help="Export all qualifying memories to markdown files",
+    )
+    mwb.add_argument(
+        "--dry-run", "-n", action="store_true",
+        help="Preview what would be written without writing",
+    )
+    p.set_defaults(func=cmd_migrate)
+
+    # sync (issue #20: reconcile write-back files against the DB)
+    p = sub.add_parser(
+        "sync",
+        help="Reconcile write-back files against the database (DB wins on conflict)",
+    )
+    p.set_defaults(func=cmd_sync)
 
     args = parser.parse_args()
     if not args.command:

--- a/src/neurostack/cli/writeback.py
+++ b/src/neurostack/cli/writeback.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""CLI commands for vault write-back (issue #20): migrate + sync."""
+
+import json as _json
+import os
+import sys
+from pathlib import Path
+
+
+def _get_writer_or_exit():
+    from ..vault_writer import get_vault_writer
+
+    writer = get_vault_writer()
+    if writer is None:
+        print(
+            "Write-back is disabled. Enable it first:\n"
+            "  set [writeback] enabled = true in ~/.config/neurostack/config.toml\n"
+            "  (or export NEUROSTACK_WRITEBACK_ENABLED=1)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return writer
+
+
+def _conn():
+    from ..schema import DB_PATH, get_db
+
+    db_path = Path(os.environ.get("NEUROSTACK_DB_PATH", DB_PATH))
+    return get_db(db_path)
+
+
+def cmd_migrate(args):
+    """Dispatch `neurostack migrate <sub>`. Only `write-back` exists for now."""
+    sub = getattr(args, "migrate_command", None)
+    if sub != "write-back":
+        print("usage: neurostack migrate write-back [--dry-run]", file=sys.stderr)
+        sys.exit(1)
+    _cmd_migrate_writeback(args)
+
+
+def _cmd_migrate_writeback(args):
+    from ..vault_writer import migrate_writeback
+
+    writer = _get_writer_or_exit()
+    conn = _conn()
+    dry = getattr(args, "dry_run", False)
+    report = migrate_writeback(conn, writer, dry_run=dry)
+
+    if getattr(args, "json", False):
+        print(_json.dumps(report, indent=2))
+        return
+
+    written = report["written"]
+    skipped = report["skipped"]
+    label = "Would write" if dry else "Wrote"
+    print(f"{label} {len(written)} memory file(s) under {writer.writeback_path}/memories/")
+
+    by_type: dict[str, int] = {}
+    for w in written:
+        by_type[w["entity_type"]] = by_type.get(w["entity_type"], 0) + 1
+    for t, n in sorted(by_type.items()):
+        print(f"  {t}: {n}")
+
+    msg = (
+        f"Skipped {skipped['ttl']} ephemeral (TTL), "
+        f"{skipped['type']} non-qualifying type"
+    )
+    if skipped["no_uuid"]:
+        msg += f", {skipped['no_uuid']} without uuid"
+    print(msg + ".")
+
+    if dry:
+        print("\nDry run — no files written. Re-run without --dry-run to apply.")
+    else:
+        print(
+            f"\nMemories written to {writer.writeback_path}/. A .gitignore inside it "
+            "keeps them\nout of git by default; delete that file to version them. "
+            "NeuroStack never commits."
+        )
+
+
+def cmd_sync(args):
+    from ..vault_writer import sync_writeback
+
+    writer = _get_writer_or_exit()
+    conn = _conn()
+    report = sync_writeback(conn, writer)
+
+    if getattr(args, "json", False):
+        print(_json.dumps(report, indent=2))
+        return
+
+    print("Sync complete (DB wins on conflict):")
+    print(f"  created:   {len(report['created'])}")
+    print(f"  updated:   {len(report['updated'])}")
+    print(f"  in sync:   {report['in_sync']}")
+    print(f"  removed:   {len(report['removed'])} orphan file(s)")
+    if report["conflicts"]:
+        print(
+            f"  conflicts: {len(report['conflicts'])} user-edited file(s) "
+            "overwritten from DB:"
+        )
+        for c in report["conflicts"]:
+            print(f"    - {c}")

--- a/src/neurostack/cli/writeback.py
+++ b/src/neurostack/cli/writeback.py
@@ -70,6 +70,11 @@ def _cmd_migrate_writeback(args):
         msg += f", {skipped['no_uuid']} without uuid"
     print(msg + ".")
 
+    if report.get("errors"):
+        print(f"\n{len(report['errors'])} memory file(s) failed to write:")
+        for e in report["errors"]:
+            print(f"  - memory {e['memory_id']}: {e['error']}")
+
     if dry:
         print("\nDry run — no files written. Re-run without --dry-run to apply.")
     else:
@@ -96,6 +101,10 @@ def cmd_sync(args):
     print(f"  updated:   {len(report['updated'])}")
     print(f"  in sync:   {report['in_sync']}")
     print(f"  removed:   {len(report['removed'])} orphan file(s)")
+    if report.get("errors"):
+        print(f"  errors:    {len(report['errors'])} memory(ies) failed:")
+        for e in report["errors"]:
+            print(f"    - memory {e['memory_id']}: {e['error']}")
     if report["conflicts"]:
         print(
             f"  conflicts: {len(report['conflicts'])} user-edited file(s) "

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -63,6 +63,15 @@ class Config:
     # text attached. This is the weight given to the (normalized) summary score in
     # the blended note ranking; the triple score gets (1 - auto_summary_weight).
     auto_summary_weight: float = 0.5      # 0.0 = triples only, 1.0 = summaries only
+    # Vault write-back (issue #20): opt-in persistence of qualifying memories as
+    # markdown files under a quarantined directory (default ``.neurostack/``).
+    # Off by default — the DB stays the source of truth; files are exports. Only
+    # persistent (no-TTL) decision/convention/learning/bug memories are written;
+    # observation/context are written only when include_observations is set.
+    writeback_enabled: bool = False
+    writeback_path: str = ".neurostack"   # relative to vault_root; NeuroStack only
+                                          # ever writes inside this directory
+    writeback_include_observations: bool = False
 
     @property
     def db_path(self) -> Path:
@@ -104,6 +113,16 @@ def load_config() -> Config:
         if "auto_summary_weight" in data:
             cfg.auto_summary_weight = float(data["auto_summary_weight"])
 
+        # Write-back is configured under a [writeback] table.
+        wb = data.get("writeback")
+        if isinstance(wb, dict):
+            if "enabled" in wb:
+                cfg.writeback_enabled = bool(wb["enabled"])
+            if "path" in wb:
+                cfg.writeback_path = str(wb["path"])
+            if "include_observations" in wb:
+                cfg.writeback_include_observations = bool(wb["include_observations"])
+
     # Env var overrides (NEUROSTACK_ prefix)
     env_map = {
         "NEUROSTACK_MODE": ("mode", str),
@@ -124,6 +143,11 @@ def load_config() -> Config:
         "NEUROSTACK_LINK_SECTION_PENALTY": ("link_section_penalty", float),
         "NEUROSTACK_LINK_DENSITY_THRESHOLD": ("link_density_threshold", float),
         "NEUROSTACK_AUTO_SUMMARY_WEIGHT": ("auto_summary_weight", float),
+        "NEUROSTACK_WRITEBACK_ENABLED": ("writeback_enabled", bool),
+        "NEUROSTACK_WRITEBACK_PATH": ("writeback_path", str),
+        "NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS": (
+            "writeback_include_observations", bool,
+        ),
     }
 
     for env_key, (attr, typ) in env_map.items():

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -226,7 +226,7 @@ def save_memory(
         except Exception as exc:
             log.debug("Dedup check failed (non-fatal): %s", exc)
 
-    return Memory(
+    memory = Memory(
         memory_id=memory_id,
         content=content,
         tags=tags or [],
@@ -243,14 +243,28 @@ def save_memory(
         ),
     )
 
+    # Vault write-back (issue #20): persist as a markdown file when enabled.
+    # No-op (and zero IO) when write-back is off — the default.
+    from .vault_writer import apply_writeback_create
+    apply_writeback_create(conn, memory)
+
+    return memory
+
 
 def forget_memory(conn: sqlite3.Connection, memory_id: int) -> bool:
     """Delete a specific memory. Returns True if deleted."""
+    row = conn.execute(
+        "SELECT file_path FROM memories WHERE memory_id = ?", (memory_id,)
+    ).fetchone()
     cursor = conn.execute(
         "DELETE FROM memories WHERE memory_id = ?", (memory_id,)
     )
     conn.commit()
-    return cursor.rowcount > 0
+    deleted = cursor.rowcount > 0
+    if deleted and row is not None:
+        from .vault_writer import apply_writeback_delete
+        apply_writeback_delete(row["file_path"])
+    return deleted
 
 
 def update_memory(
@@ -375,7 +389,15 @@ def update_memory(
     updated_row = conn.execute(
         "SELECT * FROM memories WHERE memory_id = ?", (memory_id,)
     ).fetchone()
-    return _row_to_memory(updated_row)
+    updated = _row_to_memory(updated_row)
+
+    # Vault write-back (issue #20): rewrite/move/remove the file as needed. The
+    # pre-update file_path is captured from `row` so a type or TTL change can
+    # relocate or drop the stale file.
+    from .vault_writer import apply_writeback_update
+    apply_writeback_update(conn, updated, row.get("file_path"))
+
+    return updated
 
 
 def find_similar_memories(
@@ -576,7 +598,14 @@ def merge_memories(
     updated = conn.execute(
         "SELECT * FROM memories WHERE memory_id = ?", (target_id,)
     ).fetchone()
-    return _row_to_memory(updated)
+    merged = _row_to_memory(updated)
+
+    # Vault write-back (issue #20): drop the source's file, reconcile target's.
+    from .vault_writer import apply_writeback_delete, apply_writeback_update
+    apply_writeback_delete(source.get("file_path"))
+    apply_writeback_update(conn, merged, target.get("file_path"))
+
+    return merged
 
 
 def search_memories(

--- a/src/neurostack/vault_writer.py
+++ b/src/neurostack/vault_writer.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Vault write-back: persist qualifying memories as markdown files (issue #20).
+
+The DB stays the source of truth; these files are readable exports living in a
+single quarantined directory (default ``.neurostack/``) under ``vault_root``.
+NeuroStack NEVER writes outside that directory and NEVER commits — the quarantine
+dir self-ignores via its own ``.gitignore`` so memories don't enter a git-backed
+vault unless the user opts in.
+
+Layout: ``{vault_root}/{writeback_path}/memories/<entity_type>/<YYYY-MM>/<uuid>.md``
+
+Filenames are the memory UUID (stable across content edits and DB rebuilds, so
+Obsidian wiki-links don't break). Conflict detection uses a SHA256 of the file
+body stored in frontmatter as ``neurostack_hash`` — not mtime, which is unreliable
+across git checkout / rsync / cloud sync.
+
+This module is the only writer for the quarantine dir; it deliberately does NOT
+reuse ``tools.file_tools`` (which commits + pushes to origin and demands note
+frontmatter).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import uuid as _uuid
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger("neurostack")
+
+# Persistent types always written when write-back is enabled.
+PERSISTENT_TYPES = frozenset({"decision", "convention", "learning", "bug"})
+# Noisier types written only when include_observations is set.
+OPTIN_TYPES = frozenset({"observation", "context"})
+
+_FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n?", re.DOTALL)
+
+_GITIGNORE_BODY = (
+    "# NeuroStack memory write-back (issue #20).\n"
+    "# This directory is git-ignored by default so exported memories don't enter\n"
+    "# your repository unless you choose to version them. To track them, delete\n"
+    "# this file or replace '*' with specific exceptions. NeuroStack never commits.\n"
+    "*\n"
+)
+
+
+class WriteBackError(Exception):
+    """Raised on an unrecoverable write-back configuration/path error."""
+
+
+def _body_hash(content: str) -> str:
+    """SHA256 of the normalized memory body. Whitespace-stripped for stability."""
+    digest = hashlib.sha256((content or "").strip().encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _year_month(created_at: str | None) -> str:
+    """Extract YYYY-MM from a DB timestamp like '2026-06-13 12:00:00'."""
+    if created_at and len(created_at) >= 7 and created_at[4] == "-":
+        return created_at[:7]
+    # Fallback bucket — only reached for malformed/missing timestamps.
+    return "unknown"
+
+
+class VaultWriter:
+    """Writes qualifying memories to markdown files under the quarantine dir."""
+
+    def __init__(
+        self,
+        vault_root: Path,
+        writeback_path: str = ".neurostack",
+        include_observations: bool = False,
+    ):
+        self.vault_root = Path(vault_root).resolve()
+        # Guard against a dangerously shallow root (e.g. "/" or "/home"): a
+        # misconfigured vault_root must never let write-back loose near the
+        # filesystem root.
+        if len(self.vault_root.parts) < 3:
+            raise WriteBackError(
+                f"vault_root is too shallow for safe write-back: {self.vault_root}"
+            )
+        rel = writeback_path.strip("/")
+        if not rel or ".." in Path(rel).parts:
+            raise WriteBackError(f"invalid writeback path: {writeback_path!r}")
+        self.writeback_path = rel
+        self.include_observations = include_observations
+        self.writeback_dir = (self.vault_root / rel).resolve()
+        self.memories_dir = self.writeback_dir / "memories"
+
+    # --------------------------- policy --------------------------------------
+
+    def should_write(self, memory) -> bool:
+        """Whether this memory qualifies for a file under the current policy."""
+        if getattr(memory, "expires_at", None):
+            return False  # ephemeral / TTL memories are never written
+        if not getattr(memory, "uuid", None):
+            return False  # no stable filename without a UUID
+        et = memory.entity_type
+        if et in PERSISTENT_TYPES:
+            return True
+        if et in OPTIN_TYPES:
+            return self.include_observations
+        return False
+
+    # --------------------------- paths ---------------------------------------
+
+    def relpath(self, memory) -> str:
+        """Vault-relative POSIX path for this memory's file. Validates the UUID."""
+        # Normalize + validate the UUID so it can never inject path segments.
+        canonical = str(_uuid.UUID(str(memory.uuid)))
+        et = memory.entity_type
+        if et not in PERSISTENT_TYPES and et not in OPTIN_TYPES:
+            raise WriteBackError(f"unsupported entity_type for write-back: {et!r}")
+        ym = _year_month(memory.created_at)
+        return f"{self.writeback_path}/memories/{et}/{ym}/{canonical}.md"
+
+    def _abs(self, relpath: str) -> Path:
+        """Resolve a vault-relative path and assert it stays inside the dir."""
+        abs_path = (self.vault_root / relpath).resolve()
+        try:
+            abs_path.relative_to(self.writeback_dir)
+        except ValueError as exc:
+            raise WriteBackError(
+                f"path escapes write-back directory: {relpath!r}"
+            ) from exc
+        return abs_path
+
+    def to_relpath(self, abs_path: Path) -> str:
+        return Path(abs_path).resolve().relative_to(self.vault_root).as_posix()
+
+    # --------------------------- serialization -------------------------------
+
+    def render(self, memory) -> str:
+        """Render a memory to its full file text (frontmatter + body)."""
+        body = (memory.content or "").strip()
+        title = self._title(memory)
+        front = {
+            "title": title,
+            "neurostack_id": str(memory.uuid),
+            "memory_id": memory.memory_id,
+            "entity_type": memory.entity_type,
+            "tags": list(memory.tags or []),
+            "workspace": memory.workspace,
+            "source_agent": memory.source_agent,
+            "created_at": memory.created_at,
+            "updated_at": memory.updated_at,
+            "revision_count": memory.revision_count,
+            "neurostack_hash": _body_hash(body),
+        }
+        fm = yaml.safe_dump(
+            front, sort_keys=False, allow_unicode=True, default_flow_style=False,
+        )
+        return f"---\n{fm}---\n\n{body}\n"
+
+    @staticmethod
+    def _title(memory) -> str:
+        """Human-readable title: first non-empty line of content, truncated."""
+        for line in (memory.content or "").splitlines():
+            line = line.strip().lstrip("#").strip()
+            if line:
+                return line[:80]
+        return f"{memory.entity_type} {memory.memory_id}"
+
+    def parse_file(self, abs_path: Path) -> dict:
+        """Return {'frontmatter': dict|None, 'body': str} for an existing file."""
+        text = Path(abs_path).read_text(encoding="utf-8")
+        m = _FRONTMATTER_RE.match(text)
+        if not m:
+            return {"frontmatter": None, "body": text.strip()}
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError:
+            fm = None
+        body = text[m.end():].strip()
+        return {"frontmatter": fm if isinstance(fm, dict) else None, "body": body}
+
+    # --------------------------- write / delete ------------------------------
+
+    def write(self, memory) -> str:
+        """Write (or overwrite) the memory's file atomically. Returns vault-rel path."""
+        relpath = self.relpath(memory)
+        abs_path = self._abs(relpath)
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ensure_gitignore()
+        text = self.render(memory).encode("utf-8")
+        tmp = abs_path.with_name(abs_path.name + ".tmp")
+        tmp.write_bytes(text)
+        os.replace(tmp, abs_path)  # atomic on POSIX
+        return relpath
+
+    def delete(self, relpath: str) -> bool:
+        """Delete the file at a vault-relative path. Prunes emptied dirs. Idempotent."""
+        if not relpath:
+            return False
+        abs_path = self._abs(relpath)
+        if not abs_path.exists():
+            return False
+        abs_path.unlink()
+        # Prune now-empty type/month directories up to (not including) memories_dir.
+        parent = abs_path.parent
+        while parent != self.memories_dir and parent.is_relative_to(self.memories_dir):
+            try:
+                next(parent.iterdir())
+                break  # not empty
+            except StopIteration:
+                parent.rmdir()
+                parent = parent.parent
+        return True
+
+    def iter_existing_files(self):
+        """Yield absolute paths of every memory file currently on disk."""
+        if not self.memories_dir.is_dir():
+            return
+        for fp in sorted(self.memories_dir.rglob("*.md")):
+            if fp.is_file():
+                yield fp
+
+    def ensure_gitignore(self) -> None:
+        """Drop a self-ignoring .gitignore inside the quarantine dir (idempotent).
+
+        This keeps the quarantine dir out of git by default without ever touching
+        the user's repo-level .gitignore — write-back stays inside its own folder.
+        """
+        self.writeback_dir.mkdir(parents=True, exist_ok=True)
+        gi = self.writeback_dir / ".gitignore"
+        if not gi.exists():
+            gi.write_text(_GITIGNORE_BODY, encoding="utf-8")
+
+
+# --------------------------- factory + CRUD hooks ----------------------------
+
+
+def get_vault_writer() -> VaultWriter | None:
+    """Return a configured VaultWriter, or None when write-back is disabled.
+
+    Built fresh from the current config each call (cheap) so it always reflects
+    the live config singleton — important for tests that reset it.
+    """
+    from .config import get_config
+
+    cfg = get_config()
+    if not cfg.writeback_enabled:
+        return None
+    try:
+        return VaultWriter(
+            vault_root=cfg.vault_root,
+            writeback_path=cfg.writeback_path,
+            include_observations=cfg.writeback_include_observations,
+        )
+    except WriteBackError as exc:
+        log.warning("write-back disabled: %s", exc)
+        return None
+
+
+def apply_writeback_create(conn, memory) -> None:
+    """After an INSERT: write the file and record its path. Best-effort."""
+    writer = get_vault_writer()
+    if writer is None:
+        return
+    try:
+        if not writer.should_write(memory):
+            return
+        relpath = writer.write(memory)
+        conn.execute(
+            "UPDATE memories SET file_path = ? WHERE memory_id = ?",
+            (relpath, memory.memory_id),
+        )
+        conn.commit()
+        memory.file_path = relpath
+    except Exception as exc:  # never let file IO break the DB write
+        log.warning("write-back (create) failed for memory %s: %s",
+                    getattr(memory, "memory_id", "?"), exc)
+
+
+def apply_writeback_update(conn, memory, old_file_path: str | None) -> None:
+    """After an UPDATE/merge: reconcile the file (rewrite, move, or remove)."""
+    writer = get_vault_writer()
+    if writer is None:
+        return
+    try:
+        if writer.should_write(memory):
+            new_relpath = writer.write(memory)
+            # Type or month change relocates the file — drop the stale one.
+            if old_file_path and old_file_path != new_relpath:
+                writer.delete(old_file_path)
+            if memory.file_path != new_relpath:
+                conn.execute(
+                    "UPDATE memories SET file_path = ? WHERE memory_id = ?",
+                    (new_relpath, memory.memory_id),
+                )
+                conn.commit()
+                memory.file_path = new_relpath
+        else:
+            # No longer qualifies (TTL added, or type demoted without opt-in).
+            if old_file_path:
+                writer.delete(old_file_path)
+            if memory.file_path is not None:
+                conn.execute(
+                    "UPDATE memories SET file_path = NULL WHERE memory_id = ?",
+                    (memory.memory_id,),
+                )
+                conn.commit()
+                memory.file_path = None
+    except Exception as exc:
+        log.warning("write-back (update) failed for memory %s: %s",
+                    getattr(memory, "memory_id", "?"), exc)
+
+
+def apply_writeback_delete(old_file_path: str | None) -> None:
+    """After a DELETE: remove the backing file. Best-effort."""
+    if not old_file_path:
+        return
+    writer = get_vault_writer()
+    if writer is None:
+        return
+    try:
+        writer.delete(old_file_path)
+    except Exception as exc:
+        log.warning("write-back (delete) failed for %s: %s", old_file_path, exc)
+
+
+# --------------------------- migrate / sync ----------------------------------
+
+
+def migrate_writeback(conn, writer: VaultWriter, dry_run: bool = False) -> dict:
+    """Write files for all qualifying existing memories.
+
+    Returns a report dict. With dry_run=True nothing is written; the report
+    lists the paths that would be created and whether each already exists.
+    """
+    from .memories import _row_to_memory
+
+    rows = conn.execute("SELECT * FROM memories ORDER BY memory_id").fetchall()
+    written: list[dict] = []
+    skipped = {"ttl": 0, "type": 0, "no_uuid": 0}
+    for row in rows:
+        mem = _row_to_memory(row)
+        if not writer.should_write(mem):
+            if getattr(mem, "expires_at", None):
+                skipped["ttl"] += 1
+            elif not mem.uuid:
+                skipped["no_uuid"] += 1
+            else:
+                skipped["type"] += 1
+            continue
+        relpath = writer.relpath(mem)
+        if dry_run:
+            written.append({
+                "memory_id": mem.memory_id,
+                "entity_type": mem.entity_type,
+                "path": relpath,
+                "exists": (writer.vault_root / relpath).exists(),
+            })
+            continue
+        relpath = writer.write(mem)
+        conn.execute(
+            "UPDATE memories SET file_path = ? WHERE memory_id = ?",
+            (relpath, mem.memory_id),
+        )
+        written.append({
+            "memory_id": mem.memory_id,
+            "entity_type": mem.entity_type,
+            "path": relpath,
+        })
+    if not dry_run:
+        conn.commit()
+        writer.ensure_gitignore()
+    return {"written": written, "skipped": skipped, "dry_run": dry_run}
+
+
+def sync_writeback(conn, writer: VaultWriter) -> dict:
+    """Reconcile files against the DB. The DB always wins on conflict.
+
+    - Missing file for a qualifying memory  -> created
+    - File body differs from DB content     -> overwritten from DB
+      (reported as a 'conflict' when the file was user-edited since last write)
+    - File with no qualifying DB memory      -> removed (orphan)
+    """
+    from .memories import _row_to_memory
+
+    def _set_path(memory_id: int, relpath: str) -> None:
+        conn.execute(
+            "UPDATE memories SET file_path = ? WHERE memory_id = ?",
+            (relpath, memory_id),
+        )
+
+    rows = conn.execute("SELECT * FROM memories ORDER BY memory_id").fetchall()
+    desired: dict[str, object] = {}
+    created: list[str] = []
+    updated: list[str] = []
+    conflicts: list[str] = []
+    removed: list[str] = []
+    in_sync = 0
+
+    for row in rows:
+        mem = _row_to_memory(row)
+        if not writer.should_write(mem):
+            continue
+        relpath = writer.relpath(mem)
+        desired[relpath] = mem
+        abs_path = writer.vault_root / relpath
+
+        if not abs_path.exists():
+            writer.write(mem)
+            _set_path(mem.memory_id, relpath)
+            created.append(relpath)
+            continue
+
+        parsed = writer.parse_file(abs_path)
+        stored_hash = (parsed["frontmatter"] or {}).get("neurostack_hash")
+        file_body_hash = _body_hash(parsed["body"])
+        db_hash = _body_hash(mem.content)
+
+        if db_hash == file_body_hash:
+            if mem.file_path != relpath:
+                _set_path(mem.memory_id, relpath)
+            in_sync += 1
+            continue
+
+        # Divergence — DB wins, overwrite the file.
+        writer.write(mem)
+        _set_path(mem.memory_id, relpath)
+        if stored_hash and stored_hash != file_body_hash:
+            conflicts.append(relpath)  # user had edited the file on disk
+        else:
+            updated.append(relpath)
+
+    # Orphans: files on disk with no qualifying memory backing them.
+    for abs_path in writer.iter_existing_files():
+        relpath = writer.to_relpath(abs_path)
+        if relpath not in desired:
+            writer.delete(relpath)
+            removed.append(relpath)
+
+    conn.commit()
+    writer.ensure_gitignore()
+    return {
+        "created": created,
+        "updated": updated,
+        "conflicts": conflicts,
+        "removed": removed,
+        "in_sync": in_sync,
+    }

--- a/src/neurostack/vault_writer.py
+++ b/src/neurostack/vault_writer.py
@@ -337,40 +337,48 @@ def migrate_writeback(conn, writer: VaultWriter, dry_run: bool = False) -> dict:
 
     rows = conn.execute("SELECT * FROM memories ORDER BY memory_id").fetchall()
     written: list[dict] = []
+    errors: list[dict] = []
     skipped = {"ttl": 0, "type": 0, "no_uuid": 0}
     for row in rows:
-        mem = _row_to_memory(row)
-        if not writer.should_write(mem):
-            if getattr(mem, "expires_at", None):
-                skipped["ttl"] += 1
-            elif not mem.uuid:
-                skipped["no_uuid"] += 1
-            else:
-                skipped["type"] += 1
-            continue
-        relpath = writer.relpath(mem)
-        if dry_run:
+        # Isolate each row: one malformed memory must not abort the batch.
+        try:
+            mem = _row_to_memory(row)
+            if not writer.should_write(mem):
+                if getattr(mem, "expires_at", None):
+                    skipped["ttl"] += 1
+                elif not mem.uuid:
+                    skipped["no_uuid"] += 1
+                else:
+                    skipped["type"] += 1
+                continue
+            relpath = writer.relpath(mem)
+            if dry_run:
+                written.append({
+                    "memory_id": mem.memory_id,
+                    "entity_type": mem.entity_type,
+                    "path": relpath,
+                    "exists": (writer.vault_root / relpath).exists(),
+                })
+                continue
+            relpath = writer.write(mem)
+            conn.execute(
+                "UPDATE memories SET file_path = ? WHERE memory_id = ?",
+                (relpath, mem.memory_id),
+            )
             written.append({
                 "memory_id": mem.memory_id,
                 "entity_type": mem.entity_type,
                 "path": relpath,
-                "exists": (writer.vault_root / relpath).exists(),
             })
-            continue
-        relpath = writer.write(mem)
-        conn.execute(
-            "UPDATE memories SET file_path = ? WHERE memory_id = ?",
-            (relpath, mem.memory_id),
-        )
-        written.append({
-            "memory_id": mem.memory_id,
-            "entity_type": mem.entity_type,
-            "path": relpath,
-        })
+        except Exception as exc:
+            errors.append({"memory_id": row["memory_id"], "error": str(exc)})
+            log.warning("write-back migrate failed for memory %s: %s",
+                        row["memory_id"], exc)
     if not dry_run:
         conn.commit()
         writer.ensure_gitignore()
-    return {"written": written, "skipped": skipped, "dry_run": dry_run}
+    return {"written": written, "skipped": skipped, "errors": errors,
+            "dry_run": dry_run}
 
 
 def sync_writeback(conn, writer: VaultWriter) -> dict:
@@ -395,40 +403,46 @@ def sync_writeback(conn, writer: VaultWriter) -> dict:
     updated: list[str] = []
     conflicts: list[str] = []
     removed: list[str] = []
+    errors: list[dict] = []
     in_sync = 0
 
     for row in rows:
-        mem = _row_to_memory(row)
-        if not writer.should_write(mem):
-            continue
-        relpath = writer.relpath(mem)
-        desired[relpath] = mem
-        abs_path = writer.vault_root / relpath
+        try:
+            mem = _row_to_memory(row)
+            if not writer.should_write(mem):
+                continue
+            relpath = writer.relpath(mem)
+            desired[relpath] = mem
+            abs_path = writer.vault_root / relpath
 
-        if not abs_path.exists():
+            if not abs_path.exists():
+                writer.write(mem)
+                _set_path(mem.memory_id, relpath)
+                created.append(relpath)
+                continue
+
+            parsed = writer.parse_file(abs_path)
+            stored_hash = (parsed["frontmatter"] or {}).get("neurostack_hash")
+            file_body_hash = _body_hash(parsed["body"])
+            db_hash = _body_hash(mem.content)
+
+            if db_hash == file_body_hash:
+                if mem.file_path != relpath:
+                    _set_path(mem.memory_id, relpath)
+                in_sync += 1
+                continue
+
+            # Divergence — DB wins, overwrite the file.
             writer.write(mem)
             _set_path(mem.memory_id, relpath)
-            created.append(relpath)
-            continue
-
-        parsed = writer.parse_file(abs_path)
-        stored_hash = (parsed["frontmatter"] or {}).get("neurostack_hash")
-        file_body_hash = _body_hash(parsed["body"])
-        db_hash = _body_hash(mem.content)
-
-        if db_hash == file_body_hash:
-            if mem.file_path != relpath:
-                _set_path(mem.memory_id, relpath)
-            in_sync += 1
-            continue
-
-        # Divergence — DB wins, overwrite the file.
-        writer.write(mem)
-        _set_path(mem.memory_id, relpath)
-        if stored_hash and stored_hash != file_body_hash:
-            conflicts.append(relpath)  # user had edited the file on disk
-        else:
-            updated.append(relpath)
+            if stored_hash and stored_hash != file_body_hash:
+                conflicts.append(relpath)  # user had edited the file on disk
+            else:
+                updated.append(relpath)
+        except Exception as exc:
+            errors.append({"memory_id": row["memory_id"], "error": str(exc)})
+            log.warning("write-back sync failed for memory %s: %s",
+                        row["memory_id"], exc)
 
     # Orphans: files on disk with no qualifying memory backing them.
     for abs_path in writer.iter_existing_files():
@@ -444,5 +458,6 @@ def sync_writeback(conn, writer: VaultWriter) -> dict:
         "updated": updated,
         "conflicts": conflicts,
         "removed": removed,
+        "errors": errors,
         "in_sync": in_sync,
     }

--- a/src/neurostack/watcher.py
+++ b/src/neurostack/watcher.py
@@ -46,6 +46,19 @@ def _vault_root():
     return get_config().vault_root
 
 
+def _base_skip_parts() -> set[str]:
+    """Path segments excluded from indexing.
+
+    Includes the write-back quarantine dir (issue #20): its memory exports are
+    derived data, and indexing them would trigger reindex-on-write loops.
+    """
+    parts = {".git", ".obsidian", ".trash"}
+    rel = get_config().writeback_path.strip("/")
+    if rel:
+        parts.add(rel.split("/")[0])
+    return parts
+
+
 class DebouncedHandler(FileSystemEventHandler):
     """Debounces file changes and triggers indexing."""
 
@@ -72,7 +85,7 @@ class DebouncedHandler(FileSystemEventHandler):
         p = Path(path)
         if not p.suffix == ".md":
             return False
-        skip = {".git", ".obsidian", ".trash"}
+        skip = _base_skip_parts()
         skip.update(self._exclude_dirs)
         if skip.intersection(p.parts):
             return False
@@ -584,7 +597,7 @@ def reconcile_deletions(
     or unmounted ``vault_root``, not a genuinely emptied vault, and we refuse
     to wipe the whole index on that basis.
     """
-    skip_parts = {".git", ".obsidian", ".trash"}
+    skip_parts = _base_skip_parts()
     skip_parts.update(exclude_dirs or [])
     disk_paths = {
         str(f.relative_to(vault_root))
@@ -666,8 +679,8 @@ def full_index(
 
     conn = get_db(DB_PATH)
     md_files = sorted(vault_root.rglob("*.md"))
-    # Filter out .git, .obsidian, .trash, and any extra exclude dirs
-    skip_parts = {".git", ".obsidian", ".trash"}
+    # Filter out .git, .obsidian, .trash, the write-back dir, and extra excludes
+    skip_parts = _base_skip_parts()
     skip_parts.update(exclude_dirs or [])
     md_files = [
         f for f in md_files

--- a/tests/test_vault_writer.py
+++ b/tests/test_vault_writer.py
@@ -1,0 +1,390 @@
+"""Tests for neurostack.vault_writer — issue #20 vault write-back."""
+
+from __future__ import annotations
+
+import json
+import uuid as _uuid
+
+import pytest
+
+from neurostack import config as nsconfig
+from neurostack.memories import (
+    Memory,
+    forget_memory,
+    merge_memories,
+    save_memory,
+    update_memory,
+)
+from neurostack.vault_writer import (
+    VaultWriter,
+    WriteBackError,
+    _body_hash,
+    get_vault_writer,
+    migrate_writeback,
+    sync_writeback,
+)
+
+# --------------------------- fixtures ----------------------------------------
+
+
+@pytest.fixture
+def wb_vault(tmp_path, monkeypatch):
+    """A temp vault with write-back enabled via env; resets the config singleton."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("NEUROSTACK_VAULT_ROOT", str(vault))
+    monkeypatch.setenv("NEUROSTACK_WRITEBACK_ENABLED", "1")
+    monkeypatch.delenv("NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS", raising=False)
+    # Point embeddings at a dead port so save_memory fails fast and offline.
+    monkeypatch.setenv("NEUROSTACK_EMBED_URL", "http://127.0.0.1:1")
+    nsconfig._config = None
+    yield vault
+    nsconfig._config = None
+
+
+def _mem(content="Decision body", entity_type="decision", expires_at=None,
+         tags=None, memory_id=1, created_at="2026-06-13 12:00:00", uuid=None):
+    return Memory(
+        memory_id=memory_id,
+        content=content,
+        tags=tags or [],
+        entity_type=entity_type,
+        source_agent="test",
+        workspace=None,
+        created_at=created_at,
+        expires_at=expires_at,
+        uuid=uuid or str(_uuid.uuid4()),
+    )
+
+
+def _insert(conn, content, entity_type="decision", expires_at=None,
+            tags=None, workspace=None, uuid=None):
+    """Raw INSERT that bypasses the write-back hook (clean DB-only state)."""
+    uid = uuid or str(_uuid.uuid4())
+    cur = conn.execute(
+        "INSERT INTO memories (content, tags, entity_type, source_agent, "
+        "workspace, embedding, expires_at, session_id, uuid, embed_pending) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        (content, json.dumps(tags or []), entity_type, "test", workspace,
+         None, expires_at, None, uid),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+# --------------------------- policy ------------------------------------------
+
+
+def test_should_write_persistent_types(tmp_path):
+    w = VaultWriter(tmp_path / "v", include_observations=False)
+    for t in ("decision", "convention", "learning", "bug"):
+        assert w.should_write(_mem(entity_type=t)) is True
+
+
+def test_should_write_excludes_ttl(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    assert w.should_write(_mem(expires_at="2026-12-01 00:00:00")) is False
+
+
+def test_should_write_observation_gated(tmp_path):
+    off = VaultWriter(tmp_path / "v", include_observations=False)
+    on = VaultWriter(tmp_path / "v", include_observations=True)
+    for t in ("observation", "context"):
+        assert off.should_write(_mem(entity_type=t)) is False
+        assert on.should_write(_mem(entity_type=t)) is True
+
+
+def test_should_write_requires_uuid(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    m = _mem()
+    m.uuid = None
+    assert w.should_write(m) is False
+
+
+# --------------------------- paths & safety ----------------------------------
+
+
+def test_shallow_vault_root_rejected():
+    with pytest.raises(WriteBackError):
+        VaultWriter("/")
+
+
+def test_invalid_writeback_path_rejected(tmp_path):
+    with pytest.raises(WriteBackError):
+        VaultWriter(tmp_path / "v", writeback_path="../escape")
+
+
+def test_relpath_layout_and_uuid_validation(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    uid = "0123abcd-0000-0000-0000-000000000000"
+    m = _mem(entity_type="learning", created_at="2026-03-09 08:00:00", uuid=uid)
+    assert w.relpath(m) == f".neurostack/memories/learning/2026-03/{uid}.md"
+
+    m.uuid = "not-a-uuid"
+    with pytest.raises(ValueError):
+        w.relpath(m)
+
+
+# --------------------------- render / write ----------------------------------
+
+
+def test_write_produces_frontmatter_body_and_hash(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    m = _mem(content="# Heading\n\nThe decision text.", tags=["a", "b"])
+    relpath = w.write(m)
+    abs_path = w.vault_root / relpath
+    assert abs_path.is_file()
+
+    parsed = w.parse_file(abs_path)
+    fm = parsed["frontmatter"]
+    assert fm["neurostack_id"] == m.uuid
+    assert fm["entity_type"] == "decision"
+    assert fm["tags"] == ["a", "b"]
+    assert fm["title"] == "Heading"  # first non-empty line, '#' stripped
+    assert parsed["body"] == "# Heading\n\nThe decision text."
+    # Stored hash matches the body content.
+    assert fm["neurostack_hash"] == _body_hash(parsed["body"])
+
+
+def test_write_is_atomic_overwrite(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    m = _mem(content="v1")
+    w.write(m)
+    m.content = "v2 longer content"
+    w.write(m)
+    abs_path = w.vault_root / w.relpath(m)
+    assert w.parse_file(abs_path)["body"] == "v2 longer content"
+    # No stray .tmp left behind.
+    assert not list(abs_path.parent.glob("*.tmp"))
+
+
+def test_gitignore_self_ignores(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    w.write(_mem())
+    gi = w.writeback_dir / ".gitignore"
+    assert gi.is_file()
+    assert gi.read_text().strip().endswith("*")
+
+
+def test_delete_prunes_empty_dirs(tmp_path):
+    w = VaultWriter(tmp_path / "v")
+    m = _mem()
+    relpath = w.write(m)
+    assert w.delete(relpath) is True
+    assert not (w.vault_root / relpath).exists()
+    # type/month dirs pruned, but memories_dir survives.
+    assert not (w.memories_dir / "decision").exists()
+    assert w.delete(relpath) is False  # idempotent
+
+
+# --------------------------- CRUD integration --------------------------------
+
+
+def test_save_memory_writes_file(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "A real decision", entity_type="decision",
+                    dedup=False)
+    assert m.file_path is not None
+    assert (wb_vault / m.file_path).is_file()
+    # DB column populated too.
+    row = in_memory_db.execute(
+        "SELECT file_path FROM memories WHERE memory_id = ?", (m.memory_id,)
+    ).fetchone()
+    assert row["file_path"] == m.file_path
+
+
+def test_save_ttl_memory_not_written(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "ephemeral", entity_type="decision",
+                    ttl_hours=1, dedup=False)
+    assert m.file_path is None
+    assert not list((wb_vault / ".neurostack").rglob("*.md"))
+
+
+def test_save_observation_gated(tmp_path, monkeypatch, in_memory_db):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("NEUROSTACK_VAULT_ROOT", str(vault))
+    monkeypatch.setenv("NEUROSTACK_WRITEBACK_ENABLED", "1")
+    monkeypatch.setenv("NEUROSTACK_EMBED_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS", "1")
+    nsconfig._config = None
+    try:
+        m = save_memory(in_memory_db, "an observation",
+                        entity_type="observation", dedup=False)
+        assert m.file_path is not None
+        assert "/observation/" in m.file_path
+    finally:
+        nsconfig._config = None
+
+
+def test_update_moves_file_on_type_change(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "starts as learning",
+                    entity_type="learning", dedup=False)
+    old = m.file_path
+    assert "/learning/" in old
+
+    updated = update_memory(in_memory_db, m.memory_id, entity_type="decision")
+    assert updated.file_path is not None
+    assert "/decision/" in updated.file_path
+    assert not (wb_vault / old).exists()         # stale file removed
+    assert (wb_vault / updated.file_path).is_file()
+
+
+def test_update_adding_ttl_removes_file(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "permanent then ephemeral",
+                    entity_type="decision", dedup=False)
+    assert (wb_vault / m.file_path).exists()
+
+    updated = update_memory(in_memory_db, m.memory_id, ttl_hours=2)
+    assert updated.file_path is None
+    assert not list((wb_vault / ".neurostack").rglob("*.md"))
+
+
+def test_update_content_rewrites_and_bumps_hash(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "original", entity_type="bug", dedup=False)
+    w = get_vault_writer()
+    before = w.parse_file(wb_vault / m.file_path)["frontmatter"]["neurostack_hash"]
+
+    update_memory(in_memory_db, m.memory_id, content="rewritten body")
+    after_fm = w.parse_file(wb_vault / m.file_path)["frontmatter"]
+    assert after_fm["neurostack_hash"] != before
+    assert after_fm["revision_count"] == 2
+
+
+def test_forget_deletes_file(wb_vault, in_memory_db):
+    m = save_memory(in_memory_db, "to be forgotten",
+                    entity_type="decision", dedup=False)
+    path = wb_vault / m.file_path
+    assert path.exists()
+    assert forget_memory(in_memory_db, m.memory_id) is True
+    assert not path.exists()
+
+
+def test_merge_deletes_source_keeps_target(wb_vault, in_memory_db):
+    target = save_memory(in_memory_db, "short", entity_type="decision",
+                         dedup=False)
+    source = save_memory(
+        in_memory_db,
+        "a much longer and more detailed decision body that should win",
+        entity_type="decision", dedup=False,
+    )
+    src_path = wb_vault / source.file_path
+    assert src_path.exists()
+
+    merged = merge_memories(in_memory_db, target.memory_id, source.memory_id)
+    assert not src_path.exists()                  # source file gone
+    assert merged.file_path is not None
+    merged_file = wb_vault / merged.file_path
+    assert merged_file.is_file()
+    body = get_vault_writer().parse_file(merged_file)["body"]
+    assert "longer and more detailed" in body     # target absorbed source body
+
+
+def test_writeback_disabled_writes_nothing(tmp_path, monkeypatch, in_memory_db):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("NEUROSTACK_VAULT_ROOT", str(vault))
+    monkeypatch.delenv("NEUROSTACK_WRITEBACK_ENABLED", raising=False)
+    monkeypatch.setenv("NEUROSTACK_EMBED_URL", "http://127.0.0.1:1")
+    nsconfig._config = None
+    try:
+        m = save_memory(in_memory_db, "decision", entity_type="decision",
+                        dedup=False)
+        assert m.file_path is None
+        assert get_vault_writer() is None
+        assert not (vault / ".neurostack").exists()
+    finally:
+        nsconfig._config = None
+
+
+# --------------------------- migrate -----------------------------------------
+
+
+def test_migrate_dry_run_writes_nothing(wb_vault, in_memory_db):
+    _insert(in_memory_db, "d1", "decision")
+    _insert(in_memory_db, "l1", "learning")
+    _insert(in_memory_db, "ttl", "decision", expires_at="2026-12-01 00:00:00")
+    _insert(in_memory_db, "obs", "observation")
+
+    w = get_vault_writer()
+    report = migrate_writeback(in_memory_db, w, dry_run=True)
+    assert report["dry_run"] is True
+    assert len(report["written"]) == 2          # decision + learning only
+    assert report["skipped"]["ttl"] == 1
+    assert report["skipped"]["type"] == 1       # the observation
+    assert not list((wb_vault / ".neurostack").rglob("*.md"))
+
+
+def test_migrate_real_writes_qualifying_only(wb_vault, in_memory_db):
+    d = _insert(in_memory_db, "d1", "decision")
+    _insert(in_memory_db, "ttl", "bug", expires_at="2026-12-01 00:00:00")
+
+    w = get_vault_writer()
+    report = migrate_writeback(in_memory_db, w, dry_run=False)
+    assert len(report["written"]) == 1
+    files = list((wb_vault / ".neurostack").rglob("*.md"))
+    assert len(files) == 1
+    row = in_memory_db.execute(
+        "SELECT file_path FROM memories WHERE memory_id = ?", (d,)
+    ).fetchone()
+    assert row["file_path"] is not None
+
+
+# --------------------------- sync --------------------------------------------
+
+
+def test_sync_creates_missing(wb_vault, in_memory_db):
+    _insert(in_memory_db, "d1", "decision")
+    w = get_vault_writer()
+    report = sync_writeback(in_memory_db, w)
+    assert len(report["created"]) == 1
+    assert report["in_sync"] == 0
+
+
+def test_sync_conflict_db_wins(wb_vault, in_memory_db):
+    mid = _insert(in_memory_db, "the canonical body", "decision")
+    w = get_vault_writer()
+    sync_writeback(in_memory_db, w)  # create the file
+
+    relpath = in_memory_db.execute(
+        "SELECT file_path FROM memories WHERE memory_id = ?", (mid,)
+    ).fetchone()["file_path"]
+    abs_path = wb_vault / relpath
+    # Simulate a user editing the file body in Obsidian.
+    edited = abs_path.read_text().replace("the canonical body", "user edit")
+    abs_path.write_text(edited)
+
+    report = sync_writeback(in_memory_db, w)
+    assert relpath in report["conflicts"]
+    # DB content wins.
+    assert w.parse_file(abs_path)["body"] == "the canonical body"
+
+
+def test_sync_removes_orphan(wb_vault, in_memory_db):
+    w = get_vault_writer()
+    orphan = w.memories_dir / "decision" / "2026-06" / "deadbeef.md"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text("---\ntitle: x\n---\n\norphan\n")
+
+    report = sync_writeback(in_memory_db, w)
+    assert len(report["removed"]) == 1
+    assert not orphan.exists()
+
+
+def test_sync_in_sync_noop(wb_vault, in_memory_db):
+    _insert(in_memory_db, "stable", "decision")
+    w = get_vault_writer()
+    sync_writeback(in_memory_db, w)
+    report = sync_writeback(in_memory_db, w)
+    assert report["in_sync"] == 1
+    assert report["created"] == []
+    assert report["updated"] == []
+
+
+# --------------------------- watcher exclusion -------------------------------
+
+
+def test_watcher_excludes_writeback_dir(wb_vault):
+    from neurostack import watcher
+
+    parts = watcher._base_skip_parts()
+    assert ".neurostack" in parts

--- a/tests/test_vault_writer.py
+++ b/tests/test_vault_writer.py
@@ -314,6 +314,22 @@ def test_migrate_dry_run_writes_nothing(wb_vault, in_memory_db):
     assert not list((wb_vault / ".neurostack").rglob("*.md"))
 
 
+def test_migrate_isolates_bad_rows(wb_vault, in_memory_db):
+    good = _insert(in_memory_db, "good", "decision")
+    # A qualifying row with a corrupt uuid: should_write passes (uuid truthy)
+    # but relpath() rejects it — the batch must survive and report the error.
+    _insert(in_memory_db, "bad", "decision", uuid="not-a-real-uuid")
+
+    w = get_vault_writer()
+    report = migrate_writeback(in_memory_db, w, dry_run=False)
+    assert len(report["written"]) == 1
+    assert len(report["errors"]) == 1
+    row = in_memory_db.execute(
+        "SELECT file_path FROM memories WHERE memory_id = ?", (good,)
+    ).fetchone()
+    assert row["file_path"] is not None
+
+
 def test_migrate_real_writes_qualifying_only(wb_vault, in_memory_db):
     d = _insert(in_memory_db, "d1", "decision")
     _insert(in_memory_db, "ttl", "bug", expires_at="2026-12-01 00:00:00")


### PR DESCRIPTION
## Summary

Implements **issue #20**: opt-in vault write-back so agent memories survive a DB loss and become browsable/linkable in Obsidian. Off by default — **deploying this changes nothing until `[writeback] enabled = true`**.

Design per the settled 8-agent consensus (`writeback-consensus.md`) reconciled with the issue spec: quarantined `.neurostack/` dir, UUID filenames (link-stable), SHA256 body-hash conflict detection (not mtime), DB stays source of truth.

## What it does

- **`vault_writer.py`** — `VaultWriter` writes only inside `{vault_root}/.neurostack/memories/<type>/<YYYY-MM>/<uuid>.md`. Atomic write (`.tmp` + `os.replace`), realpath containment check, vault-root depth guard (rejects `/`, `/home`), UUID validation. Frontmatter carries `neurostack_hash: sha256:…` of the body for conflict detection.
- **Quarantine + git** — only ever writes under `.neurostack/`; user notes untouched. The dir self-ignores via its own `.gitignore` (never touches the user's repo `.gitignore`); NeuroStack never commits. Deliberately does **not** reuse `vault_write_file` (which commits+pushes).
- **CRUD hooks** in `memories.py` (best-effort, wrapped so file IO can't break the DB op) — cover both MCP and CLI: `remember`→write, `update`→rewrite/move/remove (handles type change relocating the file, TTL added removing it), `forget`→delete, `merge`→drop source file + reconcile target.
- **Policy** — writes persistent (no-TTL) `decision`/`convention`/`learning`/`bug`; `observation`/`context` gated behind `include_observations`; TTL memories never written.
- **Watcher** — `.neurostack/` excluded from `_should_process`, `full_index`, and `reconcile_deletions` so exports don't trigger reindex loops.
- **CLI** — `neurostack migrate write-back [--dry-run]` (backfill existing memories) and `neurostack sync` (reconcile, DB wins on conflict; reports user-edited files it overwrote).
- **Config** — `[writeback] enabled/path/include_observations` + `NEUROSTACK_WRITEBACK_*` env overrides.

## Out of scope (per the issue)

Bidirectional sync, wiki-links into user notes, auto-commit, triples/communities as files.

## Test plan

- `tests/test_vault_writer.py` — 27 cases: should-write policy, render/hash, path safety, CRUD reconciliation through `memories.py`, migrate (dry-run + real), sync (create/conflict/orphan/no-op), gitignore, watcher exclusion.
- Full suite: **524 passed**, `ruff` clean, versions consistent at 0.17.0.
- Manual CLI smoke test (add → file written, sync in-sync, migrate dry-run + JSON) verified.

Closes #20