### PR TITLE
Parametrize ranking-signal weights + coordinate-ascent tuner (#66)

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -435,6 +435,20 @@ def main():
         "--no-ablation", action="store_true",
         help="Report only the full-pipeline metrics, skip the per-signal sweep",
     )
+    p.add_argument(
+        "--tune", action="store_true",
+        help="Coordinate-ascent weight tuning (issue #66) instead of the ablation "
+        "table. Tunes on a train split, reports out-of-sample on the holdout.",
+    )
+    p.add_argument(
+        "--tune-metric", default="ndcg", choices=("recall", "mrr", "ndcg"),
+        help="Objective the weight sweep maximises (default: ndcg)",
+    )
+    p.add_argument(
+        "--no-holdout", action="store_true",
+        help="Tune on the full query set with no train/test split. Faster, but the "
+        "reported gain is in-sample — never commit a weight on this alone.",
+    )
     p.set_defaults(func=cmd_eval)
 
     # ask

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -114,6 +114,11 @@ def cmd_eval(args):
             print("  Run with --refresh-embeddings (live embedder) or pass --live.")
             raise SystemExit(1)
 
+    # Weight tuning (issue #66) — coordinate ascent instead of the ablation table.
+    if getattr(args, "tune", False):
+        _run_tune(args, queries, db_path, cache)
+        return
+
     rows = ev.run_eval(
         queries,
         db_path=db_path,
@@ -128,6 +133,54 @@ def cmd_eval(args):
         return
     print(f"\n  {len(queries)} queries · db={db_path} · k={args.top_k}\n")
     print(ev.format_table(rows, args.top_k))
+
+
+def _run_tune(args, queries, db_path, cache):
+    """Coordinate-ascent weight tuning (issue #66).
+
+    Tunes on the train half and reports the holdout (out-of-sample) score, which
+    is the number that gates committing a weight. ``--no-holdout`` tunes on the
+    full set — faster, but the reported gain is in-sample only.
+    """
+    from .. import tune as tn
+
+    if args.no_holdout:
+        train, holdout = queries, None
+    else:
+        train, holdout = tn.interleaved_split(queries)
+
+    result = tn.coordinate_ascent(
+        train,
+        db_path=db_path,
+        k=args.top_k,
+        metric=args.tune_metric,
+        cache=cache,
+        embed_url=args.embed_url,
+    )
+
+    if args.json:
+        out = {
+            "metric": result.metric,
+            "k": args.top_k,
+            "n_evals": result.n_evals,
+            "rounds": result.rounds,
+            "train_baseline": round(result.baseline_score, 4),
+            "train_tuned": round(result.best_score, 4),
+            "changed_weights": {k: list(v) for k, v in result.changed_params.items()},
+            "tuned_weights": vars(result.best_weights),
+            "history": result.history,
+        }
+        print(json.dumps(out, indent=2, default=str))
+        return
+
+    n = len(queries)
+    split_note = "full set (in-sample only)" if args.no_holdout else \
+        f"{len(train)} train / {len(holdout)} test"
+    print(f"\n  weight tuning · {n} queries ({split_note}) · db={db_path} · k={args.top_k}\n")
+    print(tn.format_tune_report(
+        result, holdout=holdout, db_path=db_path, k=args.top_k,
+        cache=cache, embed_url=args.embed_url,
+    ))
 
 
 def cmd_ask(args):

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -170,6 +170,16 @@ def _run_tune(args, queries, db_path, cache):
             "tuned_weights": vars(result.best_weights),
             "history": result.history,
         }
+        # The out-of-sample score is the number that gates committing a weight, so
+        # emit it here too — not just on the human-readable path.
+        if holdout is not None:
+            base_h, tuned_h = tn.holdout_scores(
+                result, holdout, db_path=db_path, k=args.top_k,
+                cache=cache, embed_url=args.embed_url,
+            )
+            out["test_baseline"] = round(base_h, 4)
+            out["test_tuned"] = round(tuned_h, 4)
+            out["test_delta"] = round(tuned_h - base_h, 4)
         print(json.dumps(out, indent=2, default=str))
         return
 

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -58,6 +58,16 @@ class Config:
     link_section_penalty: float = 0.5     # score multiplier for link-list chunk matches
     link_density_threshold: float = 0.5   # chunk is a "link section" when this fraction
                                           # or more of its characters are wiki-link markup
+    # Ranking-signal weights (issue #66). Scalars that hybrid_search blends on top
+    # of the base FTS+cosine score. These four were hardcoded in search.py before
+    # #66; the defaults reproduce that exact behaviour. A weight sweep
+    # (RankingWeights + the tune harness) varies them against the eval metrics
+    # (recall@k / MRR / NDCG), and a validated set can be pinned here or via env.
+    convergence_weight: float = 0.3       # blend: score = (1-w)*score + w*convergence
+    hotness_weight: float = 0.2           # blend: score = (1-w)*score + w*hotness
+    inhibition_threshold: float = 0.65    # suppress a result only when its cosine sim to a
+                                          # higher-ranked result exceeds this
+    inhibition_strength: float = 0.30     # max fractional score reduction at sim = 1.0
     # Auto-router merge (issue #58): depth="auto" merges the triple ranking with
     # an independent summary search instead of returning triple order with summary
     # text attached. This is the weight given to the (normalized) summary score in
@@ -89,6 +99,40 @@ class Config:
         return self.db_dir / "sessions.db"
 
 
