### PR TITLE
fix: reindex no longer wipes note_metadata status/date_added

### DIFF
--- a/src/neurostack/watcher.py
+++ b/src/neurostack/watcher.py
@@ -163,10 +163,21 @@ def index_single_note(
 
     frontmatter_json = json.dumps(parsed.frontmatter, default=str)
 
-    # Update note
+    # Update the note row IN PLACE. Deliberately not INSERT OR REPLACE: with
+    # foreign_keys=ON, REPLACE deletes the existing row first, which cascades to
+    # note_metadata (ON DELETE CASCADE) and wipes its status/date_added BEFORE
+    # the upsert below can preserve them — a reindex of a changed note silently
+    # reset dormant->active and bumped date_added. ON CONFLICT UPDATE keeps the
+    # row so the cascade never fires. Chunks/summaries/triples are cleared
+    # explicitly further down, so nothing relied on the REPLACE cascade.
     conn.execute(
-        """INSERT OR REPLACE INTO notes (path, title, frontmatter, content_hash, updated_at)
-           VALUES (?, ?, ?, ?, ?)""",
+        """INSERT INTO notes (path, title, frontmatter, content_hash, updated_at)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(path) DO UPDATE SET
+             title = excluded.title,
+             frontmatter = excluded.frontmatter,
+             content_hash = excluded.content_hash,
+             updated_at = excluded.updated_at""",
         (parsed.path, parsed.title, frontmatter_json, parsed.content_hash, now),
     )
 
@@ -479,10 +490,17 @@ def _write_note_results(conn, result: dict, _has_vec: bool) -> None:
     triples = result["triples"]
     triple_embeddings = result["triple_embeddings"]
 
-    # Update note
+    # Update the note row IN PLACE — see index_single_note for why not REPLACE:
+    # REPLACE cascade-deletes note_metadata (status/date_added) before the upsert
+    # below can preserve it. ON CONFLICT UPDATE keeps the row.
     conn.execute(
-        """INSERT OR REPLACE INTO notes (path, title, frontmatter, content_hash, updated_at)
-           VALUES (?, ?, ?, ?, ?)""",
+        """INSERT INTO notes (path, title, frontmatter, content_hash, updated_at)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(path) DO UPDATE SET
+             title = excluded.title,
+             frontmatter = excluded.frontmatter,
+             content_hash = excluded.content_hash,
+             updated_at = excluded.updated_at""",
         (parsed.path, parsed.title, frontmatter_json, parsed.content_hash, now),
     )
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -199,3 +199,56 @@ class TestTripleRetryQueue:
         assert conn.execute(
             "SELECT COUNT(*) c FROM triples WHERE note_path=?", ("notes/a.md",)
         ).fetchone()["c"] == 1
+
+
+class TestReindexPreservesNoteMetadata:
+    """A reindex of a *changed* note must not wipe accumulated per-note state.
+
+    Regression: `INSERT OR REPLACE INTO notes` cascade-deleted the note_metadata
+    row (ON DELETE CASCADE) before the upsert could preserve it, so status reset
+    dormant->active and date_added was bumped on every reindex. The fix updates
+    the note row in place via ON CONFLICT so the cascade never fires.
+    """
+
+    def _write(self, path, body):
+        path.write_text(
+            "---\ndate: 2026-01-01\ntags: [x]\ntype: permanent\n---\n\n# N\n\n" + body + "\n"
+        )
+
+    def test_status_date_and_usage_survive_reindex(self, in_memory_db, tmp_path, monkeypatch):
+        import neurostack.watcher as w
+
+        # Avoid the embedder: chunk embeddings aren't needed to prove metadata survival.
+        monkeypatch.setattr(w, "get_embeddings_batch", lambda texts, **k: [None] * len(texts))
+        conn = in_memory_db
+        note = tmp_path / "n.md"
+        self._write(note, "original body")
+        w.index_single_note(note, tmp_path, conn, skip_summary=True, skip_triples=True)
+
+        # Accumulate state that only exists post-index: a demotion, a distinct
+        # date_added sentinel, and a usage row (hotness).
+        conn.execute(
+            "UPDATE note_metadata SET status='dormant', date_added='2020-12-25'"
+            " WHERE note_path='n.md'"
+        )
+        conn.execute("INSERT INTO note_usage(note_path,used_at) VALUES('n.md','2026-06-01')")
+        conn.commit()
+
+        # Edit the file so content_hash changes, forcing a real reindex.
+        self._write(note, "EDITED body now")
+        w.index_single_note(note, tmp_path, conn, skip_summary=True, skip_triples=True)
+
+        row = conn.execute(
+            "SELECT status, date_added FROM note_metadata WHERE note_path='n.md'"
+        ).fetchone()
+        assert row["status"] == "dormant", "reindex must preserve dormant status"
+        assert row["date_added"] == "2020-12-25", "reindex must preserve date_added"
+        # Hotness history (no FK, must be untouched)
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM note_usage WHERE note_path='n.md'"
+        ).fetchone()["c"] == 1
+        # ...and the content genuinely updated (chunks reflect the edit)
+        chunks = conn.execute(
+            "SELECT content FROM chunks WHERE note_path='n.md'"
+        ).fetchall()
+        assert any("EDITED" in c["content"] for c in chunks)


### PR DESCRIPTION
Found while investigating "does reindex lose stats?" before the #63–#65 merges.

## The bug

`index_single_note` and the full-index writer used `INSERT OR REPLACE INTO notes`. With `foreign_keys=ON` (set in `get_db`), `REPLACE` is DELETE-then-INSERT, and the DELETE cascades to `note_metadata` (`ON DELETE CASCADE`) — removing its row **before** the immediately-following `INSERT … ON CONFLICT(note_path) DO UPDATE` can preserve it. So the preserve branch never fires and a fresh row lands with `status='active'`.

**Effect:** every reindex of a *changed* note silently reset `dormant → active` and bumped `date_added`, contradicting the code comment that claimed both were preserved. Verified empirically (`dormant → active`, `date_added` reset).

## What was *not* affected

`note_usage` (hotness) and `prediction_errors` have **no** foreign key and are never deleted anywhere — they survive reindex (verified). The `entity_cooccurrence` reset on full reindex is a separate, already-tracked issue (#60).

## Fix

Update the note row in place via `ON CONFLICT(path) DO UPDATE SET …` at both write sites — no cascade fires, so `note_metadata` survives and its own upsert preserves `status`/`date_added` as intended. Chunks are deleted explicitly (`DELETE FROM chunks`), summaries/triples are upserted per-note, so nothing relied on the old REPLACE cascade.

## Test

New `TestReindexPreservesNoteMetadata` drives a real reindex of an edited note and asserts `status`, `date_added`, `note_usage`, and the content update all hold. `ruff` clean; full suite 526 passed.

Note: this is lower-severity once #64 lands (with the excitability boost gone, `status` no longer drives ranking) — but it's a real data-loss bug regardless, and cheap to fix.