### PR TITLE
feat: community-partition staleness reporting + gated rebuild (#65)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -497,8 +497,13 @@ def main():
     comm_sub = p.add_subparsers(dest="communities_cmd")
 
     # communities build
-    comm_sub.add_parser(
+    p_b = comm_sub.add_parser(
         "build", help="Run attractor basin detection + LLM summaries",
+    )
+    p_b.add_argument(
+        "--if-stale", action="store_true",
+        help="Only rebuild when the partition has drifted past the staleness "
+        "thresholds (age/drift). No-ops when fresh — safe for a cron/timer.",
     )
 
     # communities query

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -273,6 +273,25 @@ def cmd_tiered(args):
 
 def cmd_communities(args):
     if args.communities_cmd == "build":
+        # --if-stale: only rebuild when the partition has drifted past the
+        # staleness thresholds — cheap enough for a cron/timer to call (#65).
+        if getattr(args, "if_stale", False):
+            from ..community import maybe_rebuild_communities
+            outcome = maybe_rebuild_communities(
+                summarize_url=args.summarize_url,
+                embed_url=args.embed_url,
+            )
+            if args.json:
+                print(json.dumps(outcome, indent=2, default=str))
+                return
+            if outcome["rebuilt"]:
+                print(
+                    f"Rebuilt: {outcome['coarse']} coarse, {outcome['fine']} fine"
+                    f" communities (trigger: {outcome['trigger']})."
+                )
+            else:
+                print(f"Partition fresh, skipped rebuild ({outcome['reason']}).")
+            return
         from ..attractor import detect_communities
         from ..community import summarize_all_communities
         n_coarse, n_fine = detect_communities()
@@ -304,9 +323,15 @@ def cmd_communities(args):
             summarize_url=args.summarize_url,
             workspace=_get_workspace(args),
         )
+        from ..community import community_build_status
+        result["community_build"] = community_build_status()
         if args.json:
             print(json.dumps(result, indent=2, default=str))
             return
+        cb = result["community_build"]
+        if cb.get("stale"):
+            print(f"\n\033[33m! Community partition stale:\033[0m {cb['reason']}")
+            print("  Rebuild for a current answer: neurostack communities build --if-stale")
         print(f"\nCommunities used: {result['communities_used']}")
         print("\nTop communities:")
         for hit in result["community_hits"][:5]:
@@ -448,8 +473,10 @@ def cmd_stats(args):
         "SELECT COUNT(DISTINCT note_path) as c FROM triples"
     ).fetchone()["c"]
 
+    from ..community import community_build_status
     from ..cooccurrence import get_cooccurrence_stats
     cooc = get_cooccurrence_stats(conn)
+    community = community_build_status(conn)
 
     if args.json:
         embed_pct = embedded * 100 // max(chunks, 1)
@@ -468,6 +495,7 @@ def cmd_stats(args):
             "triple_coverage": f"{triple_pct}%",
             "cooccurrence_pairs": cooc["pairs"],
             "cooccurrence_total_weight": cooc["total_weight"],
+            "community_build": community,
         }
         print(json.dumps(output, indent=2, default=str))
         return
@@ -496,6 +524,13 @@ def cmd_stats(args):
         f"Co-occurrence: {cooc['pairs']} pairs"
         f" ({cooc['total_weight']:.1f} total weight)"
     )
+    if community["built"]:
+        flag = " \033[33m[STALE]\033[0m" if community["stale"] else ""
+        print(f"Communities: {community['reason']}{flag}")
+        if community["stale"]:
+            print("  \033[33m!\033[0m Rebuild: neurostack communities build --if-stale")
+    else:
+        print("Communities: \033[33mnot built\033[0m — run: neurostack communities build")
 
 
 def cmd_prediction_errors(args):

--- a/src/neurostack/community.py
+++ b/src/neurostack/community.py
@@ -37,6 +37,128 @@ EMBED_URL = _cfg.embed_url
 SUMMARIZE_MODEL = _cfg.llm_model
 _LLM_HEADERS = _auth_headers(_cfg.llm_api_key)
 
