### PR TITLE
feat: retrieval-quality benchmark + per-signal ablation harness (#63)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -18,6 +18,7 @@ from .search import (
     cmd_context,
     cmd_cooccurrence,
     cmd_decay,
+    cmd_eval,
     cmd_folder_summaries,
     cmd_graph,
     cmd_prediction_errors,
@@ -402,6 +403,39 @@ def main():
         "Also reads NEUROSTACK_WORKSPACE env var",
     )
     p.set_defaults(func=cmd_search)
+
+    # eval — retrieval-quality benchmark + per-signal ablation (issue #63)
+    p = sub.add_parser(
+        "eval",
+        help="Benchmark retrieval (recall@k / MRR / NDCG) + per-signal ablation",
+    )
+    p.add_argument(
+        "--queries", default=None,
+        help="Labelled query set (YAML). Default: tests/eval/queries.yaml",
+    )
+    p.add_argument("--top-k", type=int, default=5, help="k for recall@k / NDCG@k")
+    p.add_argument(
+        "--db", default=None,
+        help="SQLite index to evaluate. Default: the configured DB. "
+        "Use a COPY of the prod index — eval reads only, but point it at a copy.",
+    )
+    p.add_argument(
+        "--cache", default=None,
+        help="Query-embedding cache (JSON). Default: tests/eval/query_embeddings.json",
+    )
+    p.add_argument(
+        "--refresh-embeddings", action="store_true",
+        help="Fetch query embeddings from the live embedder and rewrite the cache",
+    )
+    p.add_argument(
+        "--live", action="store_true",
+        help="Embed queries live instead of from the cache (needs a reachable embedder)",
+    )
+    p.add_argument(
+        "--no-ablation", action="store_true",
+        help="Report only the full-pipeline metrics, skip the per-signal sweep",
+    )
+    p.set_defaults(func=cmd_eval)
 
     # ask
     p = sub.add_parser("ask", help="Ask a question using vault content (RAG)")

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -67,6 +67,69 @@ def cmd_search(args):
         print(f"   Snippet: {r.snippet[:200]}")
 
 