+@dataclass(frozen=True)
+class RankingWeights:
+    """The tunable ranking-signal scalars ``hybrid_search`` blends on top of the
+    base FTS+cosine score (issue #66).
+
+    Defaults reproduce the production constants. Passing a ``RankingWeights`` to
+    ``hybrid_search(weights=...)`` overrides them for that call without touching
+    global config — the mechanism the weight-tuning sweep uses to evaluate a
+    candidate vector against the eval harness. Production callers pass nothing and
+    get :meth:`from_config`, which reads the operator's config.toml / env.
+    """
+
+    convergence_weight: float = 0.3
+    hotness_weight: float = 0.2
+    inhibition_threshold: float = 0.65
+    inhibition_strength: float = 0.30
+    cooccurrence_boost_weight: float = 0.1
+    link_section_penalty: float = 0.5
+    link_density_threshold: float = 0.5
+
+    @classmethod
+    def from_config(cls, cfg: "Config") -> "RankingWeights":
+        """Build the weight vector from a loaded :class:`Config`."""
+        return cls(
+            convergence_weight=cfg.convergence_weight,
+            hotness_weight=cfg.hotness_weight,
+            inhibition_threshold=cfg.inhibition_threshold,
+            inhibition_strength=cfg.inhibition_strength,
+            cooccurrence_boost_weight=cfg.cooccurrence_boost_weight,
+            link_section_penalty=cfg.link_section_penalty,
+            link_density_threshold=cfg.link_density_threshold,
+        )
+
+
 def load_config() -> Config:
     """Load config from TOML file, then apply env var overrides."""
     cfg = Config()
@@ -117,6 +161,10 @@ def load_config() -> Config:
             cfg.link_section_penalty = float(data["link_section_penalty"])
         if "link_density_threshold" in data:
             cfg.link_density_threshold = float(data["link_density_threshold"])
+        for key in ("convergence_weight", "hotness_weight",
+                    "inhibition_threshold", "inhibition_strength"):
+            if key in data:
+                setattr(cfg, key, float(data[key]))
         if "auto_summary_weight" in data:
             cfg.auto_summary_weight = float(data["auto_summary_weight"])
         if "community_stale_age_days" in data:
@@ -153,6 +201,10 @@ def load_config() -> Config:
         "NEUROSTACK_COOCCURRENCE_BOOST": ("cooccurrence_boost_weight", float),
         "NEUROSTACK_LINK_SECTION_PENALTY": ("link_section_penalty", float),
         "NEUROSTACK_LINK_DENSITY_THRESHOLD": ("link_density_threshold", float),
+        "NEUROSTACK_CONVERGENCE_WEIGHT": ("convergence_weight", float),
+        "NEUROSTACK_HOTNESS_WEIGHT": ("hotness_weight", float),
+        "NEUROSTACK_INHIBITION_THRESHOLD": ("inhibition_threshold", float),
+        "NEUROSTACK_INHIBITION_STRENGTH": ("inhibition_strength", float),
         "NEUROSTACK_AUTO_SUMMARY_WEIGHT": ("auto_summary_weight", float),
         "NEUROSTACK_COMMUNITY_STALE_AGE_DAYS": ("community_stale_age_days", float),
         "NEUROSTACK_COMMUNITY_STALE_DRIFT": ("community_stale_drift", float),

--- a/src/neurostack/eval.py
+++ b/src/neurostack/eval.py
@@ -28,8 +28,12 @@ import json
 import math
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .search import ABLATABLE_SIGNALS
+
+if TYPE_CHECKING:
+    from .config import RankingWeights
 
 
 @dataclass
@@ -219,8 +223,14 @@ def evaluate_config(
     db_path,
     k: int,
     embed_url: str | None = None,
+    weights: "RankingWeights | None" = None,
 ) -> ConfigResult:
-    """Run one configuration (a set of ablated signals) over every query."""
+    """Run one configuration (a set of ablated signals) over every query.
+
+    ``weights`` overrides the tunable ranking scalars for every ``hybrid_search``
+    call in this pass — how the tuner (issue #66) scores a candidate weight
+    vector. ``None`` uses the config defaults.
+    """
     from .search import hybrid_search
 
     per_query: list[dict] = []
