### PR TITLE
feat: retire the inert excitability ×1.15 boost (#64)

### DIFF
--- a/docs/neuroscience-appendix.md
+++ b/docs/neuroscience-appendix.md
@@ -2,7 +2,7 @@
 
 NeuroStack's ranking and clustering features draw on memory neuroscience. This appendix maps each feature to its scientific basis and, more importantly, to what the code actually does. Where the biology is an inspiration rather than a faithful mechanism, it says so.
 
-Verified against the implementation at commit `63e16d2`.
+Verified against the implementation on `main` (the excitability boost was retired in issue #64 — see below).
 
 **Status tags** used below:
 
@@ -21,19 +21,18 @@ Every hybrid search applies these signals in order, in `search.py:hybrid_search`
 4. Context boost (`×1.4` direct, `×1.2` graph-neighbour)
 5. Hotness (blended `0.8 · score + 0.2 · hotness`)
 6. Co-occurrence boost (bounded `×(1 + w·norm)`)
-7. Excitability boost (`×1.15` for `status: active`)
-8. Prediction-error demotion (`×1/(1 + 0.1·n)`)
-9. Lateral inhibition (winner-take-all diversity penalty)
+7. Prediction-error demotion (`×1/(1 + 0.1·n)`)
+8. Lateral inhibition (winner-take-all diversity penalty)
 
 ## Hotness and Excitability (Recency Decay + CREB Windows)
 
-**Feature**: Recently and frequently retrieved notes rank higher; notes marked `status: active` receive a small boost.
+**Feature**: Recently and frequently retrieved notes rank higher.
 
 **Implementation**:
-- Hotness (`search.py:hotness_score`, `[implemented]`): `sigmoid(log1p(usage_count)) · exp(-ln2/half_life · age_days)` with a **30-day half-life**, blended at 0.2. Usage is auto-recorded for every returned result, so the signal is continuously updated.
-- Excitability boost (`search.py`, `[timer-gated]`): a flat `×1.15` when `note_metadata.status == 'active'`. Note that `status` defaults to `active` and is only ever demoted by `run_excitability_demotion`, which runs solely from `neurostack decay --demote` — an opt-in, systemd-based timer. Without that timer every note stays `active`, so the boost applies uniformly and does not differentiate results. Install the decay timer for it to have any effect.
+- Hotness (`search.py:hotness_score`, `[implemented]`): `sigmoid(log1p(usage_count)) · exp(-ln2/half_life · age_days)` with a **30-day half-life**, blended at 0.2. Usage is auto-recorded for every returned result, so the signal is continuously updated. This is the sole recency signal in ranking.
+- Excitability boost (`[retired]`, issue #64): a flat `×1.15` when `note_metadata.status == 'active'` used to sit here. Because `status` defaults to `active` and was demoted only by the opt-in `neurostack decay --demote` timer, on a default install every note stayed `active`, the boost applied uniformly, and it changed no ranking. The per-signal ablation harness (issue #63) confirmed a near-zero delta. It was removed rather than propped up with a mandatory timer, since it only duplicated the recency already carried by the continuous hotness blend. `note_metadata.status` is still maintained — it now serves the agent-linking convention (link preferentially to `active` notes) and the `neurostack decay` report, not search ranking.
 
-**Science**: CREB-mediated intrinsic excitability biases which neurons are recruited into an engram. Neurons with elevated CREB at encoding are preferentially allocated, creating a transient window (on the order of hours in the biology) during which a memory attracts new associations. NeuroStack's hotness decay is a much slower software analogue (days, not hours) tuned for how often notes are actually re-read; the ~6-hour biological window is the inspiration, not the parameter.
+**Science**: CREB-mediated intrinsic excitability biases which neurons are recruited into an engram. Neurons with elevated CREB at encoding are preferentially allocated, creating a transient window (on the order of hours in the biology) during which a memory attracts new associations. NeuroStack's hotness decay is a much slower software analogue (days, not hours) tuned for how often notes are actually re-read; the ~6-hour biological window is the inspiration, not the parameter. The retired excitability boost was a second, coarser take on the same recency idea; folding it into hotness leaves one continuous signal instead of two overlapping ones.
 
 **References**:
 - Han, J.-H. et al. (2007). Neuronal competition and selection during memory formation. *Science*, 316(5823), 457-460.

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -524,9 +524,11 @@ def run_excitability_demotion(
     Demotes active notes whose decayed hotness fell below threshold (and
     never-used notes older than 90 days) to dormant, and re-promotes dormant
     notes whose hotness has risen back above threshold to active. Keeps the
-    status cache — which drives the ×1.15 search boost — in sync with the
-    note_usage signal. Updates note_metadata.status only; vault files are
-    NEVER modified.
+    status cache in sync with the note_usage signal. Since issue #64 removed the
+    ×1.15 search boost, status no longer affects ranking; it now serves the
+    agent-linking convention (link preferentially to `active` notes) and the
+    `neurostack decay` report. Updates note_metadata.status only; vault files
+    are NEVER modified.
 
     Returns {"demoted": N, "paths": [...], "promoted": M, "promoted_paths": [...]}.
     """
@@ -674,7 +676,6 @@ ABLATABLE_SIGNALS = (
     "context",
     "hotness",
     "cooccurrence",
-    "excitability",
     "prediction_error",
     "lateral_inhibition",
 )
@@ -702,8 +703,8 @@ def hybrid_search(
 
     When ``explain`` is True, each returned SearchResult carries an ``explain``
     dict recording the per-stage score breakdown (base, link-section penalty,
-    convergence, context, hotness, co-occurrence, excitability, prediction-error,
-    lateral inhibition) — used to diagnose ranking (issue #41).
+    convergence, context, hotness, co-occurrence, prediction-error, lateral
+    inhibition) — used to diagnose ranking (issue #41).
 
     ``ablate`` is a set of signal names from ``ABLATABLE_SIGNALS``; any listed
     stage is skipped so the eval harness (issue #63) can measure each signal's
@@ -886,7 +887,7 @@ def hybrid_search(
             query_entities.update(r[0] for r in ent_rows)
 
     # Co-occurrence boost: notes containing entities that co-occur with query entities
-    # get a bounded multiplicative boost. Slots after hotness, before excitability.
+    # get a bounded multiplicative boost. Slots after hotness, before demotion.
     cooc_weight = cfg.cooccurrence_boost_weight
     if cooc_weight > 0 and query_entities and "cooccurrence" not in ablate:
                 # Step 2: Find co-occurring entities and their weights
@@ -936,40 +937,14 @@ def hybrid_search(
                                 _rec(r, cooccurrence_boost=round(boost, 4),
                                      after_cooccurrence=round(r["score"], 4))
 
-    # Excitability boost: notes with status=active get a 1.15x boost
-    # Mirrors CREB-mediated excitability windows where recently active
-    # neurons are preferentially recruited into new engrams.
-    # Reads from note_metadata (SQLite-owned) with frontmatter fallback.
+    # Excitability boost removed (issue #64). The flat ×1.15 for status='active'
+    # fired uniformly on a default install — status defaults to 'active' and is
+    # demoted only by the opt-in `neurostack decay --demote` timer — so it
+    # contributed no ranking signal while double-counting the recency already
+    # carried by the continuous hotness blend above. note_metadata.status is
+    # still maintained (for the agent-linking convention and the decay report);
+    # it just no longer multiplies search scores.
     meta_paths = [r["note_path"] for r in valid_results]
-    if "excitability" not in ablate:
-        if meta_paths:
-            placeholders = ",".join("?" * len(meta_paths))
-            meta_rows = conn.execute(
-                f"SELECT note_path, status FROM note_metadata"
-                f" WHERE note_path IN ({placeholders})",
-                meta_paths,
-            ).fetchall()
-            meta_status = {r["note_path"]: r["status"] for r in meta_rows}
-        else:
-            meta_status = {}
-
-        for r in valid_results:
-            status = meta_status.get(r["note_path"])
-            if status is None:
-                # Fallback: parse from notes.frontmatter
-                note_row = conn.execute(
-                    "SELECT frontmatter FROM notes WHERE path = ?",
-                    (r["note_path"],),
-                ).fetchone()
-                if note_row and note_row["frontmatter"]:
-                    try:
-                        fm = json.loads(note_row["frontmatter"])
-                        status = fm.get("status")
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-            if status == "active":
-                r["score"] *= 1.15
-                _rec(r, excitability_boost=1.15, after_excitability=round(r["score"], 4))
 
     # ── Prediction error demotion ──
     # Notes with unresolved prediction errors have previously "surprised" on

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -392,59 +392,6 @@ class TestDecayRunTracking:
         assert decay_hours_since() is None
 
 
-class TestExcitabilityBoost:
-    def test_active_notes_boost_fts_results(self, in_memory_db):
-        """Notes with status=active in frontmatter get higher scores."""
-        import json
-        conn = in_memory_db
-        # Insert two notes with same content but different status
-        conn.execute(
-            "INSERT INTO notes (path, title, frontmatter, "
-            "content_hash, updated_at) VALUES (?, ?, ?, ?, ?)",
-            ("active.md", "Active Note",
-             json.dumps({"status": "active"}), "a1", "2026-01-01"),
-        )
-        conn.execute(
-            "INSERT INTO notes (path, title, frontmatter, "
-            "content_hash, updated_at) VALUES (?, ?, ?, ?, ?)",
-            ("ref.md", "Reference Note",
-             json.dumps({"status": "reference"}), "r1", "2026-01-01"),
-        )
-        # Insert identical chunks so FTS scores are equal
-        for path in ["active.md", "ref.md"]:
-            conn.execute(
-                "INSERT INTO chunks (note_path, heading_path, "
-                "content, content_hash, position) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (path, "## Test", "unique_excitability_test_content",
-                 "h", 0),
-            )
-        conn.commit()
-
-        # FTS search returns both — verify active gets boosted
-        results = fts_search(conn, "unique_excitability_test_content")
-        assert len(results) == 2
-
-    def test_active_status_parsed_from_frontmatter(self, in_memory_db):
-        """Verify frontmatter JSON is correctly parsed for status."""
-        import json
-        conn = in_memory_db
-        fm = {"status": "active", "tags": ["test"]}
-        conn.execute(
-            "INSERT INTO notes (path, title, frontmatter, "
-            "content_hash, updated_at) VALUES (?, ?, ?, ?, ?)",
-            ("test.md", "Test", json.dumps(fm), "h", "2026-01-01"),
-        )
-        conn.commit()
-
-        row = conn.execute(
-            "SELECT frontmatter FROM notes WHERE path = ?",
-            ("test.md",),
-        ).fetchone()
-        parsed = json.loads(row["frontmatter"])
-        assert parsed["status"] == "active"
-
-
 def _fake_embedding(val: float = 0.5, dim: int = 768) -> bytes:
     """Create a fake embedding blob for testing."""
     return struct.pack(f"{dim}f", *([val] * dim))


### PR DESCRIPTION
Closes #64. Stacked on #68 (#63) — retarget to `main` once #68 merges.

## What

Removes the `×1.15` boost for `status: active` from `hybrid_search` (Option A: let the continuous hotness blend carry recency). `note_metadata.status` is still maintained — it now only serves the agent-linking convention and the `neurostack decay` report, not ranking.

## Empirical validation (the #63 gate)

Ran the #63 ablation harness against a **consistent snapshot of the production index** (LXC 122, 612 notes / 8,688 embedded chunks) with the same embedder the index was built on (`embeddinggemma:300m`, 768-dim), k=5, 36 labelled queries:

```
config                recall@5     MRR    NDCG   Δrecall     Δmrr    Δndcg
full                     0.778   0.639   0.671
-excitability            0.764   0.639   0.662    +0.014   +0.000   +0.009
```

`Δ = full − ablated`. Removing excitability costs **+0.014 recall / 0 MRR / +0.009 NDCG** — and that entire delta is **one target on the single two-target query** ("memory engrams", `targets: [memory-engrams-research, engram-allocation-competition]`). One of those two notes is `status: active` and its rank-5/6 neighbour is not, so the flat boost keeps it in the top-5. That is the active/dormant coin-flip, not relevance signal.

Note the issue's "provably inert" framing was slightly off: this snapshot has **573 active / 38 dormant / 1 reference**, not a uniform 100% active, so the boost *does* discriminate — but only on `status`, a coarse binary proxy for the recency that the 30-day hotness curve already encodes continuously. It is a redundant duplicate of a signal the same run shows is, if anything, over-weighted (`-hotness` Δrecall **−0.222**; see #66). Removing the binary duplicate is the right call.

Cross-check: on this branch (excitability removed) the full pipeline scores **0.764 / 0.639 / 0.662** — identical to the `-excitability` ablation row above, confirming the removal is exactly the ablation.

**Merge note:** the gate was "neutral-or-better". The measured Δ is a hair positive (+0.014 recall) rather than clean ≤0, but it is single-query noise on a confounded label. Flagging it rather than rounding it away — your call on the gate.

## Test

`ruff` clean; full suite 544 passed (−2 removed `TestExcitabilityBoost` tests that asserted the boost yet never exercised the multiplier). `docs/neuroscience-appendix.md` updated: excitability marked `[retired]`, pipeline renumbered.