+def _default_eval_path(name: str) -> Path:
+    """Resolve a file under ``tests/eval/`` relative to the repo root.
+
+    Works from a source checkout (where ``neurostack eval`` is actually run);
+    the eval set is test data, not packaged with the pip/npm distribution.
+    """
+    # cli/search.py -> cli -> neurostack -> src -> repo root
+    return Path(__file__).resolve().parents[3] / "tests" / "eval" / name
+
+
+def cmd_eval(args):
+    """Retrieval-quality benchmark + per-signal ablation harness (issue #63)."""
+    from .. import eval as ev
+
+    queries_path = Path(args.queries) if args.queries else _default_eval_path("queries.yaml")
+    if not queries_path.exists():
+        print(f"  Query set not found: {queries_path}")
+        print("  Pass --queries <path/to/queries.yaml> or run from a source checkout.")
+        raise SystemExit(1)
+    queries = ev.load_queries(queries_path)
+
+    cache_path = Path(args.cache) if args.cache else _default_eval_path("query_embeddings.json")
+
+    # Rebuild the offline embedding cache from a live embedder, then continue.
+    if args.refresh_embeddings:
+        print(f"  Fetching {len(queries)} query embeddings from {args.embed_url} ...")
+        cache = ev.build_embedding_cache(queries, embed_url=args.embed_url)
+        ev.save_embedding_cache(cache_path, cache)
+        print(f"  Wrote {len(cache)} embeddings to {cache_path}")
+
+    # Resolve the DB under test (a copy of the prod index for a real run).
+    if args.db:
+        db_path = Path(args.db)
+    else:
+        from ..schema import DB_PATH
+        db_path = Path(DB_PATH)
+
+    # Live embedder vs cached replay. --live skips the cache (needs Ollama up).
+    cache = None
+    if not args.live:
+        cache = ev.load_embedding_cache(cache_path)
+        missing = [q.query for q in queries if q.query not in cache]
+        if missing:
+            print(f"  {len(missing)} queries have no cached embedding (e.g. {missing[0]!r}).")
+            print("  Run with --refresh-embeddings (live embedder) or pass --live.")
+            raise SystemExit(1)
+
+    rows = ev.run_eval(
+        queries,
+        db_path=db_path,
+        k=args.top_k,
+        embed_url=args.embed_url,
+        cache=cache,
+        ablation=not args.no_ablation,
+    )
+
+    if args.json:
+        print(json.dumps(ev.results_to_dict(rows, args.top_k), indent=2))
+        return
+    print(f"\n  {len(queries)} queries · db={db_path} · k={args.top_k}\n")
+    print(ev.format_table(rows, args.top_k))
+
+
 def cmd_ask(args):
     from ..ask import ask_vault
     result = ask_vault(

--- a/src/neurostack/eval.py
+++ b/src/neurostack/eval.py
@@ -127,12 +127,19 @@ def mrr(ranked: list[str], targets: list[str]) -> float:
 
 
 def ndcg_at_k(ranked: list[str], targets: list[str], k: int) -> float:
-    """Binary-relevance NDCG@k. Ideal DCG assumes as many relevant docs as
-    there are labelled targets (capped at k), each ranked first."""
+    """Binary-relevance NDCG@k. Each labelled target counts as one relevant
+    document scored at the rank where it is *first* found — so a target that
+    matches several result paths (e.g. a directory prefix hitting sibling notes)
+    cannot inflate DCG past IDCG. Ideal DCG places every target at the top."""
     if not targets:
         return 0.0
-    rels = _hits(ranked[:k], targets)
-    dcg = sum(1.0 / math.log2(i + 2) for i, rel in enumerate(rels) if rel)
+    topk = ranked[:k]
+    dcg = 0.0
+    for t in targets:
+        for i, p in enumerate(topk):
+            if matches(p, t):
+                dcg += 1.0 / math.log2(i + 2)
+                break
     n_ideal = min(len(targets), k)
     idcg = sum(1.0 / math.log2(i + 2) for i in range(n_ideal))
     return dcg / idcg if idcg > 0 else 0.0

--- a/src/neurostack/eval.py
+++ b/src/neurostack/eval.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Retrieval-quality benchmark + per-signal ablation harness (issue #63).
+
+Runs ``hybrid_search`` over a labelled query set and reports recall@k, MRR and
+NDCG, then re-runs with each ranking signal disabled so the marginal
+contribution of every stacked multiplier is measured against relevance ground
+truth rather than assumed.
+
+Design notes
+------------
+* **Offline in CI.** Query embeddings are served from a JSON cache
+  (``cached_query_embeddings``) so a run needs no live Ollama. Chunk embeddings
+  come from whatever DB is under test — the committed test fixture builds a tiny
+  deterministic corpus; a real run points ``--db`` at a copy of the prod index.
+* **Side-effect-free.** Every ``hybrid_search`` call passes ``record=False`` so
+  an ablation sweep (many passes over the same query) never mutates usage,
+  hotness, co-occurrence weights, or the prediction-error log between configs.
+* **Ablation via the search pipeline itself.** Each config disables one signal
+  through ``hybrid_search(ablate=...)`` and re-runs, rather than trying to undo
+  a multiplier after the fact — lateral inhibition and dedup reorder results, so
+  a signal's effect can only be read by re-ranking without it.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .search import ABLATABLE_SIGNALS
+
+
+@dataclass
+class EvalQuery:
+    """One labelled query: text plus the note paths that count as relevant."""
+
+    query: str
+    targets: list[str]          # note-path prefixes / substrings that are relevant
+    category: str = ""
+    context: str | None = None  # optional --context domain to pass through
+
+
+@dataclass
+class ConfigResult:
+    """Aggregate + per-query metrics for one pipeline configuration."""
+
+    name: str
+    ablated: set[str]
+    recall: float
+    mrr: float
+    ndcg: float
+    per_query: list[dict] = field(default_factory=list)
+
+
+# ── label loading ─────────────────────────────────────────────────────────
+
+
+def load_queries(path) -> list[EvalQuery]:
+    """Load a labelled query set from YAML.
+
+    Schema::
+
+        queries:
+          - query: "Home lab network topology"
+            category: pinpoint
+            targets: [home/resources/infrastructure]
+          - query: "HashiCorp Vault SSH CA"
+            target: home/resources/hashicorp-vault   # singular shorthand
+    """
+    import yaml
+
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    items = raw.get("queries", raw) if isinstance(raw, dict) else raw
+    queries: list[EvalQuery] = []
+    for item in items:
+        targets = item.get("targets")
+        if targets is None:
+            single = item.get("target")
+            targets = [single] if single else []
+        queries.append(
+            EvalQuery(
+                query=item["query"],
+                targets=[str(t) for t in targets],
+                category=item.get("category", ""),
+                context=item.get("context"),
+            )
+        )
+    return queries
+
+
+# ── relevance + metrics ───────────────────────────────────────────────────
+
+
+def matches(path: str, target: str) -> bool:
+    """Whether a result path is relevant to a label target.
+
+    Relevant when the target is a path prefix of the result or appears anywhere
+    in it — the match rule from the 2026-04-16 benchmark note, tolerant of the
+    ``.md`` suffix and section-anchored paths.
+    """
+    p = path.lower()
+    t = target.lower().rstrip("/")
+    return p == t or p.startswith(t + "/") or t in p
+
+
+def _hits(ranked: list[str], targets: list[str]) -> list[bool]:
+    return [any(matches(p, t) for t in targets) for p in ranked]
+
+
+def recall_at_k(ranked: list[str], targets: list[str], k: int) -> float:
+    """Fraction of distinct relevant targets that appear in the top-k results."""
+    if not targets:
+        return 0.0
+    topk = ranked[:k]
+    found = sum(1 for t in targets if any(matches(p, t) for p in topk))
+    return found / len(targets)
+
+
+def mrr(ranked: list[str], targets: list[str]) -> float:
+    """Reciprocal rank of the first relevant result (0 if none)."""
+    for i, p in enumerate(ranked, start=1):
+        if any(matches(p, t) for t in targets):
+            return 1.0 / i
+    return 0.0
+
+
+def ndcg_at_k(ranked: list[str], targets: list[str], k: int) -> float:
+    """Binary-relevance NDCG@k. Ideal DCG assumes as many relevant docs as
+    there are labelled targets (capped at k), each ranked first."""
+    if not targets:
+        return 0.0
+    rels = _hits(ranked[:k], targets)
+    dcg = sum(1.0 / math.log2(i + 2) for i, rel in enumerate(rels) if rel)
+    n_ideal = min(len(targets), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(n_ideal))
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+# ── query-embedding cache (offline replay) ────────────────────────────────
+
+
+def load_embedding_cache(path) -> dict[str, list[float]]:
+    p = Path(path)
+    if p.exists():
+        return json.loads(p.read_text(encoding="utf-8"))
+    return {}
+
+
+def save_embedding_cache(path, cache: dict[str, list[float]]) -> None:
+    Path(path).write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def build_embedding_cache(queries: list[EvalQuery], embed_url: str) -> dict[str, list[float]]:
+    """Fetch query embeddings from a live embedder and return a JSON-able cache.
+
+    Used by ``--refresh-embeddings``; requires a reachable Ollama/embed service.
+    """
+    from .embedder import get_embedding
+
+    cache: dict[str, list[float]] = {}
+    for q in queries:
+        vec = get_embedding(q.query, base_url=embed_url)
+        cache[q.query] = [float(x) for x in vec]
+    return cache
+
+
+@contextlib.contextmanager
+def cached_query_embeddings(cache: dict[str, list[float]]):
+    """Patch ``search.get_embedding`` to serve query vectors from a cache.
+
+    Lets the harness run with no live embedder. A query missing from the cache
+    raises a clear error pointing at ``--refresh-embeddings`` rather than
+    silently falling back to FTS-only (which would quietly change the metrics).
+    """
+    import numpy as np
+
+    from . import search as search_mod
+
+    original = search_mod.get_embedding
+
+    def _fake(text, base_url=None, model=None):
+        if text in cache:
+            return np.array(cache[text], dtype=np.float32)
+        raise KeyError(
+            f"No cached embedding for query {text!r}. Rebuild the cache with "
+            f"`neurostack eval --refresh-embeddings` against a live embedder."
+        )
+
+    search_mod.get_embedding = _fake
+    try:
+        yield
+    finally:
+        search_mod.get_embedding = original
+
+
+# ── evaluation ────────────────────────────────────────────────────────────
+
+
+def configs(signals=ABLATABLE_SIGNALS) -> list[tuple[str, set[str]]]:
+    """The baseline plus one single-signal-ablation config per signal."""
+    out: list[tuple[str, set[str]]] = [("full", set())]
+    out.extend((f"-{s}", {s}) for s in signals)
+    return out
+
+
+def evaluate_config(
+    queries: list[EvalQuery],
+    ablate: set[str],
+    *,
+    db_path,
+    k: int,
+    embed_url: str | None = None,
+) -> ConfigResult:
+    """Run one configuration (a set of ablated signals) over every query."""
+    from .search import hybrid_search
+
+    per_query: list[dict] = []
+    for q in queries:
+        results = hybrid_search(
+            query=q.query,
+            top_k=k,
+            mode="hybrid",
+            db_path=db_path,
+            embed_url=embed_url,
+            context=q.context,
+            ablate=ablate,
+            record=False,
+        )
+        ranked = [r.note_path for r in results]
+        per_query.append(
+            {
+                "query": q.query,
+                "category": q.category,
+                "recall": recall_at_k(ranked, q.targets, k),
+                "mrr": mrr(ranked, q.targets),
+                "ndcg": ndcg_at_k(ranked, q.targets, k),
+                "hit": any(_hits(ranked[:k], q.targets)),
+                "ranked": ranked[:k],
+                "targets": q.targets,
+            }
+        )
+
+    n = len(per_query) or 1
+    return ConfigResult(
+        name="full" if not ablate else "-" + ",".join(sorted(ablate)),
+        ablated=set(ablate),
+        recall=sum(x["recall"] for x in per_query) / n,
+        mrr=sum(x["mrr"] for x in per_query) / n,
+        ndcg=sum(x["ndcg"] for x in per_query) / n,
+        per_query=per_query,
+    )
+
+
+def run_eval(
+    queries: list[EvalQuery],
+    *,
+    db_path,
+    k: int = 5,
+    embed_url: str | None = None,
+    cache: dict[str, list[float]] | None = None,
+    ablation: bool = True,
+) -> list[ConfigResult]:
+    """Evaluate the full pipeline, then (optionally) each single-signal ablation.
+
+    ``cache`` supplies query embeddings for offline replay; pass ``None`` to use
+    the live embedder configured on ``embed_url``.
+    """
+    # Fail loud on an incomplete cache. hybrid_search swallows an embedding
+    # error into a silent FTS-only fallback, which would quietly change the
+    # metrics — so the harness verifies coverage up front rather than trusting
+    # the per-query patch to raise.
+    if cache is not None:
+        missing = [q.query for q in queries if q.query not in cache]
+        if missing:
+            raise KeyError(
+                f"No cached embedding for {len(missing)} quer"
+                f"{'y' if len(missing) == 1 else 'ies'} (e.g. {missing[0]!r}). "
+                f"Rebuild the cache with `neurostack eval --refresh-embeddings`."
+            )
+
+    run_configs = configs() if ablation else [("full", set())]
+
+    def _run() -> list[ConfigResult]:
+        rows: list[ConfigResult] = []
+        for name, ablate in run_configs:
+            res = evaluate_config(
+                queries, ablate, db_path=db_path, k=k, embed_url=embed_url
+            )
+            res.name = name
+            rows.append(res)
+        return rows
+
+    if cache is not None:
+        with cached_query_embeddings(cache):
+            return _run()
+    return _run()
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+
+def format_table(rows: list[ConfigResult], k: int) -> str:
+    """A metric-per-configuration table with per-signal deltas vs the full pipeline."""
+    full = next((r for r in rows if r.name == "full"), rows[0])
+    lines = []
+    header = (
+        f"{'config':<20} {'recall@' + str(k):>9} {'MRR':>7} {'NDCG':>7} "
+        f"{'Δrecall':>9} {'Δmrr':>8} {'Δndcg':>8}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for r in rows:
+        if r.name == "full":
+            drecall = dmrr = dndcg = ""
+        else:
+            # Δ = full − ablated: positive means the removed signal was helping.
+            drecall = f"{full.recall - r.recall:+.3f}"
+            dmrr = f"{full.mrr - r.mrr:+.3f}"
+            dndcg = f"{full.ndcg - r.ndcg:+.3f}"
+        lines.append(
+            f"{r.name:<20} {r.recall:>9.3f} {r.mrr:>7.3f} {r.ndcg:>7.3f} "
+            f"{drecall:>9} {dmrr:>8} {dndcg:>8}"
+        )
+    lines.append("")
+    lines.append(
+        "Δ = full − ablated. Positive Δ ⇒ the removed signal earns its weight; "
+        "≤0 ⇒ it is inert or harmful (candidate for removal, issue #66)."
+    )
+    return "\n".join(lines)
+
+
+def results_to_dict(rows: list[ConfigResult], k: int) -> dict:
+    full = next((r for r in rows if r.name == "full"), rows[0])
+    return {
+        "k": k,
+        "n_queries": len(rows[0].per_query) if rows else 0,
+        "configs": [
+            {
+                "name": r.name,
+                "ablated": sorted(r.ablated),
+                "recall": round(r.recall, 4),
+                "mrr": round(r.mrr, 4),
+                "ndcg": round(r.ndcg, 4),
+                "delta_recall": None if r.name == "full" else round(full.recall - r.recall, 4),
+                "delta_mrr": None if r.name == "full" else round(full.mrr - r.mrr, 4),
+                "delta_ndcg": None if r.name == "full" else round(full.ndcg - r.ndcg, 4),
+            }
+            for r in rows
+        ],
+    }

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -664,6 +664,22 @@ def decay_hours_since(now=None) -> float | None:
     return (current - last).total_seconds() / 3600.0
 
 
+#: Ranking signals stacked on top of the base (FTS + cosine) score, in pipeline
+#: order. Each name can be passed in ``hybrid_search(ablate=...)`` to skip that
+#: stage — the mechanism the eval harness (issue #63) uses to measure a signal's
+#: marginal contribution to recall@k / MRR / NDCG.
+ABLATABLE_SIGNALS = (
+    "link_section",
+    "convergence",
+    "context",
+    "hotness",
+    "cooccurrence",
+    "excitability",
+    "prediction_error",
+    "lateral_inhibition",
+)
+
+
 def hybrid_search(
     query: str,
     top_k: int = 5,
@@ -673,6 +689,8 @@ def hybrid_search(
     context: str = None,
     workspace: str | None = None,
     explain: bool = False,
+    ablate: set[str] | None = None,
+    record: bool = True,
 ) -> list[SearchResult]:
     """
     Hybrid search combining FTS5 and semantic similarity.
@@ -686,9 +704,18 @@ def hybrid_search(
     dict recording the per-stage score breakdown (base, link-section penalty,
     convergence, context, hotness, co-occurrence, excitability, prediction-error,
     lateral inhibition) — used to diagnose ranking (issue #41).
+
+    ``ablate`` is a set of signal names from ``ABLATABLE_SIGNALS``; any listed
+    stage is skipped so the eval harness (issue #63) can measure each signal's
+    marginal contribution. ``record`` gates the write side-effects — usage
+    recording (which feeds hotness), Hebbian co-occurrence reinforcement, and
+    prediction-error logging. Pass ``record=False`` for a side-effect-free run:
+    an ablation sweep re-runs the same query many times, and letting each run
+    mutate usage/hotness would contaminate every subsequent configuration.
     """
     from .schema import DB_PATH
 
+    ablate = ablate or set()
     cfg = get_config()
     embed_url = embed_url or cfg.embed_url
     conn = get_db(db_path or DB_PATH)
@@ -768,7 +795,7 @@ def hybrid_search(
         is_link_section = _is_link_section(
             r.get("heading_path", ""), r.get("content", "") or "", link_density_threshold
         )
-        if is_link_section:
+        if is_link_section and "link_section" not in ablate:
             r["score"] *= link_section_penalty
         if explain:
             r["_explain"]["link_density"] = round(density, 3)
@@ -787,7 +814,7 @@ def hybrid_search(
     # The final score is blended: 0.7 * raw_score + 0.3 * convergence
     # so convergence can lift or dampen but never dominate.
     note_paths_unique = list({r["note_path"] for r in valid_results})
-    if note_paths_unique:
+    if note_paths_unique and "convergence" not in ablate:
         placeholders = ",".join("?" * len(note_paths_unique))
         all_chunks = conn.execute(
             f"SELECT note_path, embedding FROM chunks "
@@ -824,7 +851,7 @@ def hybrid_search(
 
     # Apply context boost; track which notes are in-context for mismatch detection
     in_context_notes: set[str] = set()
-    if context:
+    if context and "context" not in ablate:
         direct_ctx, neighbor_ctx = _get_context_notes(conn, context, embed_url=embed_url)
         in_context_notes = direct_ctx | neighbor_ctx
         for r in valid_results:
@@ -837,12 +864,13 @@ def hybrid_search(
                 _rec(r, context_boost=1.2, after_context=round(r["score"], 4))
 
     # Apply hotness blend: final_score = 0.8 * semantic + 0.2 * hotness
-    hotness_map = batch_hotness_scores(conn, [r["note_path"] for r in valid_results])
-    for r in valid_results:
-        h = hotness_map.get(r["note_path"], 0.0)
-        if h > 0.0:
-            r["score"] = 0.8 * r["score"] + 0.2 * h
-            _rec(r, hotness=round(h, 4), after_hotness=round(r["score"], 4))
+    if "hotness" not in ablate:
+        hotness_map = batch_hotness_scores(conn, [r["note_path"] for r in valid_results])
+        for r in valid_results:
+            h = hotness_map.get(r["note_path"], 0.0)
+            if h > 0.0:
+                r["score"] = 0.8 * r["score"] + 0.2 * h
+                _rec(r, hotness=round(h, 4), after_hotness=round(r["score"], 4))
 
     # Extract query-matched entities (used for co-occurrence boost AND reinforcement)
     query_words = [w.lower() for w in query.split() if len(w) > 2]
@@ -860,7 +888,7 @@ def hybrid_search(
     # Co-occurrence boost: notes containing entities that co-occur with query entities
     # get a bounded multiplicative boost. Slots after hotness, before excitability.
     cooc_weight = cfg.cooccurrence_boost_weight
-    if cooc_weight > 0 and query_entities:
+    if cooc_weight > 0 and query_entities and "cooccurrence" not in ablate:
                 # Step 2: Find co-occurring entities and their weights
                 cooc_entities = {}  # entity -> max co-occurrence weight
                 for qe in query_entities:
@@ -913,34 +941,35 @@ def hybrid_search(
     # neurons are preferentially recruited into new engrams.
     # Reads from note_metadata (SQLite-owned) with frontmatter fallback.
     meta_paths = [r["note_path"] for r in valid_results]
-    if meta_paths:
-        placeholders = ",".join("?" * len(meta_paths))
-        meta_rows = conn.execute(
-            f"SELECT note_path, status FROM note_metadata"
-            f" WHERE note_path IN ({placeholders})",
-            meta_paths,
-        ).fetchall()
-        meta_status = {r["note_path"]: r["status"] for r in meta_rows}
-    else:
-        meta_status = {}
+    if "excitability" not in ablate:
+        if meta_paths:
+            placeholders = ",".join("?" * len(meta_paths))
+            meta_rows = conn.execute(
+                f"SELECT note_path, status FROM note_metadata"
+                f" WHERE note_path IN ({placeholders})",
+                meta_paths,
+            ).fetchall()
+            meta_status = {r["note_path"]: r["status"] for r in meta_rows}
+        else:
+            meta_status = {}
 
-    for r in valid_results:
-        status = meta_status.get(r["note_path"])
-        if status is None:
-            # Fallback: parse from notes.frontmatter
-            note_row = conn.execute(
-                "SELECT frontmatter FROM notes WHERE path = ?",
-                (r["note_path"],),
-            ).fetchone()
-            if note_row and note_row["frontmatter"]:
-                try:
-                    fm = json.loads(note_row["frontmatter"])
-                    status = fm.get("status")
-                except (json.JSONDecodeError, TypeError):
-                    pass
-        if status == "active":
-            r["score"] *= 1.15
-            _rec(r, excitability_boost=1.15, after_excitability=round(r["score"], 4))
+        for r in valid_results:
+            status = meta_status.get(r["note_path"])
+            if status is None:
+                # Fallback: parse from notes.frontmatter
+                note_row = conn.execute(
+                    "SELECT frontmatter FROM notes WHERE path = ?",
+                    (r["note_path"],),
+                ).fetchone()
+                if note_row and note_row["frontmatter"]:
+                    try:
+                        fm = json.loads(note_row["frontmatter"])
+                        status = fm.get("status")
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+            if status == "active":
+                r["score"] *= 1.15
+                _rec(r, excitability_boost=1.15, after_excitability=round(r["score"], 4))
 
     # ── Prediction error demotion ──
     # Notes with unresolved prediction errors have previously "surprised" on
@@ -954,7 +983,7 @@ def hybrid_search(
     # Only notes that have surprised >= PREDICTION_ERROR_MIN_OCCURRENCES distinct
     # retrieval events are demoted; a single ad-hoc flag is query noise and must
     # not deprioritise an otherwise-correct note in future searches.
-    if meta_paths:
+    if meta_paths and "prediction_error" not in ablate:
         try:
             placeholders = ",".join("?" * len(meta_paths))
             error_rows = conn.execute(
@@ -1003,7 +1032,7 @@ def hybrid_search(
     # penalty = 1 - inhibition_strength * max_similarity_to_higher_ranked
     INHIBITION_THRESHOLD = 0.65   # only suppress when note embeddings are >0.65 similar
     INHIBITION_STRENGTH = 0.30    # max 30% score reduction at similarity=1.0
-    if len(deduped) > 1:
+    if len(deduped) > 1 and "lateral_inhibition" not in ablate:
         # Build embedding lookup for deduped results
         deduped_embeddings = []
         for r in deduped:
@@ -1042,55 +1071,60 @@ def hybrid_search(
     # Trim to final top_k after lateral inhibition
     deduped = deduped[:top_k]
 
-    # Auto-record usage for returned results (drives hotness scoring)
+    # Write side-effects — skipped entirely when record=False so an eval /
+    # ablation sweep (issue #63) can re-run the same query many times without
+    # each pass mutating usage, hotness, co-occurrence weights, or the
+    # prediction-error log that the next configuration would then read back.
     returned_paths = [r["note_path"] for r in deduped[:top_k]]
-    _record_note_usage(conn, returned_paths)
+    if record:
+        # Auto-record usage for returned results (drives hotness scoring)
+        _record_note_usage(conn, returned_paths)
 
-    # Hebbian reinforcement: strengthen co-occurrence for entity pairs shared
-    # between query-matched entities and result-note entities.
-    # Fires regardless of cooccurrence_boost_weight setting.
-    if query_entities and returned_paths:
-        try:
-            placeholders = ",".join("?" * len(returned_paths))
-            result_ent_rows = conn.execute(
-                f"SELECT DISTINCT subject, object FROM triples "
-                f"WHERE note_path IN ({placeholders})",
-                returned_paths,
-            ).fetchall()
-            result_entities: set[str] = set()
-            for rer in result_ent_rows:
-                result_entities.add(rer["subject"])
-                result_entities.add(rer["object"])
+        # Hebbian reinforcement: strengthen co-occurrence for entity pairs shared
+        # between query-matched entities and result-note entities.
+        # Fires regardless of cooccurrence_boost_weight setting.
+        if query_entities and returned_paths:
+            try:
+                placeholders = ",".join("?" * len(returned_paths))
+                result_ent_rows = conn.execute(
+                    f"SELECT DISTINCT subject, object FROM triples "
+                    f"WHERE note_path IN ({placeholders})",
+                    returned_paths,
+                ).fetchall()
+                result_entities: set[str] = set()
+                for rer in result_ent_rows:
+                    result_entities.add(rer["subject"])
+                    result_entities.add(rer["object"])
 
-            # Build reinforcement pairs: each query entity x each result entity
-            reinforce_pairs = [
-                (qe, re)
-                for qe in query_entities
-                for re in result_entities
-                if qe != re
-            ]
-            if reinforce_pairs:
-                reinforce_cooccurrence(conn, reinforce_pairs)
-        except Exception:
-            pass  # Never let reinforcement disrupt search
+                # Build reinforcement pairs: each query entity x each result entity
+                reinforce_pairs = [
+                    (qe, re)
+                    for qe in query_entities
+                    for re in result_entities
+                    if qe != re
+                ]
+                if reinforce_pairs:
+                    reinforce_cooccurrence(conn, reinforce_pairs)
+            except Exception:
+                pass  # Never let reinforcement disrupt search
 
-    # Prediction error detection — check top result for high semantic distance
-    if deduped:
-        top = deduped[0]
-        top_cosine = top.get("cosine_sim", 1.0)
-        if top_cosine < PREDICTION_ERROR_SIM_THRESHOLD:
-            log_prediction_error(
-                conn, top["note_path"], query, top_cosine, "low_overlap", context
-            )
-        elif (
-            context
-            and in_context_notes
-            and top["note_path"] not in in_context_notes
-            and top_cosine < CONTEXTUAL_MISMATCH_MAX_SIM
-        ):
-            log_prediction_error(
-                conn, top["note_path"], query, top_cosine, "contextual_mismatch", context
-            )
+        # Prediction error detection — check top result for high semantic distance
+        if deduped:
+            top = deduped[0]
+            top_cosine = top.get("cosine_sim", 1.0)
+            if top_cosine < PREDICTION_ERROR_SIM_THRESHOLD:
+                log_prediction_error(
+                    conn, top["note_path"], query, top_cosine, "low_overlap", context
+                )
+            elif (
+                context
+                and in_context_notes
+                and top["note_path"] not in in_context_notes
+                and top_cosine < CONTEXTUAL_MISMATCH_MAX_SIM
+            ):
+                log_prediction_error(
+                    conn, top["note_path"], query, top_cosine, "contextual_mismatch", context
+                )
 
     return _to_search_results(conn, deduped)
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,59 @@
+# Retrieval eval + ablation harness (issue #63)
+
+Measures whether the stacked ranking signals in `hybrid_search` actually rank
+better than the base FTS+cosine score — against relevance ground truth, not
+wiring assertions. It reports recall@k / MRR / NDCG for the full pipeline, then
+re-runs with each signal disabled so every multiplier's marginal contribution is
+visible.
+
+## Files
+
+| File | What it is |
+|------|-----------|
+| `queries.yaml` | Labelled query set: 36 queries → the note(s) each should surface. Seeded from the 2026-04-16 retrieval benchmark and expanded across pinpoint / thematic / crossref / adversarial. |
+| `query_embeddings.json` | Cache of query embeddings (created by `--refresh-embeddings`). Lets the harness run offline. Not committed until you generate it against your embedder. |
+
+The code lives in `src/neurostack/eval.py`; the CLI is `neurostack eval`; the
+offline unit tests are `tests/test_eval.py`.
+
+## Running it
+
+Against a **copy** of the prod index (eval is read-only — `record=False` — but
+point it at a copy anyway), on the box with a live embedder:
+
+```bash
+# 1. First run on a new box builds the query-embedding cache, then evaluates
+neurostack eval --db /tmp/neurostack-copy.db --refresh-embeddings
+
+# 2. Subsequent runs replay the cache — fully offline, no Ollama needed
+neurostack eval --db /tmp/neurostack-copy.db
+
+# JSON for scripting / regression tracking
+neurostack --json eval --db /tmp/neurostack-copy.db | jq '.configs'
+```
+
+Output is a metric-per-configuration table. Read the delta columns as
+`Δ = full − ablated`:
+
+* **Δ > 0** — removing the signal *hurt*; it earns its weight.
+* **Δ ≈ 0** — the signal is inert on this query set (candidate for removal, #66).
+* **Δ < 0** — removing the signal *helped*; it is actively mis-ranking.
+
+This is the loop that gates #64 (excitability removal must be Δ ≤ 0, i.e.
+neutral-or-better) and #66 (weight tuning).
+
+## Offline CI
+
+`tests/test_eval.py` builds a tiny deterministic corpus with hand-assigned
+embeddings and an injected query-embedding cache, so the harness — including the
+per-signal ablation and the side-effect-free guarantee — runs in CI with no
+embedder. It does **not** use `queries.yaml`'s real vault paths (those need the
+real index); it only checks that `queries.yaml` ships and parses.
+
+## Maintaining the labels
+
+Paths in `queries.yaml` were verified against the live vault on 2026-07-02. If
+the vault is reorganised, re-verify with `vault_list_files` and adjust targets.
+Labels are a starting point — after the first real run, inspect misses
+(`--json` shows each query's top-k) and correct any target that is genuinely
+wrong before trusting the deltas for weight decisions.

--- a/tests/eval/queries.yaml
+++ b/tests/eval/queries.yaml
@@ -1,0 +1,132 @@
+# Labelled retrieval-eval query set for `neurostack eval` (issue #63).
+#
+# Each query maps to the note(s) that should surface in the top-k. `target` is
+# a note-path prefix (the `.md` and any section anchor are matched loosely — see
+# neurostack.eval.matches). Use `targets: [...]` when more than one note is
+# co-canonical. `category` groups queries by retrieval difficulty; `context`
+# passes a --context domain through to hybrid_search.
+#
+# Seeded from the 2026-04-16 retrieval benchmark (17 queries) and expanded to
+# span pinpoint / thematic / crossref / adversarial across home, work,
+# literature and research. Paths verified against the live vault on 2026-07-02;
+# re-verify with `vault_list_files` if the vault has been reorganised since, and
+# tune labels after the first real run (they are a starting point, not gospel).
+
+queries:
+  # ── pinpoint: one obvious canonical note ──
+  - query: "NeuroStack LXC migration"
+    category: pinpoint
+    target: home/projects/neurostack/lxc-migration-2026-04-16
+  - query: "Home lab network topology"
+    category: pinpoint
+    target: home/resources/infrastructure
+  - query: "HashiCorp Vault SSH CA"
+    category: pinpoint
+    target: home/resources/hashicorp-vault
+  - query: "grocery system Ocado weekly order"
+    category: pinpoint
+    target: home/resources/grocery-system
+  - query: "Reddit engagement daemon"
+    category: pinpoint
+    target: home/resources/reddit-engagement-daemon
+  - query: "Sunshine game streaming setup"
+    category: pinpoint
+    target: home/projects/sunshine-streaming
+  - query: "IBM licensing ILMT ILS"
+    category: pinpoint
+    target: literature/ibm-licensing-ilmt-ils-research
+  - query: "Azure Front Door migration AFD"
+    category: pinpoint
+    target: work/nyk-europe-azure/projects/afd-migration
+  - query: "SSH config aliases for home lab hosts"
+    category: pinpoint
+    target: home/resources/ssh-config-setup
+  - query: "morning briefing timer Gmail draft"
+    category: pinpoint
+    target: home/resources/morning-briefing
+  - query: "Proxmox backup and disaster recovery"
+    category: pinpoint
+    target: home/resources/proxmox-backup-dr
+  - query: "Pi-hole DNS blocking configuration"
+    category: pinpoint
+    target: home/resources/pihole-dns-blocking
+  - query: "NBSE certificate rotation ACM to Azure Key Vault"
+    category: pinpoint
+    target: work/nyk-europe-azure/projects/nbse-cert-rotation
+  - query: "EAS AKS Kubernetes 1.33 end of life upgrade"
+    category: pinpoint
+    target: work/nyk-europe-azure/resources/eas-aks-k8s-1.33-eol-2026-06
+  - query: "Rapid7 InsightVM May 2026 sprint"
+    category: pinpoint
+    target: work/nyk-europe-azure/resources/rapid7-r7-may-2026-sprint
+  - query: "Azure Bastion DMZ deploy failure"
+    category: pinpoint
+    target: work/nyk-europe-azure/resources/az-bst-dmz-prod-deploy-failure-2026-05-14
+  - query: "iSeries KPN hosts and clients"
+    category: pinpoint
+    target: work/nyk-europe-azure/resources/iseries-hosts-and-clients
+
+  # ── thematic: concept spanning a note (or a few) ──
+  - query: "What are my main home projects"
+    category: thematic
+    target: home/projects/index
+  - query: "infrastructure-as-code Terraform layered architecture NYK"
+    category: thematic
+    target: work/nyk-europe-azure/projects/infra-terraform
+  - query: "Hopfield networks associative memory"
+    category: thematic
+    target: literature/hopfield-networks-memory-research
+  - query: "canine ultrasonography gestational age estimation"
+    category: thematic
+    target: literature/canine-fetal-ultrasonography-gestational-age-research
+  - query: "predictive coding as a knowledge architecture"
+    category: thematic
+    target: research/predictive-coding-knowledge-architecture
+  - query: "Tolman-Eichenbaum Machine grid cells structural abstraction"
+    category: thematic
+    target: research/tolman-eichenbaum-machine
+  - query: "memory engrams and neuronal allocation"
+    category: thematic
+    targets:
+      - literature/memory-engrams-research
+      - research/engram-allocation-competition
+
+  # ── crossref: answer lives in a note about something broader ──
+  - query: "Obsidian LiveSync CouchDB self-hosted"
+    category: crossref
+    target: home/projects/obsidian-livesync
+  - query: "Plex media server LXC container"
+    category: crossref
+    target: home/resources/infrastructure
+  - query: "Bassnet SQL health check"
+    category: crossref
+    target: work/nyk-europe-azure/projects/bassnet-sql-health
+  - query: "Azure VWAN routing intent and firewall"
+    category: crossref
+    target: work/nyk-europe-azure/resources/azure-networking
+  - query: "Citrix CVAD 2402 IMDS workaround"
+    category: crossref
+    target: work/nyk-europe-azure/resources/citrix-cvad-2402-imds-workaround
+  - query: "M365 Copilot MCP bridge on the work laptop"
+    category: crossref
+    target: work/nyk-europe-azure/resources/m365-copilot-mcp
+
+  # ── adversarial: phrased away from the note's own wording ──
+  - query: "dual boot Pop OS and Windows"
+    category: adversarial
+    target: home/projects/dual-boot-setup
+  - query: "Azure consolidation proposal"
+    category: adversarial
+    target: work/nyk-europe-azure/resources/azure-consolidation-proposal
+  - query: "how do I root my Samsung tablet"
+    category: adversarial
+    target: home/resources/tab-s4-root-guide
+  - query: "WinRM hop to reach the work laptop"
+    category: adversarial
+    target: work/nyk-europe-azure/resources/winrm-hop1
+  - query: "lateral inhibition and engram sparsity"
+    category: adversarial
+    target: research/engram-allocation-competition
+  - query: "reconcile deleted notes ghost communities"
+    category: adversarial
+    target: home/projects/neurostack/community-modularity-fix-2026-06-03

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,199 @@
+"""Tests for neurostack.eval — the retrieval benchmark + ablation harness (#63).
+
+Two layers:
+  * pure metric functions (recall@k / MRR / NDCG / match rule) on hand-built
+    rankings — no DB, no embeddings;
+  * an end-to-end run over a tiny on-disk corpus with deterministic embeddings
+    and an injected query-embedding cache, so the whole harness exercises
+    ``hybrid_search`` offline (no Ollama) and stays side-effect-free.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neurostack.embedder import embedding_to_blob
+from neurostack.eval import (
+    EvalQuery,
+    configs,
+    load_queries,
+    matches,
+    mrr,
+    ndcg_at_k,
+    recall_at_k,
+    run_eval,
+)
+from neurostack.schema import get_db
+from neurostack.search import ABLATABLE_SIGNALS
+
+# ── pure metric functions ──────────────────────────────────────────────────
+
+
+class TestMatchRule:
+    def test_prefix_match(self):
+        assert matches("home/resources/infrastructure.md", "home/resources/infrastructure")
+
+    def test_directory_target(self):
+        assert matches("home/projects/sunshine/setup.md", "home/projects/sunshine")
+
+    def test_substring_match(self):
+        assert matches("work/x/afd-migration/afd-migration.md", "afd-migration")
+
+    def test_case_insensitive(self):
+        assert matches("Home/Resources/Foo.md", "home/resources/foo")
+
+    def test_no_match(self):
+        assert not matches("home/resources/infrastructure.md", "home/resources/grocery-system")
+
+
+class TestRecall:
+    def test_hit_in_topk(self):
+        ranked = ["a.md", "target.md", "c.md"]
+        assert recall_at_k(ranked, ["target"], k=5) == 1.0
+
+    def test_miss_outside_k(self):
+        ranked = ["a.md", "b.md", "target.md"]
+        assert recall_at_k(ranked, ["target"], k=2) == 0.0
+
+    def test_partial_multi_target(self):
+        ranked = ["one.md", "x.md"]
+        assert recall_at_k(ranked, ["one", "two"], k=5) == 0.5
+
+    def test_no_targets(self):
+        assert recall_at_k(["a.md"], [], k=5) == 0.0
+
+
+class TestMRR:
+    def test_first_rank(self):
+        assert mrr(["target.md", "b.md"], ["target"]) == 1.0
+
+    def test_third_rank(self):
+        assert mrr(["a.md", "b.md", "target.md"], ["target"]) == pytest.approx(1 / 3)
+
+    def test_none_found(self):
+        assert mrr(["a.md", "b.md"], ["target"]) == 0.0
+
+
+class TestNDCG:
+    def test_ideal_ranking(self):
+        # single relevant doc at rank 1 → perfect
+        assert ndcg_at_k(["target.md", "b.md", "c.md"], ["target"], k=5) == pytest.approx(1.0)
+
+    def test_demoted_relevant(self):
+        # relevant at rank 2 → 1/log2(3) discounted, idcg = 1.0
+        got = ndcg_at_k(["a.md", "target.md"], ["target"], k=5)
+        assert got == pytest.approx(1.0 / np.log2(3))
+
+    def test_none_relevant(self):
+        assert ndcg_at_k(["a.md", "b.md"], ["target"], k=5) == 0.0
+
+
+# ── labelled query set ships and parses ────────────────────────────────────
+
+
+def test_shipped_query_set_loads():
+    path = Path(__file__).parent / "eval" / "queries.yaml"
+    queries = load_queries(path)
+    assert len(queries) >= 30, "issue #63 asks for 30-50 labelled queries"
+    for q in queries:
+        assert q.query
+        assert q.targets, f"{q.query!r} has no target"
+        assert q.category in {"pinpoint", "thematic", "crossref", "adversarial"}
+
+
+def test_configs_cover_every_signal():
+    names = configs()
+    assert names[0][0] == "full" and names[0][1] == set()
+    ablated = {c[0] for c in names[1:]}
+    assert ablated == {f"-{s}" for s in ABLATABLE_SIGNALS}
+
+
+# ── end-to-end over a synthetic corpus ─────────────────────────────────────
+
+FRUITS = ["apple", "banana", "cherry", "date"]
+
+
+def _unit(i: int, dim: int = 4) -> np.ndarray:
+    v = np.zeros(dim, dtype=np.float32)
+    v[i] = 1.0
+    return v
+
+
+@pytest.fixture
+def eval_corpus(tmp_path):
+    """A 4-note on-disk vault: each note is a distinct fruit with a near-
+    orthogonal embedding, all sharing 'fruit harvest' vocabulary so FTS returns
+    every note and the cosine rerank (plus signals) decides the order."""
+    db_file = tmp_path / "eval.db"
+    conn = get_db(db_file)
+    for i, fruit in enumerate(FRUITS):
+        path = f"notes/{fruit}.md"
+        content = f"{fruit} fruit harvest notes. The {fruit} orchard season report."
+        conn.execute(
+            "INSERT INTO notes (path, title, frontmatter, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (path, fruit.title(), "{}", "h", "2026-01-01T00:00:00+00:00"),
+        )
+        conn.execute(
+            "INSERT INTO chunks (note_path, heading_path, content, content_hash, "
+            "position, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            (path, "", content, "h", 0, embedding_to_blob(_unit(i))),
+        )
+        conn.execute(
+            "INSERT INTO note_metadata (note_path, status) VALUES (?, 'active')",
+            (path,),
+        )
+    conn.commit()
+    conn.close()
+
+    # Query per fruit; cached embedding points mostly at that fruit's axis.
+    queries = []
+    cache = {}
+    for i, fruit in enumerate(FRUITS):
+        q = f"{fruit} fruit harvest"
+        queries.append(EvalQuery(query=q, targets=[f"notes/{fruit}"], category="pinpoint"))
+        vec = _unit(i) * 0.9 + np.full(4, 0.05, dtype=np.float32)
+        cache[q] = [float(x) for x in vec]
+    return db_file, queries, cache
+
+
+def test_run_eval_full_finds_targets(eval_corpus):
+    db_file, queries, cache = eval_corpus
+    rows = run_eval(queries, db_path=db_file, k=5, cache=cache, ablation=False)
+    full = rows[0]
+    assert full.name == "full"
+    # deterministic space: every query's own fruit is the nearest note
+    assert full.recall == pytest.approx(1.0)
+    assert full.mrr == pytest.approx(1.0)
+
+
+def test_ablation_produces_a_row_per_signal(eval_corpus):
+    db_file, queries, cache = eval_corpus
+    rows = run_eval(queries, db_path=db_file, k=5, cache=cache, ablation=True)
+    assert len(rows) == 1 + len(ABLATABLE_SIGNALS)
+    names = {r.name for r in rows}
+    assert names == {"full"} | {f"-{s}" for s in ABLATABLE_SIGNALS}
+    for r in rows:
+        assert 0.0 <= r.recall <= 1.0
+        assert 0.0 <= r.mrr <= 1.0
+        assert 0.0 <= r.ndcg <= 1.0
+
+
+def test_eval_is_side_effect_free(eval_corpus):
+    """record=False must not write usage rows — else an ablation sweep would
+    poison hotness for every configuration after the first."""
+    db_file, queries, cache = eval_corpus
+    run_eval(queries, db_path=db_file, k=5, cache=cache, ablation=True)
+    conn = get_db(db_file)
+    usage = conn.execute("SELECT COUNT(*) FROM note_usage").fetchone()[0]
+    errors = conn.execute("SELECT COUNT(*) FROM prediction_errors").fetchone()[0]
+    conn.close()
+    assert usage == 0
+    assert errors == 0
+
+
+def test_missing_cached_embedding_raises(eval_corpus):
+    db_file, queries, _ = eval_corpus
+    with pytest.raises(KeyError, match="No cached embedding"):
+        run_eval(queries, db_path=db_file, k=5, cache={}, ablation=False)


### PR DESCRIPTION
Closes #63.

## What

`neurostack eval` — runs `hybrid_search` over a labelled query set and reports **recall@k / MRR / NDCG** for the full pipeline, then re-runs with each ranking signal disabled to show its marginal contribution against relevance ground truth (not the wiring assertions `test_search.py` already covers).

## How

- **`search.py`** — `hybrid_search` gains two params:
  - `ablate: set[str]` — skip any signal in the new `ABLATABLE_SIGNALS` tuple (`link_section`, `convergence`, `context`, `hotness`, `cooccurrence`, `excitability`, `prediction_error`, `lateral_inhibition`). Ablating re-runs the pipeline without that stage rather than trying to undo a multiplier after dedup/inhibition have reordered results.
  - `record: bool` — gates the write side-effects (usage recording → hotness, Hebbian co-occurrence, prediction-error logging). Eval passes `record=False`; without it an ablation sweep's repeated passes would mutate hotness between configs and contaminate every later row.
- **`eval.py`** — metric functions, YAML loader, an offline **query-embedding cache** (patches `search.get_embedding` so CI needs no Ollama; refuses to run on an incomplete cache rather than silently degrading to FTS-only), the ablation runner, and a metric-per-config table with `Δ = full − ablated`.
- **`tests/eval/queries.yaml`** — 36 labelled queries across pinpoint/thematic/crossref/adversarial, seeded from the 2026-04-16 benchmark note, paths verified against the live vault.
- **`tests/test_eval.py`** — 21 tests: pure metrics + an end-to-end run over a synthetic deterministic corpus proving the sweep runs offline and writes nothing.

## Running for real

```bash
neurostack eval --db /tmp/prod-copy.db --refresh-embeddings   # first run builds the cache
neurostack eval --db /tmp/prod-copy.db                        # offline replay thereafter
```

Read `Δ > 0` as "signal earns its weight", `Δ ≤ 0` as "inert or harmful". This is the loop that gates #64 (excitability removal must be Δ ≤ 0) and #66 (weight tuning).

## Test

`uv run ruff check` clean; `uv run pytest` 546 passed (was ~508).