+def community_build_status(conn=None) -> dict:
+    """Report how fresh the community partition is (issue #65).
+
+    ``detect_communities`` runs only from ``communities build`` / ``init``,
+    never in the index pipeline, so after notes are added or edited the
+    partition and its LLM summaries drift while ``vault_communities`` keeps
+    answering from the stale partition with no signal to the caller. This
+    surfaces the drift: when the partition was last built, how old that is, and
+    how many notes have changed since — plus a ``stale`` verdict against the
+    configured thresholds.
+
+    Returns a dict with: built, last_built, age_days, notes_total,
+    notes_changed_since, drift, stale, reason.
+    """
+    cfg = get_config()
+    if conn is None:
+        conn = get_db(DB_PATH)
+
+    n_communities = conn.execute("SELECT COUNT(*) FROM communities").fetchone()[0]
+    total_notes = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+    # community_level_stats.updated_at is written once per build; fall back to
+    # the communities table if the level-stats row is somehow absent.
+    last_built = conn.execute(
+        "SELECT MAX(updated_at) FROM community_level_stats"
+    ).fetchone()[0]
+    if last_built is None:
+        last_built = conn.execute(
+            "SELECT MAX(updated_at) FROM communities"
+        ).fetchone()[0]
+
+    if not n_communities or not last_built:
+        return {
+            "built": False,
+            "last_built": None,
+            "age_days": None,
+            "notes_total": total_notes,
+            "notes_changed_since": None,
+            "drift": None,
+            "stale": True,
+            "reason": "communities never built — run `neurostack communities build`",
+        }
+
+    changed = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE updated_at > ?", (last_built,)
+    ).fetchone()[0]
+    drift = changed / total_notes if total_notes else 0.0
+
+    age_days = None
+    try:
+        built_dt = datetime.fromisoformat(last_built)
+        if built_dt.tzinfo is None:
+            built_dt = built_dt.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - built_dt).total_seconds() / 86400.0
+    except (ValueError, TypeError):
+        pass
+
+    stale_age = age_days is not None and age_days > cfg.community_stale_age_days
+    stale_drift = drift > cfg.community_stale_drift
+    stale = stale_age or stale_drift
+
+    parts = []
+    if age_days is not None:
+        parts.append(f"built {age_days:.1f}d ago")
+    parts.append(f"{changed}/{total_notes} notes changed since ({drift * 100:.0f}%)")
+    reason = ", ".join(parts)
+    if stale:
+        drivers = []
+        if stale_age:
+            drivers.append(f">{cfg.community_stale_age_days:g}d old")
+        if stale_drift:
+            drivers.append(f">{cfg.community_stale_drift * 100:g}% drift")
+        reason = f"STALE ({', '.join(drivers)}): {reason}"
+
+    return {
+        "built": True,
+        "last_built": last_built,
+        "age_days": round(age_days, 2) if age_days is not None else None,
+        "notes_total": total_notes,
+        "notes_changed_since": changed,
+        "drift": round(drift, 4),
+        "stale": stale,
+        "reason": reason,
+    }
+
+
+def maybe_rebuild_communities(
+    conn=None,
+    *,
+    force: bool = False,
+    summarize_url: str | None = None,
+    embed_url: str | None = None,
+) -> dict:
+    """Rebuild the community partition when it has drifted past the staleness
+    thresholds (issue #65), or when ``force`` is set.
+
+    Cheap to call on a timer: it no-ops when the partition is fresh, so a cron
+    or the decay timer can invoke it every cadence without paying for a rebuild
+    on every note edit. Returns what it did.
+    """
+    from .attractor import detect_communities
+
+    status = community_build_status(conn)
+    if not force and not status["stale"]:
+        return {"rebuilt": False, "reason": status["reason"], "status": status}
+
+    n_coarse, n_fine = detect_communities(conn=conn)
+    # summarize_all_communities defaults its URLs to module constants — only
+    # forward overrides, never a None that would clobber the default.
+    summ_kwargs = {}
+    if summarize_url is not None:
+        summ_kwargs["summarize_url"] = summarize_url
+    if embed_url is not None:
+        summ_kwargs["embed_url"] = embed_url
+    summarize_all_communities(conn=conn, **summ_kwargs)
+    return {
+        "rebuilt": True,
+        "coarse": n_coarse,
+        "fine": n_fine,
+        "trigger": "force" if force else status["reason"],
+    }
+
+
 COMMUNITY_PROMPT = (
     "You are summarizing a cluster of thematically"
     " related notes from a personal knowledge vault.\n"

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -63,6 +63,13 @@ class Config:
     # text attached. This is the weight given to the (normalized) summary score in
     # the blended note ranking; the triple score gets (1 - auto_summary_weight).
     auto_summary_weight: float = 0.5      # 0.0 = triples only, 1.0 = summaries only
+    # Community-detection staleness (issue #65): detect_communities runs only on
+    # `communities build` / `init`, never in the index pipeline, so the partition
+    # and its LLM summaries drift as notes are added or edited. These thresholds
+    # decide when vault_stats / vault_communities flag the partition stale and
+    # when `communities build --if-stale` triggers a rebuild.
+    community_stale_age_days: float = 14.0   # flag/rebuild if last build older than this
+    community_stale_drift: float = 0.10      # ...or if this fraction of notes changed since
     # Vault write-back (issue #20): opt-in persistence of qualifying memories as
     # markdown files under a quarantined directory (default ``.neurostack/``).
     # Off by default — the DB stays the source of truth; files are exports. Only
@@ -112,6 +119,10 @@ def load_config() -> Config:
             cfg.link_density_threshold = float(data["link_density_threshold"])
         if "auto_summary_weight" in data:
             cfg.auto_summary_weight = float(data["auto_summary_weight"])
+        if "community_stale_age_days" in data:
+            cfg.community_stale_age_days = float(data["community_stale_age_days"])
+        if "community_stale_drift" in data:
+            cfg.community_stale_drift = float(data["community_stale_drift"])
 
         # Write-back is configured under a [writeback] table.
         wb = data.get("writeback")
@@ -143,6 +154,8 @@ def load_config() -> Config:
         "NEUROSTACK_LINK_SECTION_PENALTY": ("link_section_penalty", float),
         "NEUROSTACK_LINK_DENSITY_THRESHOLD": ("link_density_threshold", float),
         "NEUROSTACK_AUTO_SUMMARY_WEIGHT": ("auto_summary_weight", float),
+        "NEUROSTACK_COMMUNITY_STALE_AGE_DAYS": ("community_stale_age_days", float),
+        "NEUROSTACK_COMMUNITY_STALE_DRIFT": ("community_stale_drift", float),
         "NEUROSTACK_WRITEBACK_ENABLED": ("writeback_enabled", bool),
         "NEUROSTACK_WRITEBACK_PATH": ("writeback_path", str),
         "NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS": (

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -363,10 +363,11 @@ def vault_communities(
         workspace: Optional vault subdirectory prefix to restrict
             results (e.g. "work/acme-cloud")
     """
+    from ..community import community_build_status
     from ..community_search import global_query
 
     _, embed_url = _cfg()
-    return global_query(
+    result = global_query(
         query=query,
         top_k=top_k,
         level=level,
@@ -374,11 +375,16 @@ def vault_communities(
         embed_url=embed_url,
         workspace=workspace,
     )
+    # Flag a drifted partition so the caller knows the answer may be built on a
+    # stale community map rather than silently trusting it (issue #65).
+    result["community_build"] = community_build_status()
+    return result
 
 
 @registry.tool(tags=["search", "stats"], annotations=_READ_ONLY)
 def vault_stats() -> dict:
     """Get index health: note count, embedding coverage, graph stats, triple stats."""
+    from ..community import community_build_status as _community_build_status
     from ..cooccurrence import get_cooccurrence_stats
     from ..memories import get_memory_stats
     from ..schema import DB_PATH, get_db
@@ -435,6 +441,7 @@ def vault_stats() -> dict:
             "SELECT COUNT(*) as c FROM communities WHERE summary IS NOT NULL"
         ).fetchone()["c"],
         "community_levels": _community_level_stats(conn),
+        "community_build": _community_build_status(conn),
         "excitability": {
             "active": dormancy["active_count"],
             "dormant": dormancy["dormant_count"],

--- a/tests/test_community_status.py
+++ b/tests/test_community_status.py
@@ -1,0 +1,148 @@
+"""Tests for community-partition staleness reporting + gated rebuild (issue #65)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from neurostack.community import community_build_status, maybe_rebuild_communities
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _seed_notes(conn, n: int, updated_at: str):
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?, ?, ?, ?)",
+            (f"notes/n{i}.md", f"N{i}", "h", updated_at),
+        )
+
+
+def _seed_build(conn, built_at: str, level_stats=True):
+    conn.execute(
+        "INSERT INTO communities (level, title, summary, updated_at) VALUES (0, 'C', 's', ?)",
+        (built_at,),
+    )
+    if level_stats:
+        conn.execute(
+            "INSERT INTO community_level_stats "
+            "(level, n_communities, min_size, max_size, mean_size, modularity, updated_at) "
+            "VALUES (0, 1, 1, 1, 1.0, 0.3, ?)",
+            (built_at,),
+        )
+
+
+class TestCommunityBuildStatus:
+    def test_never_built(self, in_memory_db):
+        _seed_notes(in_memory_db, 5, _iso(datetime.now(timezone.utc)))
+        in_memory_db.commit()
+        s = community_build_status(in_memory_db)
+        assert s["built"] is False
+        assert s["stale"] is True
+        assert "never built" in s["reason"]
+
+    def test_fresh_partition(self, in_memory_db):
+        now = datetime.now(timezone.utc)
+        # notes updated before the build; build is recent → not stale
+        _seed_notes(in_memory_db, 10, _iso(now - timedelta(days=1)))
+        _seed_build(in_memory_db, _iso(now))
+        in_memory_db.commit()
+        s = community_build_status(in_memory_db)
+        assert s["built"] is True
+        assert s["stale"] is False
+        assert s["notes_changed_since"] == 0
+        assert s["drift"] == 0.0
+
+    def test_stale_by_age(self, in_memory_db):
+        now = datetime.now(timezone.utc)
+        _seed_notes(in_memory_db, 10, _iso(now - timedelta(days=40)))
+        _seed_build(in_memory_db, _iso(now - timedelta(days=30)))  # > 14d default
+        in_memory_db.commit()
+        s = community_build_status(in_memory_db)
+        assert s["stale"] is True
+        assert s["age_days"] > 14
+        assert "old" in s["reason"]
+
+    def test_stale_by_drift(self, in_memory_db):
+        now = datetime.now(timezone.utc)
+        built = now - timedelta(days=1)
+        # 8 old + 2 changed-after-build of 10 = 20% drift > 10% default
+        _seed_notes(in_memory_db, 8, _iso(built - timedelta(days=1)))
+        for i in range(2):
+            in_memory_db.execute(
+                "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?, ?, ?, ?)",
+                (f"notes/new{i}.md", "new", "h", _iso(now)),
+            )
+        _seed_build(in_memory_db, _iso(built))
+        in_memory_db.commit()
+        s = community_build_status(in_memory_db)
+        assert s["notes_changed_since"] == 2
+        assert s["drift"] == pytest.approx(0.2)
+        assert s["stale"] is True
+        assert "drift" in s["reason"]
+
+    def test_falls_back_to_communities_timestamp(self, in_memory_db):
+        now = datetime.now(timezone.utc)
+        _seed_notes(in_memory_db, 5, _iso(now - timedelta(days=1)))
+        _seed_build(in_memory_db, _iso(now), level_stats=False)  # only communities row
+        in_memory_db.commit()
+        s = community_build_status(in_memory_db)
+        assert s["built"] is True
+        assert s["last_built"] is not None
+
+
+class TestMaybeRebuild:
+    def test_fresh_no_ops(self, in_memory_db, monkeypatch):
+        now = datetime.now(timezone.utc)
+        _seed_notes(in_memory_db, 10, _iso(now - timedelta(days=1)))
+        _seed_build(in_memory_db, _iso(now))
+        in_memory_db.commit()
+
+        called = {"detect": False}
+
+        def _detect(conn=None, db_path=None):
+            called["detect"] = True
+            return (1, 1)
+
+        monkeypatch.setattr("neurostack.attractor.detect_communities", _detect)
+        out = maybe_rebuild_communities(in_memory_db)
+        assert out["rebuilt"] is False
+        assert called["detect"] is False
+
+    def test_force_rebuilds(self, in_memory_db, monkeypatch):
+        now = datetime.now(timezone.utc)
+        _seed_notes(in_memory_db, 10, _iso(now - timedelta(days=1)))
+        _seed_build(in_memory_db, _iso(now))
+        in_memory_db.commit()
+
+        def _detect(conn=None, db_path=None):
+            return (3, 5)
+
+        monkeypatch.setattr("neurostack.attractor.detect_communities", _detect)
+        monkeypatch.setattr(
+            "neurostack.community.summarize_all_communities",
+            lambda *a, **k: None,
+        )
+        out = maybe_rebuild_communities(in_memory_db, force=True)
+        assert out["rebuilt"] is True
+        assert out["coarse"] == 3 and out["fine"] == 5
+        assert out["trigger"] == "force"
+
+    def test_stale_rebuilds(self, in_memory_db, monkeypatch):
+        now = datetime.now(timezone.utc)
+        _seed_notes(in_memory_db, 10, _iso(now - timedelta(days=40)))
+        _seed_build(in_memory_db, _iso(now - timedelta(days=30)))
+        in_memory_db.commit()
+
+        monkeypatch.setattr(
+            "neurostack.attractor.detect_communities",
+            lambda conn=None, db_path=None: (2, 4),
+        )
+        monkeypatch.setattr(
+            "neurostack.community.summarize_all_communities",
+            lambda *a, **k: None,
+        )
+        out = maybe_rebuild_communities(in_memory_db)
+        assert out["rebuilt"] is True
+        assert "old" in out["trigger"]


### PR DESCRIPTION
Closes #65.

## Problem

`detect_communities` runs only from `neurostack communities build` and `init` — it is absent from `watcher.py`, so it is not in the index pipeline. After any note add/edit the community partition and its LLM summaries go stale, and `vault_communities` answers from the out-of-date partition with no signal to the caller.

## What

- **`community.py: community_build_status(conn)`** — reports when the partition was last built (keyed off `MAX(community_level_stats.updated_at)`, falling back to `communities.updated_at`), its age in days, how many notes changed since, the drift fraction, and a `stale` verdict against configurable thresholds.
- **`community.py: maybe_rebuild_communities(force=…)`** — rebuilds only when stale (or forced). Cheap enough for a cron/decay-timer to call every cadence since it no-ops on a fresh partition (a full rebuild per edit is too expensive at scale, as the issue notes).
- **`config.py`** — `community_stale_age_days` (14) and `community_stale_drift` (0.10), TOML + env overridable.
- **`vault_stats` / `vault_communities`** (and the CLI `stats` / `communities query`) now include the build status, so a drifted partition reads as stale instead of current.
- **`neurostack communities build --if-stale`** — the threshold-gated rebuild entry point for a timer.

## Verified on the live index

Against a snapshot of the production DB (612 notes):

```json
{"built": true, "last_built": "2026-07-02T10:40:32+00:00", "age_days": 0.33,
 "notes_total": 612, "notes_changed_since": 7, "drift": 0.0114, "stale": false,
 "reason": "built 0.3d ago, 7/612 notes changed since (1%)"}
```

The current partition (modularity 0.327 coarse / 0.266 fine per the issue) is only ~5h old with 1% drift — so its weak modularity is a real property of this partition, not a staleness artifact. That helps disambiguate the open question in #66/#33.

## Test

8 new tests (`tests/test_community_status.py`): fresh / stale-by-age / stale-by-drift / never-built / fallback-timestamp / gated-noop / forced / stale-triggers-rebuild. `ruff` clean; full suite 533 passed.