@@ -234,6 +244,7 @@ def evaluate_config(
             context=q.context,
             ablate=ablate,
             record=False,
+            weights=weights,
         )
         ranked = [r.note_path for r in results]
         per_query.append(
@@ -268,11 +279,13 @@ def run_eval(
     embed_url: str | None = None,
     cache: dict[str, list[float]] | None = None,
     ablation: bool = True,
+    weights: "RankingWeights | None" = None,
 ) -> list[ConfigResult]:
     """Evaluate the full pipeline, then (optionally) each single-signal ablation.
 
     ``cache`` supplies query embeddings for offline replay; pass ``None`` to use
-    the live embedder configured on ``embed_url``.
+    the live embedder configured on ``embed_url``. ``weights`` overrides the
+    tunable ranking scalars for every config in the run (issue #66).
     """
     # Fail loud on an incomplete cache. hybrid_search swallows an embedding
     # error into a silent FTS-only fallback, which would quietly change the
@@ -293,7 +306,8 @@ def run_eval(
         rows: list[ConfigResult] = []
         for name, ablate in run_configs:
             res = evaluate_config(
-                queries, ablate, db_path=db_path, k=k, embed_url=embed_url
+                queries, ablate, db_path=db_path, k=k, embed_url=embed_url,
+                weights=weights,
             )
             res.name = name
             rows.append(res)

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-from .config import get_config
+from .config import RankingWeights, get_config
 
 log = logging.getLogger("neurostack")
 
@@ -692,6 +692,7 @@ def hybrid_search(
     explain: bool = False,
     ablate: set[str] | None = None,
     record: bool = True,
+    weights: RankingWeights | None = None,
 ) -> list[SearchResult]:
     """
     Hybrid search combining FTS5 and semantic similarity.
@@ -713,15 +714,22 @@ def hybrid_search(
     prediction-error logging. Pass ``record=False`` for a side-effect-free run:
     an ablation sweep re-runs the same query many times, and letting each run
     mutate usage/hotness would contaminate every subsequent configuration.
+
+    ``weights`` overrides the tunable ranking scalars (convergence / hotness
+    blends, lateral-inhibition threshold and strength, co-occurrence boost, link
+    penalties) for this call only, without touching global config — the mechanism
+    the weight-tuning sweep (issue #66) uses to score a candidate vector. Defaults
+    to :meth:`RankingWeights.from_config`, so production behaviour is unchanged.
     """
     from .schema import DB_PATH
 
     ablate = ablate or set()
     cfg = get_config()
+    weights = weights or RankingWeights.from_config(cfg)
     embed_url = embed_url or cfg.embed_url
     conn = get_db(db_path or DB_PATH)
-    link_section_penalty = cfg.link_section_penalty
-    link_density_threshold = cfg.link_density_threshold
+    link_section_penalty = weights.link_section_penalty
+    link_density_threshold = weights.link_density_threshold
 
     def _rec(r: dict, **fields) -> None:
         """Record a per-stage score breakdown onto a result when explain is on."""
@@ -846,8 +854,10 @@ def hybrid_search(
             chunk_sims = cosine_similarity_batch(query_embedding, chunk_matrix)
             sigma = float(np.std(chunk_sims))
             convergence = centroid_sim / (1.0 + sigma)
-            # Blend: keep 70% of existing score, add 30% convergence influence
-            r["score"] = 0.7 * r["score"] + 0.3 * convergence
+            # Blend: keep (1-w) of the existing score, add w of convergence
+            # influence (default w=0.3 → 0.7 score + 0.3 convergence).
+            cw = weights.convergence_weight
+            r["score"] = (1.0 - cw) * r["score"] + cw * convergence
             _rec(r, convergence=round(convergence, 4), after_convergence=round(r["score"], 4))
 
     # Apply context boost; track which notes are in-context for mismatch detection
@@ -864,13 +874,15 @@ def hybrid_search(
                 r["score"] *= 1.2
                 _rec(r, context_boost=1.2, after_context=round(r["score"], 4))
 
-    # Apply hotness blend: final_score = 0.8 * semantic + 0.2 * hotness
+    # Apply hotness blend: final_score = (1-w) * score + w * hotness
+    # (default w=0.2 → 0.8 score + 0.2 hotness).
     if "hotness" not in ablate:
+        hw = weights.hotness_weight
         hotness_map = batch_hotness_scores(conn, [r["note_path"] for r in valid_results])
         for r in valid_results:
             h = hotness_map.get(r["note_path"], 0.0)
             if h > 0.0:
-                r["score"] = 0.8 * r["score"] + 0.2 * h
+                r["score"] = (1.0 - hw) * r["score"] + hw * h
                 _rec(r, hotness=round(h, 4), after_hotness=round(r["score"], 4))
 
     # Extract query-matched entities (used for co-occurrence boost AND reinforcement)
@@ -888,7 +900,7 @@ def hybrid_search(
 
     # Co-occurrence boost: notes containing entities that co-occur with query entities
     # get a bounded multiplicative boost. Slots after hotness, before demotion.
-    cooc_weight = cfg.cooccurrence_boost_weight
+    cooc_weight = weights.cooccurrence_boost_weight
     if cooc_weight > 0 and query_entities and "cooccurrence" not in ablate:
                 # Step 2: Find co-occurring entities and their weights
                 cooc_entities = {}  # entity -> max co-occurrence weight
@@ -1005,8 +1017,10 @@ def hybrid_search(
     # maximally similar results retain 70% of their score.
     #
     # penalty = 1 - inhibition_strength * max_similarity_to_higher_ranked
-    INHIBITION_THRESHOLD = 0.65   # only suppress when note embeddings are >0.65 similar
-    INHIBITION_STRENGTH = 0.30    # max 30% score reduction at similarity=1.0
+    # Defaults (threshold 0.65, strength 0.30) live in RankingWeights / config;
+    # the weight sweep (issue #66) tunes them against the eval harness.
+    INHIBITION_THRESHOLD = weights.inhibition_threshold  # suppress above this cosine sim
+    INHIBITION_STRENGTH = weights.inhibition_strength    # max fractional reduction at sim=1.0
     if len(deduped) > 1 and "lateral_inhibition" not in ablate:
         # Build embedding lookup for deduped results
         deduped_embeddings = []

--- a/src/neurostack/tune.py
+++ b/src/neurostack/tune.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Weight tuning for the ranking signals (issue #66).
+
+Coordinate ascent over :class:`RankingWeights` against the eval harness
+(``recall@k`` / ``MRR`` / ``NDCG``). Sweep one signal's scalar while the rest
+are held fixed, keep the value that most improves the objective, iterate over
+signals until a full round makes no accepted change.
+
+This is deliberately the cheapest, most interpretable optimiser in the strategy
+shortlist: it reuses ``evaluate_config`` verbatim, needs only numpy-free stdlib,
+and every accepted step is a single scalar move you can read off the history.
+It cannot see interactions two signals only exhibit jointly — that is what a
+grid / random / Bayesian pass (a later strategy) is for.
+
+**Gate, not a shipping path.** A tuned vector out of here is a *candidate*. Do
+not pin it to config until it clears the label-quality pass and an out-of-sample
+check — a 36-query set overfits trivially. :func:`interleaved_split` +
+:func:`evaluate_weights` give the honest train/test read; the tuner optimises on
+train only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from .config import RankingWeights
+from .eval import EvalQuery, cached_query_embeddings, evaluate_config
+
+# Per-parameter candidate grids. Centred on the production defaults so the
+# baseline is always reachable (coordinate ascent can decline to move). Kept
+# small — coordinate ascent visits |params| × |grid| configs per round.
+DEFAULT_GRIDS: dict[str, list[float]] = {
+    # Convergence spans the full [0, 1] — the #66 snapshot sweep found its clean
+    # optimum well past 0.6, so a grid capped there would silently under-move it.
+    "convergence_weight": [0.0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9, 1.0],
+    "hotness_weight": [0.0, 0.1, 0.2, 0.3, 0.4],
+    "inhibition_threshold": [0.55, 0.65, 0.75, 0.85, 0.95],
+    "inhibition_strength": [0.0, 0.15, 0.3, 0.45],
+    "cooccurrence_boost_weight": [0.0, 0.05, 0.1, 0.2],
+    "link_section_penalty": [0.3, 0.5, 0.7, 1.0],
+}
+
+# Order signals are swept in each round: strongest-known-effect first so an
+# early round already captures most of the available lift (ablation memory 1196:
+# convergence is the strongest positive, lateral inhibition the cleanest tuning
+# target). Order only affects the path, not the reachable set.
+DEFAULT_ORDER: tuple[str, ...] = (
+    "convergence_weight",
+    "inhibition_strength",
+    "inhibition_threshold",
+    "hotness_weight",
+    "cooccurrence_boost_weight",
+    "link_section_penalty",
+)
+
+METRICS = ("recall", "mrr", "ndcg")
+
+
+@dataclass
+class TuneResult:
+    """Outcome of one coordinate-ascent run."""
+
+    metric: str
+    baseline_weights: RankingWeights
+    baseline_score: float
+    best_weights: RankingWeights
+    best_score: float
+    rounds: int
+    n_evals: int
+    history: list[dict] = field(default_factory=list)
+
+    @property
+    def improved(self) -> bool:
+        return self.best_score > self.baseline_score
+
+    @property
+    def changed_params(self) -> dict[str, tuple[float, float]]:
+        """Params whose tuned value differs from the baseline: name → (from, to)."""
+        out: dict[str, tuple[float, float]] = {}
+        for f in RankingWeights.__dataclass_fields__:
+            a = getattr(self.baseline_weights, f)
+            b = getattr(self.best_weights, f)
+            if a != b:
+                out[f] = (a, b)
+        return out
+
+
+def evaluate_weights(
+    queries: list[EvalQuery],
+    weights: RankingWeights,
+    *,
+    db_path,
+    k: int = 5,
+    metric: str = "ndcg",
+    embed_url: str | None = None,
+) -> float:
+    """Score one weight vector over a query set (full pipeline, no ablation).
+
+    Assumes any offline embedding cache is already patched in by the caller (the
+    tuner patches once around the whole ascent rather than per candidate).
+    """
+    res = evaluate_config(
+        queries, set(), db_path=db_path, k=k, embed_url=embed_url, weights=weights
+    )
+    return _score(res, metric)
+
+
+def _score(res, metric: str) -> float:
+    if metric not in METRICS:
+        raise ValueError(f"metric must be one of {METRICS}, got {metric!r}")
+    return getattr(res, metric)
+
+
+def interleaved_split(
+    queries: list[EvalQuery],
+) -> tuple[list[EvalQuery], list[EvalQuery]]:
+    """Deterministic train/test split by even/odd position.
+
+    Index-based (no RNG) so a run is reproducible and diffable. Even indices →
+    train (tune on these), odd → test (report out-of-sample). Interleaving keeps
+    the four categories balanced across both halves better than a slice would.
+    """
+    train = [q for i, q in enumerate(queries) if i % 2 == 0]
+    test = [q for i, q in enumerate(queries) if i % 2 == 1]
+    return train, test
+
+
+def coordinate_ascent(
+    queries: list[EvalQuery],
+    *,
+    db_path,
+    k: int = 5,
+    metric: str = "ndcg",
+    cache: dict[str, list[float]] | None = None,
+    embed_url: str | None = None,
+    init: RankingWeights | None = None,
+    grids: dict[str, list[float]] | None = None,
+    order: tuple[str, ...] | None = None,
+    max_rounds: int = 4,
+    epsilon: float = 1e-6,
+) -> TuneResult:
+    """Coordinate ascent over ``RankingWeights``, maximising ``metric``.
+
+    Optimises on ``queries`` — pass the *train* split, not the whole set. Returns
+    a :class:`TuneResult`; the caller is responsible for the out-of-sample check
+    before trusting the tuned vector.
+    """
+    if metric not in METRICS:
+        raise ValueError(f"metric must be one of {METRICS}, got {metric!r}")
+
+    grids = grids or DEFAULT_GRIDS
+    order = order or DEFAULT_ORDER
+    baseline = init or RankingWeights()
+
+    # Fail loud on an incomplete cache — the same guarantee run_eval gives, so a
+    # sweep never silently degrades to FTS-only for an unseen query.
+    if cache is not None:
+        missing = [q.query for q in queries if q.query not in cache]
+        if missing:
+            raise KeyError(
+                f"No cached embedding for {len(missing)} quer"
+                f"{'y' if len(missing) == 1 else 'ies'} (e.g. {missing[0]!r}). "
+                f"Rebuild the cache with `neurostack eval --refresh-embeddings`."
+            )
+
+    history: list[dict] = []
+    state = {"evals": 0}
+
+    def _eval(w: RankingWeights) -> float:
+        state["evals"] += 1
+        return evaluate_weights(
+            queries, w, db_path=db_path, k=k, metric=metric, embed_url=embed_url
+        )
+
+    def _run() -> tuple[RankingWeights, float, int]:
+        current = baseline
+        current_score = _eval(current)
+        base_score = current_score
+        rounds_done = 0
+        for round_i in range(max_rounds):
+            improved_this_round = False
+            for param in order:
+                if param not in grids:
+                    continue
+                cur_val = getattr(current, param)
+                best_val = cur_val
+                best_score = current_score
+                for val in grids[param]:
+                    if val == cur_val:
+                        continue
+                    cand = replace(current, **{param: val})
+                    sc = _eval(cand)
+                    history.append(
+                        {
+                            "round": round_i,
+                            "param": param,
+                            "value": val,
+                            "score": round(sc, 5),
+                            "accepted": sc > best_score + epsilon,
+                        }
+                    )
+                    if sc > best_score + epsilon:
+                        best_score = sc
+                        best_val = val
+                if best_val != cur_val:
+                    current = replace(current, **{param: best_val})
+                    current_score = best_score
+                    improved_this_round = True
+            rounds_done = round_i + 1
+            if not improved_this_round:
+                break
+        return current, current_score, rounds_done, base_score
+
+    if cache is not None:
+        with cached_query_embeddings(cache):
+            best_w, best_s, rounds_done, base_s = _run()
+    else:
+        best_w, best_s, rounds_done, base_s = _run()
+
+    return TuneResult(
+        metric=metric,
+        baseline_weights=baseline,
+        baseline_score=base_s,
+        best_weights=best_w,
+        best_score=best_s,
+        rounds=rounds_done,
+        n_evals=state["evals"],
+        history=history,
+    )
+
+
+def format_tune_report(
+    result: TuneResult,
+    *,
+    holdout: list[EvalQuery] | None = None,
+    db_path=None,
+    k: int = 5,
+    cache: dict[str, list[float]] | None = None,
+    embed_url: str | None = None,
+) -> str:
+    """Human-readable summary: baseline vs tuned, changed params, and — if a
+    holdout set is given — the out-of-sample score for both, which is the number
+    that actually decides whether a tuned vector is worth committing."""
+    lines: list[str] = []
+    lines.append(f"  objective: {result.metric}@{k}  ·  {result.n_evals} evals · "
+                 f"{result.rounds} round(s)")
+    lines.append("")
+    lines.append(f"  train {result.metric}:  baseline {result.baseline_score:.4f}  "
+                 f"→  tuned {result.best_score:.4f}  "
+                 f"(Δ {result.best_score - result.baseline_score:+.4f})")
+
+    if holdout is not None and db_path is not None:
+        def _holdout_score(w: RankingWeights) -> float:
+            if cache is not None:
+                with cached_query_embeddings(cache):
+                    return evaluate_weights(
+                        holdout, w, db_path=db_path, k=k,
+                        metric=result.metric, embed_url=embed_url,
+                    )
+            return evaluate_weights(
+                holdout, w, db_path=db_path, k=k,
+                metric=result.metric, embed_url=embed_url,
+            )
+
+        base_h = _holdout_score(result.baseline_weights)
+        tuned_h = _holdout_score(result.best_weights)
+        lines.append(f"  test  {result.metric}:  baseline {base_h:.4f}  "
+                     f"→  tuned {tuned_h:.4f}  (Δ {tuned_h - base_h:+.4f})   ← out-of-sample")
+
+    lines.append("")
+    changed = result.changed_params
+    if not changed:
+        lines.append("  tuned vector == baseline (no scalar move improved the objective).")
+    else:
+        lines.append("  changed weights:")
+        for name, (a, b) in changed.items():
+            lines.append(f"    {name:<28} {a:>6} → {b:<6}")
+    return "\n".join(lines)

--- a/src/neurostack/tune.py
+++ b/src/neurostack/tune.py
@@ -21,10 +21,16 @@ train only.
 """
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass, field, replace
 
 from .config import RankingWeights
 from .eval import EvalQuery, cached_query_embeddings, evaluate_config
+
+
+def _cache_ctx(cache: dict[str, list[float]] | None):
+    """Patch in the offline query-embedding cache, or a no-op context in live mode."""
+    return cached_query_embeddings(cache) if cache is not None else contextlib.nullcontext()
 
 # Per-parameter candidate grids. Centred on the production defaults so the
 # baseline is always reachable (coordinate ascent can decline to move). Kept
@@ -172,7 +178,7 @@ def coordinate_ascent(
             queries, w, db_path=db_path, k=k, metric=metric, embed_url=embed_url
         )
 
-    def _run() -> tuple[RankingWeights, float, int]:
+    def _run() -> tuple[RankingWeights, float, int, float]:
         current = baseline
         current_score = _eval(current)
         base_score = current_score
@@ -211,10 +217,7 @@ def coordinate_ascent(
                 break
         return current, current_score, rounds_done, base_score
 
-    if cache is not None:
-        with cached_query_embeddings(cache):
-            best_w, best_s, rounds_done, base_s = _run()
-    else:
+    with _cache_ctx(cache):
         best_w, best_s, rounds_done, base_s = _run()
 
     return TuneResult(
@@ -227,6 +230,27 @@ def coordinate_ascent(
         n_evals=state["evals"],
         history=history,
     )
+
+
+def holdout_scores(
+    result: TuneResult,
+    holdout: list[EvalQuery],
+    *,
+    db_path,
+    k: int = 5,
+    cache: dict[str, list[float]] | None = None,
+    embed_url: str | None = None,
+) -> tuple[float, float]:
+    """Out-of-sample (baseline, tuned) scores for ``result.metric`` on a held-out
+    set. This is the number that gates committing a weight: the tuner optimised on
+    the train split, so the honest read is how the tuned vector does on queries it
+    never saw."""
+    with _cache_ctx(cache):
+        base = evaluate_weights(holdout, result.baseline_weights, db_path=db_path,
+                                k=k, metric=result.metric, embed_url=embed_url)
+        tuned = evaluate_weights(holdout, result.best_weights, db_path=db_path,
+                                 k=k, metric=result.metric, embed_url=embed_url)
+    return base, tuned
 
 
 def format_tune_report(
@@ -250,20 +274,8 @@ def format_tune_report(
                  f"(Δ {result.best_score - result.baseline_score:+.4f})")
 
     if holdout is not None and db_path is not None:
-        def _holdout_score(w: RankingWeights) -> float:
-            if cache is not None:
-                with cached_query_embeddings(cache):
-                    return evaluate_weights(
-                        holdout, w, db_path=db_path, k=k,
-                        metric=result.metric, embed_url=embed_url,
-                    )
-            return evaluate_weights(
-                holdout, w, db_path=db_path, k=k,
-                metric=result.metric, embed_url=embed_url,
-            )
-
-        base_h = _holdout_score(result.baseline_weights)
-        tuned_h = _holdout_score(result.best_weights)
+        base_h, tuned_h = holdout_scores(result, holdout, db_path=db_path, k=k,
+                                         cache=cache, embed_url=embed_url)
         lines.append(f"  test  {result.metric}:  baseline {base_h:.4f}  "
                      f"→  tuned {tuned_h:.4f}  (Δ {tuned_h - base_h:+.4f})   ← out-of-sample")
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -57,3 +57,38 @@ the vault is reorganised, re-verify with `vault_list_files` and adjust targets.
 Labels are a starting point — after the first real run, inspect misses
 (`--json` shows each query's top-k) and correct any target that is genuinely
 wrong before trusting the deltas for weight decisions.
+
+## Weight tuning (issue #66)
+
+The ranking scalars the ablation measures are now tunable, not hardcoded:
+`convergence_weight`, `hotness_weight`, `inhibition_threshold`,
+`inhibition_strength` (config.py / env), plus the existing co-occurrence and
+link-penalty weights. `RankingWeights` bundles them; `hybrid_search(weights=...)`
+overrides them per call without touching global config.
+
+`neurostack eval --tune` runs coordinate ascent over that vector against the
+harness — sweep one scalar, keep the best, iterate to convergence:
+
+```bash
+# Tune on a train split, report the held-out (out-of-sample) score
+neurostack eval --db /tmp/neurostack-copy.db --tune --tune-metric ndcg
+
+# Tune on the whole set (faster; the gain is in-sample only — do not commit on it)
+neurostack eval --db /tmp/neurostack-copy.db --tune --no-holdout
+```
+
+**A tuned vector is a candidate, not a shipping decision.** Two gates stand
+between the sweep and `config.py`:
+
+* **Label quality.** A signal that scores negative can be a *label* artifact, not
+  a ranking defect. Hotness is the standing example: `note_usage` reflects real
+  traffic, so hand-picked targets can be cold and the optimiser "wins" by
+  zeroing hotness. Decompose the gain — tune with the confounded signal frozen
+  (a custom `grids` without it) to isolate the committable part.
+* **Out of sample.** 36 queries overfit trivially. The holdout guards against
+  memorising specific queries, but not against a bias shared by the whole label
+  set (pinpoint-heavy labels under-value the diversity lateral inhibition buys).
+  Widen and rebalance the labels before trusting a large delta.
+
+The offline unit tests are `tests/test_tune.py`; the tuner is
+`src/neurostack/tune.py`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-from neurostack.config import Config, load_config
+from neurostack.config import Config, RankingWeights, load_config
 
 
 class TestConfig:
@@ -64,3 +64,72 @@ class TestLoadConfig:
         with patch("neurostack.config.CONFIG_PATH", config_file):
             cfg = load_config()
             assert cfg.embed_model == "nomic-embed-text"  # defaults
+
+
+class TestRankingWeights:
+    """Ranking-signal weights (issue #66): config plumbing + RankingWeights."""
+
+    def test_config_defaults_reproduce_prod_constants(self):
+        cfg = Config()
+        assert cfg.convergence_weight == 0.3
+        assert cfg.hotness_weight == 0.2
+        assert cfg.inhibition_threshold == 0.65
+        assert cfg.inhibition_strength == 0.30
+
+    def test_weights_defaults_match_config_defaults(self):
+        # A default RankingWeights and one built from a default Config must agree,
+        # or hybrid_search(weights=None) and hybrid_search(weights=RankingWeights())
+        # would diverge.
+        assert RankingWeights() == RankingWeights.from_config(Config())
+
+    def test_from_config_reads_fields(self):
+        cfg = Config(
+            convergence_weight=0.5,
+            hotness_weight=0.05,
+            inhibition_threshold=0.8,
+            inhibition_strength=0.15,
+            cooccurrence_boost_weight=0.2,
+            link_section_penalty=0.7,
+            link_density_threshold=0.6,
+        )
+        w = RankingWeights.from_config(cfg)
+        assert w.convergence_weight == 0.5
+        assert w.hotness_weight == 0.05
+        assert w.inhibition_threshold == 0.8
+        assert w.inhibition_strength == 0.15
+        assert w.cooccurrence_boost_weight == 0.2
+        assert w.link_section_penalty == 0.7
+        assert w.link_density_threshold == 0.6
+
+    def test_weights_are_frozen(self):
+        import dataclasses
+
+        import pytest
+        w = RankingWeights()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            w.convergence_weight = 0.9  # type: ignore[misc]
+
+    def test_env_overrides(self):
+        env = {
+            "NEUROSTACK_CONVERGENCE_WEIGHT": "0.42",
+            "NEUROSTACK_HOTNESS_WEIGHT": "0.11",
+            "NEUROSTACK_INHIBITION_THRESHOLD": "0.7",
+            "NEUROSTACK_INHIBITION_STRENGTH": "0.2",
+        }
+        with patch.dict(os.environ, env):
+            cfg = load_config()
+        assert cfg.convergence_weight == 0.42
+        assert cfg.hotness_weight == 0.11
+        assert cfg.inhibition_threshold == 0.7
+        assert cfg.inhibition_strength == 0.2
+
+    def test_toml_config(self, tmp_path):
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "convergence_weight = 0.25\ninhibition_strength = 0.15\n"
+        )
+        with patch("neurostack.config.CONFIG_PATH", config_file):
+            cfg = load_config()
+        assert cfg.convergence_weight == 0.25
+        assert cfg.inhibition_strength == 0.15
+        assert cfg.hotness_weight == 0.2  # untouched key keeps default

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -1,0 +1,193 @@
+"""Tests for neurostack.tune — coordinate-ascent weight tuning (issue #66).
+
+Three layers:
+  * ascent *mechanics* with a synthetic objective (monkeypatched) — no DB, so the
+    accept / decline / convergence logic is tested in isolation;
+  * the split helper and the input guards;
+  * a faithfulness pass on a real corpus proving the parametrized blends in
+    hybrid_search reduce to the old behaviour at their defaults, and to the
+    ablation no-op at weight 0.
+"""
+
+import numpy as np
+import pytest
+
+from neurostack import tune
+from neurostack.config import RankingWeights
+from neurostack.embedder import embedding_to_blob
+from neurostack.eval import EvalQuery, cached_query_embeddings
+from neurostack.schema import get_db
+from neurostack.search import hybrid_search
+
+# ── ascent mechanics (synthetic objective, no DB) ──────────────────────────
+
+
+def test_coordinate_ascent_moves_toward_optimum(monkeypatch):
+    # Objective peaks at convergence_weight = 0.45 (a grid point), flat elsewhere.
+    def fake_eval(queries, w, *, db_path, k, metric, embed_url=None):
+        return 1.0 - abs(w.convergence_weight - 0.45)
+
+    monkeypatch.setattr(tune, "evaluate_weights", fake_eval)
+    res = tune.coordinate_ascent(
+        [EvalQuery("q", ["t"])], db_path=None, metric="ndcg", cache=None
+    )
+    assert res.best_weights.convergence_weight == 0.45
+    assert res.best_score > res.baseline_score
+    assert res.changed_params == {"convergence_weight": (0.3, 0.45)}
+    assert res.n_evals > 0
+
+
+def test_coordinate_ascent_declines_when_baseline_optimal(monkeypatch):
+    # Flat objective: no candidate beats the baseline, so nothing is accepted and
+    # the ascent stops after a single unproductive round.
+    monkeypatch.setattr(tune, "evaluate_weights", lambda *a, **k: 0.5)
+    res = tune.coordinate_ascent([EvalQuery("q", ["t"])], db_path=None, cache=None)
+    assert not res.improved
+    assert res.changed_params == {}
+    assert res.rounds == 1
+
+
+def test_coordinate_ascent_reports_baseline_score(monkeypatch):
+    monkeypatch.setattr(tune, "evaluate_weights", lambda *a, **k: 0.73)
+    res = tune.coordinate_ascent([EvalQuery("q", ["t"])], db_path=None, cache=None)
+    assert res.baseline_score == pytest.approx(0.73)
+    assert res.best_score == pytest.approx(0.73)
+
+
+def test_bad_metric_raises():
+    with pytest.raises(ValueError, match="metric must be one of"):
+        tune.coordinate_ascent(
+            [EvalQuery("q", ["t"])], db_path=None, metric="f1", cache=None
+        )
+
+
+def test_cache_coverage_guard():
+    # A query with no cached embedding must fail loud, not silently degrade to
+    # FTS-only mid-sweep (the same guarantee run_eval gives).
+    with pytest.raises(KeyError, match="No cached embedding"):
+        tune.coordinate_ascent(
+            [EvalQuery("uncached", ["t"])], db_path=None, cache={}, metric="ndcg"
+        )
+
+
+# ── split helper ───────────────────────────────────────────────────────────
+
+
+def test_interleaved_split_even_odd():
+    qs = [EvalQuery(f"q{i}", ["t"]) for i in range(5)]
+    train, test = tune.interleaved_split(qs)
+    assert [q.query for q in train] == ["q0", "q2", "q4"]
+    assert [q.query for q in test] == ["q1", "q3"]
+
+
+# ── faithfulness on a real corpus ──────────────────────────────────────────
+
+DIM = 6
+
+
+def _axis(i: int, scale: float = 1.0) -> np.ndarray:
+    v = np.full(DIM, 0.03, dtype=np.float32)
+    v[i] = scale
+    return v
+
+
+@pytest.fixture
+def signal_corpus(tmp_path):
+    """A corpus that actually fires the parametrized signals:
+
+    * ``alpha`` has 3 chunks with slightly varied embeddings → the convergence
+      stage computes a real blend rather than short-circuiting on a single chunk;
+    * ``beta`` carries recorded usage → the hotness blend is non-zero;
+    * all notes share FTS vocabulary so the pre-filter returns every note and the
+      signals decide the order.
+    """
+    db_file = tmp_path / "signal.db"
+    conn = get_db(db_file)
+
+    def _add_note(path, title, chunk_vecs):
+        conn.execute(
+            "INSERT INTO notes (path, title, frontmatter, content_hash, updated_at) "
+            "VALUES (?, ?, '{}', 'h', '2026-01-01T00:00:00+00:00')",
+            (path, title),
+        )
+        for pos, vec in enumerate(chunk_vecs):
+            conn.execute(
+                "INSERT INTO chunks (note_path, heading_path, content, content_hash, "
+                "position, embedding) VALUES (?, ?, ?, 'h', ?, ?)",
+                (path, "", "signal ranking probe body text", pos,
+                 embedding_to_blob(vec)),
+            )
+        conn.execute(
+            "INSERT INTO note_metadata (note_path, status) VALUES (?, 'active')",
+            (path,),
+        )
+
+    _add_note("notes/alpha.md", "Alpha",
+              [_axis(0), _axis(0, 0.85) + _axis(2, 0.2), _axis(0, 0.7) + _axis(3, 0.25)])
+    _add_note("notes/beta.md", "Beta", [_axis(0, 0.9)])
+    _add_note("notes/gamma.md", "Gamma", [_axis(1)])
+
+    # Give beta recorded usage so its hotness blend is non-trivial.
+    for _ in range(4):
+        conn.execute("INSERT INTO note_usage (note_path) VALUES ('notes/beta.md')")
+    conn.commit()
+    conn.close()
+
+    query = "signal ranking probe alpha"
+    qvec = [float(x) for x in _axis(0, 0.95)]
+    return db_file, query, {query: qvec}
+
+
+def _scores(db_file, query, cache, **kwargs):
+    """Final per-note scores for one hybrid_search config, record-free."""
+    with cached_query_embeddings(cache):
+        results = hybrid_search(
+            query, top_k=10, db_path=db_file, record=False, **kwargs
+        )
+    return {r.note_path: round(r.score, 6) for r in results}
+
+
+def test_none_weights_equal_explicit_defaults(signal_corpus):
+    db_file, query, cache = signal_corpus
+    a = _scores(db_file, query, cache, weights=None)
+    b = _scores(db_file, query, cache, weights=RankingWeights())
+    assert a == b
+    assert len(a) == 3  # all three notes surfaced, so the blends really ran
+
+
+def test_convergence_weight_zero_equals_ablation(signal_corpus):
+    # Blending in 0×convergence must be identical to skipping the stage entirely.
+    db_file, query, cache = signal_corpus
+    zeroed = _scores(db_file, query, cache, weights=RankingWeights(convergence_weight=0.0))
+    ablated = _scores(db_file, query, cache, ablate={"convergence"})
+    assert zeroed == ablated
+
+
+def test_hotness_weight_zero_equals_ablation(signal_corpus):
+    db_file, query, cache = signal_corpus
+    zeroed = _scores(db_file, query, cache, weights=RankingWeights(hotness_weight=0.0))
+    ablated = _scores(db_file, query, cache, ablate={"hotness"})
+    assert zeroed == ablated
+
+
+def test_default_weights_differ_from_zeroed_signals(signal_corpus):
+    # Sanity: the signals are live on this corpus, so zeroing them actually moves
+    # scores — otherwise the equivalence tests above would be vacuous.
+    db_file, query, cache = signal_corpus
+    default = _scores(db_file, query, cache, weights=RankingWeights())
+    no_conv = _scores(db_file, query, cache, weights=RankingWeights(convergence_weight=0.0))
+    no_hot = _scores(db_file, query, cache, weights=RankingWeights(hotness_weight=0.0))
+    assert default != no_conv or default != no_hot
+
+
+def test_coordinate_ascent_end_to_end(signal_corpus):
+    # The real evaluate_config path, offline via the cache: must run, stay in
+    # range, and never return worse than baseline.
+    db_file, query, cache = signal_corpus
+    queries = [EvalQuery(query, ["notes/alpha"], category="pinpoint")]
+    res = tune.coordinate_ascent(
+        queries, db_path=db_file, k=5, cache=cache, metric="ndcg"
+    )
+    assert res.n_evals > 0
+    assert res.best_score >= res.baseline_score
+    assert 0.0 <= res.best_score <= 1.0

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -191,3 +191,15 @@ def test_coordinate_ascent_end_to_end(signal_corpus):
     assert res.n_evals > 0
     assert res.best_score >= res.baseline_score
     assert 0.0 <= res.best_score <= 1.0
+
+
+def test_holdout_scores_match_result_on_same_set(signal_corpus):
+    # holdout_scores must recompute the same metric the ascent recorded when the
+    # holdout is the set the tuner ran on — this is the out-of-sample number the
+    # CLI (human + --json) reports, so it has to be consistent.
+    db_file, query, cache = signal_corpus
+    queries = [EvalQuery(query, ["notes/alpha"], category="pinpoint")]
+    res = tune.coordinate_ascent(queries, db_path=db_file, k=5, cache=cache, metric="ndcg")
+    base, tuned = tune.holdout_scores(res, queries, db_path=db_file, k=5, cache=cache)
+    assert base == pytest.approx(res.baseline_score)
+    assert tuned == pytest.approx(res.best_score)


### PR DESCRIPTION
Prerequisite for weight tuning (#66). The scalars `hybrid_search` blends on top
of the base FTS+cosine score were hardcoded, so the eval harness could only
ablate a signal on/off — never sweep its weight. This makes them tunable and
adds the sweep, without changing production ranking.

## Changes

- **`config.py`** — `convergence_weight` (0.3), `hotness_weight` (0.2),
  `inhibition_threshold` (0.65), `inhibition_strength` (0.30) become config
  fields with TOML + env overrides. Defaults reproduce the prior constants.
- **`RankingWeights`** — a frozen bundle of all tunable ranking scalars, built
  from config via `from_config()`. `hybrid_search(weights=...)` overrides the
  vector per call without mutating global config.
- **`search.py`** — the convergence and hotness blends and the lateral-inhibition
  threshold/strength read from `weights`. The blends are rewritten as
  `(1-w)*score + w*signal`, identical to the old literals at the defaults.
- **`eval.py`** — `evaluate_config` / `run_eval` thread `weights` through.
- **`tune.py`** — coordinate ascent over `RankingWeights` against recall/MRR/NDCG,
  with an interleaved train/test split so a run reports out-of-sample.
- **CLI** — `neurostack eval --tune [--tune-metric ndcg] [--no-holdout]`.

## Faithfulness

Production behaviour is unchanged: defaults equal the old constants, and a test
pins that a weight of 0 reduces to the existing ablation no-op. Full suite green
(570), ruff clean.

## Not in this PR

No tuned weights. A sweep on a prod snapshot posts a large out-of-sample gain,
but it comes from two degenerate optima — zeroing hotness (the known
`note_usage` label confound) and pushing convergence to 1.0 (which discards the
base score, overfitting the 36 pinpoint queries). Committing a weight stays
gated on a label-quality pass and an honest out-of-sample check on a rebalanced
label set. That work continues under #66.

## Test plan

- `uv run pytest` — 570 passed
- `uv run ruff check src/ tests/` — clean
- `neurostack eval --tune` exercised end-to-end against a prod-DB snapshot