### PR TITLE
Implicit-feedback loop: learn ranking from real usage (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack record-usage "path1" "path2"` | Record note usage for hotness scoring |
 | `neurostack decay` | Report note excitability and dormancy |
 | `neurostack prediction-errors` | Show notes flagged as poor retrieval fit |
+| `neurostack feedback` | Show accumulated implicit-feedback stats — searches, uses, ranks (issue #66) |
 | `neurostack migrate write-back` | Export qualifying memories to markdown files (issue #20). `--dry-run` to preview |
 | `neurostack sync` | Reconcile write-back files against the DB (DB wins on conflict) |
 
@@ -192,6 +193,18 @@ Persist qualifying memories as markdown files under a quarantined dir. Configure
 | `writeback.include_observations` | `false` | `NEUROSTACK_WRITEBACK_INCLUDE_OBSERVATIONS` |
 
 Writes only inside `{vault_root}/<path>/memories/<type>/<YYYY-MM>/<uuid>.md`. Only persistent (no-TTL) `decision`/`convention`/`learning`/`bug` are written by default; `observation`/`context` need `include_observations`. The DB stays source of truth; `vault_writer.py` owns all file IO (it deliberately does **not** reuse `vault_write_file`, which commits to git). The dir self-ignores via its own `.gitignore`; NeuroStack never commits.
+
+### Implicit-feedback loop (issue #66, opt-in)
+
+When enabled, searches are logged and a subsequent deliberate use of a surfaced note (`vault_record_usage` / `vault_read_file`) is attributed back to the query, producing usage-grounded labels the tuner can learn from (`neurostack eval --feedback`). Off by default — turning it on adds a lightweight, failure-isolated write to the search and record-usage paths.
+
+| Key | Default | Env Override |
+|-----|---------|-------------|
+| `feedback_enabled` | `false` | `NEUROSTACK_FEEDBACK_ENABLED` |
+| `feedback_window_seconds` | `1800.0` | `NEUROSTACK_FEEDBACK_WINDOW_SECONDS` |
+| `feedback_log_retention` | `5000` | `NEUROSTACK_FEEDBACK_LOG_RETENTION` |
+
+Inspect accumulated feedback with `neurostack feedback`. The module is `src/neurostack/feedback.py`; data lives in the `search_log` and `search_feedback` tables (schema v18).
 
 ## Architecture
 

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -19,6 +19,7 @@ from .search import (
     cmd_cooccurrence,
     cmd_decay,
     cmd_eval,
+    cmd_feedback,
     cmd_folder_summaries,
     cmd_graph,
     cmd_prediction_errors,
@@ -489,7 +490,28 @@ def main():
         help="Also tune the hotness weight under --autolabel. Off by default: "
         "synthetic labels can't judge usage signals.",
     )
+    p.add_argument(
+        "--feedback", action="store_true",
+        help="Label from accumulated implicit feedback (issue #66) — real (query, "
+        "used-note) events. Unlike --autolabel these reflect usage, so hotness is tuned.",
+    )
+    p.add_argument(
+        "--feedback-min-count", type=int, default=1,
+        help="Min times a note must be chosen for a query to count as a target (default 1)",
+    )
+    p.add_argument(
+        "--feedback-max-age-days", type=float, default=None,
+        help="Only use feedback newer than this many days (default: all)",
+    )
     p.set_defaults(func=cmd_eval)
+
+    # feedback — inspect the implicit-feedback loop (issue #66)
+    p = sub.add_parser(
+        "feedback",
+        help="Show accumulated implicit-feedback stats (searches, uses, ranks)",
+    )
+    p.add_argument("--db", default=None, help="SQLite index to inspect (default: configured DB)")
+    p.set_defaults(func=cmd_feedback)
 
     # ask
     p = sub.add_parser("ask", help="Ask a question using vault content (RAG)")

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -450,7 +450,11 @@ def main():
         help="Tune on the full query set with no train/test split. Faster, but the "
         "reported gain is in-sample — never commit a weight on this alone.",
     )
-    p.add_argument(
+    # Label source: hand-written (default), generated from the vault (--autolabel),
+    # or from implicit feedback (--feedback). The latter two are exclusive — they
+    # differ on whether hotness is tuned, so combining them is ambiguous.
+    label_src = p.add_mutually_exclusive_group()
+    label_src.add_argument(
         "--autolabel", action="store_true",
         help="Generate the label set from the vault under test instead of a "
         "hand-written queries.yaml (issue #66) — makes the benchmark vault-agnostic.",
@@ -490,7 +494,7 @@ def main():
         help="Also tune the hotness weight under --autolabel. Off by default: "
         "synthetic labels can't judge usage signals.",
     )
-    p.add_argument(
+    label_src.add_argument(
         "--feedback", action="store_true",
         help="Label from accumulated implicit feedback (issue #66) — real (query, "
         "used-note) events. Unlike --autolabel these reflect usage, so hotness is tuned.",

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -93,6 +93,8 @@ def cmd_eval(args):
     # hand-written set. Auto-labels make the benchmark vault-agnostic — see #66.
     if getattr(args, "autolabel", False):
         queries, cache = _autolabel_queries(args, db_path, ev)
+    elif getattr(args, "feedback", False):
+        queries, cache = _feedback_queries(args, db_path, ev)
     else:
         queries, cache = _labelled_queries(args, ev)
 
@@ -175,6 +177,47 @@ def _autolabel_queries(args, db_path, ev):
     print(f"  Embedding queries from {args.embed_url} ...")
     cache = ev.build_embedding_cache(queries, embed_url=args.embed_url)
     return queries, cache
+
+
+def _feedback_queries(args, db_path, ev):
+    """Build labels from accumulated implicit feedback (issue #66). Unlike
+    auto-labels these reflect real usage, so hotness is tuned, not frozen."""
+    from .. import feedback as fb
+    from ..schema import get_db
+
+    conn = get_db(db_path)
+    queries = fb.feedback_labels(
+        conn, min_count=args.feedback_min_count, max_age_days=args.feedback_max_age_days
+    )
+    if not queries:
+        print("  No feedback labels found. Set feedback_enabled, let searches + "
+              "note uses accumulate, then retry (see `neurostack feedback`).")
+        raise SystemExit(1)
+    if len(queries) < 30:
+        print(f"  WARNING: only {len(queries)} feedback labels — too few to trust a "
+              "tuned weight. Treat any result as directional until more accumulates.")
+    print(f"  {len(queries)} feedback labels · db={db_path}")
+    print(f"  Embedding queries from {args.embed_url} ...")
+    cache = ev.build_embedding_cache(queries, embed_url=args.embed_url)
+    return queries, cache
+
+
+def cmd_feedback(args):
+    """Show accumulated implicit-feedback stats (issue #66)."""
+    from .. import feedback as fb
+    from ..schema import DB_PATH, get_db
+
+    db_path = Path(args.db) if args.db else DB_PATH
+    stats = fb.feedback_stats(get_db(db_path))
+    if args.json:
+        print(json.dumps(stats, indent=2))
+        return
+    print(f"\n  implicit feedback · db={db_path}\n")
+    for k, v in stats.items():
+        print(f"    {k:<24} {v}")
+    if stats["feedback_events"] == 0:
+        print("\n  Nothing captured yet. Enable feedback_enabled (config/env) so "
+              "searches and note uses are logged.")
 
 
 def _run_tune(args, queries, db_path, cache):

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -80,6 +80,13 @@ class Config:
     # when `communities build --if-stale` triggers a rebuild.
     community_stale_age_days: float = 14.0   # flag/rebuild if last build older than this
     community_stale_drift: float = 0.10      # ...or if this fraction of notes changed since
+    # Implicit-feedback loop (issue #66): when enabled, searches are logged and a
+    # subsequent deliberate use of a surfaced note is attributed back to the query,
+    # producing usage-grounded labels the tuner can learn from. Off by default —
+    # opting in adds a lightweight write to the search + record-usage paths.
+    feedback_enabled: bool = False
+    feedback_window_seconds: float = 1800.0  # a use counts as feedback if within this of the search
+    feedback_log_retention: int = 5000       # cap on retained search_log rows
     # Vault write-back (issue #20): opt-in persistence of qualifying memories as
     # markdown files under a quarantined directory (default ``.neurostack/``).
     # Off by default — the DB stays the source of truth; files are exports. Only
@@ -165,6 +172,12 @@ def load_config() -> Config:
                     "inhibition_threshold", "inhibition_strength"):
             if key in data:
                 setattr(cfg, key, float(data[key]))
+        if "feedback_enabled" in data:
+            cfg.feedback_enabled = bool(data["feedback_enabled"])
+        if "feedback_window_seconds" in data:
+            cfg.feedback_window_seconds = float(data["feedback_window_seconds"])
+        if "feedback_log_retention" in data:
+            cfg.feedback_log_retention = int(data["feedback_log_retention"])
         if "auto_summary_weight" in data:
             cfg.auto_summary_weight = float(data["auto_summary_weight"])
         if "community_stale_age_days" in data:
@@ -205,6 +218,9 @@ def load_config() -> Config:
         "NEUROSTACK_HOTNESS_WEIGHT": ("hotness_weight", float),
         "NEUROSTACK_INHIBITION_THRESHOLD": ("inhibition_threshold", float),
         "NEUROSTACK_INHIBITION_STRENGTH": ("inhibition_strength", float),
+        "NEUROSTACK_FEEDBACK_ENABLED": ("feedback_enabled", bool),
+        "NEUROSTACK_FEEDBACK_WINDOW_SECONDS": ("feedback_window_seconds", float),
+        "NEUROSTACK_FEEDBACK_LOG_RETENTION": ("feedback_log_retention", int),
         "NEUROSTACK_AUTO_SUMMARY_WEIGHT": ("auto_summary_weight", float),
         "NEUROSTACK_COMMUNITY_STALE_AGE_DAYS": ("community_stale_age_days", float),
         "NEUROSTACK_COMMUNITY_STALE_DRIFT": ("community_stale_drift", float),

--- a/src/neurostack/feedback.py
+++ b/src/neurostack/feedback.py
@@ -91,12 +91,22 @@ def attribute_use(conn, used_paths: list[str], window_seconds: float = 1800.0) -
             if path in shown:
                 rank = shown.index(path) + 1
                 try:
-                    conn.execute(
-                        "INSERT INTO search_feedback "
-                        "(query, chosen_path, shown_paths, rank) VALUES (?, ?, ?, ?)",
-                        (query, path, json.dumps(shown), rank),
-                    )
-                    written += 1
+                    # One logical use = one event. A read + a record-usage for the
+                    # same note (a normal RAG pairing), or re-opening it, must not
+                    # each add a row — skip if this (query, path) is already
+                    # recorded within the window.
+                    dup = conn.execute(
+                        "SELECT 1 FROM search_feedback WHERE query = ? AND "
+                        "chosen_path = ? AND created_at >= datetime('now', ?) LIMIT 1",
+                        (query, path, f"-{int(window_seconds)} seconds"),
+                    ).fetchone()
+                    if dup is None:
+                        conn.execute(
+                            "INSERT INTO search_feedback "
+                            "(query, chosen_path, shown_paths, rank) VALUES (?, ?, ?, ?)",
+                            (query, path, json.dumps(shown), rank),
+                        )
+                        written += 1
                 except Exception:
                     pass
                 break  # only the most recent surfacing search
@@ -106,6 +116,27 @@ def attribute_use(conn, used_paths: list[str], window_seconds: float = 1800.0) -
         except Exception:
             pass
     return written
+
+
+def capture_use(used_paths: list[str], conn=None) -> None:
+    """Opt-in, fully-guarded entry point for the read/usage hooks: attribute a
+    use only when ``feedback_enabled``. Never raises. When ``conn`` is omitted a
+    DB connection is opened lazily — but only after the enabled check, so a
+    default (disabled) deploy opens nothing.
+    """
+    try:
+        from .config import get_config
+
+        cfg = get_config()
+        if not cfg.feedback_enabled:
+            return
+        if conn is None:
+            from .schema import DB_PATH, get_db
+
+            conn = get_db(DB_PATH)
+        attribute_use(conn, used_paths, cfg.feedback_window_seconds)
+    except Exception:
+        pass  # feedback capture must never disrupt a read or a usage record
 
 
 # ── harvest (called from CLI — may raise) ──────────────────────────────────

--- a/src/neurostack/feedback.py
+++ b/src/neurostack/feedback.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Implicit-feedback loop for ranking (issue #66).
+
+Auto-generated labels (``autolabel``) reflect content, not behaviour, so they
+cannot judge usage signals like hotness. This closes that gap: capture which
+surfaced note a search actually led to being used, and turn those events into
+labels the tuner learns from — with hotness *unfrozen*, because the labels now
+reflect real usage.
+
+Flow:
+
+1. **log** — a search records ``(query, shown_paths)`` to ``search_log``.
+2. **attribute** — when a surfaced note is then deliberately used
+   (``vault_record_usage`` / ``vault_read_file``) within a window, that use is
+   attributed back to the most recent search that surfaced it, writing a
+   ``search_feedback`` event with the note's rank at search time.
+3. **harvest** — :func:`feedback_labels` aggregates events into an ``EvalQuery``
+   set for the existing eval / tune harness.
+
+Capture (steps 1-2) is opt-in (``feedback_enabled``, default off) and every
+capture call swallows its own errors — feedback must never disrupt search. The
+signal is position-biased (top results get used more just for being on top); the
+tuning framing absorbs the worst of it, since a use of an already-top result
+gives the ranker no gradient, but treat any tuned weight as a candidate, not a
+commit — the same #66 gate applies.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from .eval import EvalQuery
+
+log = logging.getLogger("neurostack")
+
+
+# ── capture (opt-in, on the hot path — must never raise) ───────────────────
+
+
+def log_search(conn, query: str, shown_paths: list[str], retention: int = 5000) -> None:
+    """Record what a search surfaced, for later attribution. Non-blocking."""
+    if not query or not shown_paths:
+        return
+    try:
+        cur = conn.execute(
+            "INSERT INTO search_log (query, shown_paths) VALUES (?, ?)",
+            (query, json.dumps(shown_paths)),
+        )
+        # Amortised pruning: keep the newest `retention` rows.
+        if retention and cur.lastrowid and cur.lastrowid % 200 == 0:
+            conn.execute(
+                "DELETE FROM search_log WHERE search_id NOT IN "
+                "(SELECT search_id FROM search_log ORDER BY search_id DESC LIMIT ?)",
+                (retention,),
+            )
+        conn.commit()
+    except Exception:
+        pass  # feedback capture must never disrupt search
+
+
+def attribute_use(conn, used_paths: list[str], window_seconds: float = 1800.0) -> int:
+    """Attribute a deliberate use of one or more notes back to the recent search
+    that surfaced them, writing feedback events. Returns the count written.
+
+    Non-blocking. For each used path, links to the single most recent search
+    within ``window_seconds`` whose result set contained it.
+    """
+    if not used_paths:
+        return 0
+    try:
+        rows = conn.execute(
+            "SELECT query, shown_paths FROM search_log "
+            "WHERE searched_at >= datetime('now', ?) "
+            "ORDER BY searched_at DESC, search_id DESC",
+            (f"-{int(window_seconds)} seconds",),
+        ).fetchall()
+    except Exception:
+        return 0
+
+    recent = []
+    for r in rows:
+        try:
+            recent.append((r[0], json.loads(r[1])))
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    written = 0
+    for path in dict.fromkeys(used_paths):  # dedup, preserve order
+        for query, shown in recent:
+            if path in shown:
+                rank = shown.index(path) + 1
+                try:
+                    conn.execute(
+                        "INSERT INTO search_feedback "
+                        "(query, chosen_path, shown_paths, rank) VALUES (?, ?, ?, ?)",
+                        (query, path, json.dumps(shown), rank),
+                    )
+                    written += 1
+                except Exception:
+                    pass
+                break  # only the most recent surfacing search
+    if written:
+        try:
+            conn.commit()
+        except Exception:
+            pass
+    return written
+
+
+# ── harvest (called from CLI — may raise) ──────────────────────────────────
+
+
+def feedback_labels(conn, *, min_count: int = 1, max_age_days: float | None = None):
+    """Aggregate feedback events into an ``EvalQuery`` label set.
+
+    One label per distinct query; its targets are the notes chosen for that query
+    at least ``min_count`` times. ``max_age_days`` restricts to recent feedback.
+    """
+    where = ""
+    params: list = []
+    if max_age_days is not None:
+        where = "WHERE created_at >= datetime('now', ?)"
+        params.append(f"-{float(max_age_days)} days")
+
+    rows = conn.execute(
+        f"SELECT query, chosen_path, COUNT(*) AS c FROM search_feedback {where} "
+        f"GROUP BY query, chosen_path",
+        params,
+    ).fetchall()
+
+    by_query: dict[str, list[str]] = {}
+    for r in rows:
+        if r[2] >= min_count:
+            by_query.setdefault(r[0], []).append(r[1])
+
+    return [
+        EvalQuery(query=q, targets=targets, category="feedback")
+        for q, targets in by_query.items()
+        if targets
+    ]
+
+
+def feedback_stats(conn) -> dict:
+    """Summary of accumulated feedback — volume and rank distribution."""
+    searches = conn.execute("SELECT COUNT(*) FROM search_log").fetchone()[0]
+    events = conn.execute("SELECT COUNT(*) FROM search_feedback").fetchone()[0]
+    distinct_q = conn.execute(
+        "SELECT COUNT(DISTINCT query) FROM search_feedback"
+    ).fetchone()[0]
+    distinct_notes = conn.execute(
+        "SELECT COUNT(DISTINCT chosen_path) FROM search_feedback"
+    ).fetchone()[0]
+    avg_rank = conn.execute(
+        "SELECT AVG(rank) FROM search_feedback WHERE rank IS NOT NULL"
+    ).fetchone()[0]
+    # How many chosen notes were NOT already rank 1 — the informative feedback.
+    below_top = conn.execute(
+        "SELECT COUNT(*) FROM search_feedback WHERE rank IS NOT NULL AND rank > 1"
+    ).fetchone()[0]
+    return {
+        "searches_logged": searches,
+        "feedback_events": events,
+        "distinct_queries": distinct_q,
+        "distinct_chosen_notes": distinct_notes,
+        "avg_chosen_rank": round(avg_rank, 2) if avg_rank is not None else None,
+        "informative_events": below_top,  # chosen note was not already top-ranked
+    }

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -193,6 +193,28 @@ CREATE TABLE IF NOT EXISTS note_usage (
 
 CREATE INDEX IF NOT EXISTS idx_note_usage_path ON note_usage(note_path);
 CREATE INDEX IF NOT EXISTS idx_note_usage_time ON note_usage(used_at);
+
+-- Implicit-feedback loop (issue #66): learn ranking weights from real behaviour.
+-- search_log records what each search surfaced; when a surfaced note is then
+-- deliberately used, that use is attributed back to the query as a feedback event.
+CREATE TABLE IF NOT EXISTS search_log (
+    search_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    shown_paths JSON NOT NULL,
+    searched_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_search_log_time ON search_log(searched_at);
+
+CREATE TABLE IF NOT EXISTS search_feedback (
+    feedback_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    chosen_path TEXT NOT NULL,
+    shown_paths JSON NOT NULL,
+    rank INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_search_feedback_query ON search_feedback(query);
+CREATE INDEX IF NOT EXISTS idx_search_feedback_time ON search_feedback(created_at);
 
 -- Prediction error log: signal-driven vault maintenance
 -- Populated at retrieval time when cosine distance exceeds threshold.
@@ -594,6 +616,27 @@ CREATE INDEX IF NOT EXISTS idx_triple_failed_retry
     ON triple_extraction_failed(next_retry_at);
 """
 
+MIGRATION_V18 = """
+CREATE TABLE IF NOT EXISTS search_log (
+    search_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    shown_paths JSON NOT NULL,
+    searched_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_search_log_time ON search_log(searched_at);
+
+CREATE TABLE IF NOT EXISTS search_feedback (
+    feedback_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL,
+    chosen_path TEXT NOT NULL,
+    shown_paths JSON NOT NULL,
+    rank INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_search_feedback_query ON search_feedback(query);
+CREATE INDEX IF NOT EXISTS idx_search_feedback_time ON search_feedback(created_at);
+"""
+
 
 def _run_migrations(conn: sqlite3.Connection):
     """Run schema migrations if needed."""
@@ -901,6 +944,19 @@ def _run_migrations(conn: sqlite3.Connection):
         )
         conn.commit()
         log.info("Migration to v17 complete.")
+
+    if current < 18:
+        log.info(
+            "Migrating schema v17 -> v18: "
+            "adding search_log + search_feedback tables (implicit-feedback loop)..."
+        )
+        conn.executescript(MIGRATION_V18)
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version"
+            " VALUES (18)"
+        )
+        conn.commit()
+        log.info("Migration to v18 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -1069,6 +1069,13 @@ def hybrid_search(
         # Auto-record usage for returned results (drives hotness scoring)
         _record_note_usage(conn, returned_paths)
 
+        # Implicit-feedback loop (issue #66): log what this search surfaced so a
+        # later deliberate use of one of these notes can be attributed back to
+        # the query. Opt-in; log_search swallows its own errors.
+        if cfg.feedback_enabled:
+            from .feedback import log_search
+            log_search(conn, query, returned_paths, cfg.feedback_log_retention)
+
         # Hebbian reinforcement: strengthen co-occurrence for entity pairs shared
         # between query-matched entities and result-note entities.
         # Fires regardless of cooccurrence_boost_weight setting.

--- a/src/neurostack/tools/file_tools.py
+++ b/src/neurostack/tools/file_tools.py
@@ -296,6 +296,20 @@ def vault_read_file(path: str) -> dict:
         return {"path": path, "exists": False, "size_bytes": 0, "content": ""}
 
     data = abs_path.read_bytes()
+
+    # Implicit-feedback loop (issue #66): opening a note is a deliberate use, so
+    # attribute it back to the search that surfaced it. Opt-in, non-blocking, and
+    # writes only to the index DB (not the vault) — the read stays read-only.
+    from ..config import get_config
+    cfg = get_config()
+    if cfg.feedback_enabled:
+        try:
+            from ..feedback import attribute_use
+            from ..schema import DB_PATH, get_db
+            attribute_use(get_db(DB_PATH), [path], cfg.feedback_window_seconds)
+        except Exception:
+            pass
+
     return {
         "path": path,
         "exists": True,

--- a/src/neurostack/tools/file_tools.py
+++ b/src/neurostack/tools/file_tools.py
@@ -300,15 +300,8 @@ def vault_read_file(path: str) -> dict:
     # Implicit-feedback loop (issue #66): opening a note is a deliberate use, so
     # attribute it back to the search that surfaced it. Opt-in, non-blocking, and
     # writes only to the index DB (not the vault) — the read stays read-only.
-    from ..config import get_config
-    cfg = get_config()
-    if cfg.feedback_enabled:
-        try:
-            from ..feedback import attribute_use
-            from ..schema import DB_PATH, get_db
-            attribute_use(get_db(DB_PATH), [path], cfg.feedback_window_seconds)
-        except Exception:
-            pass
+    from ..feedback import capture_use
+    capture_use([path])
 
     return {
         "path": path,

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -475,11 +475,8 @@ def vault_record_usage(note_paths: list[str]) -> dict:
 
     # Implicit-feedback loop (issue #66): a deliberate use is the click signal —
     # attribute it back to the search that surfaced it. Opt-in, non-blocking.
-    from ..config import get_config
-    cfg = get_config()
-    if cfg.feedback_enabled:
-        from ..feedback import attribute_use
-        attribute_use(conn, note_paths, cfg.feedback_window_seconds)
+    from ..feedback import capture_use
+    capture_use(note_paths, conn=conn)
     return {"recorded": len(note_paths), "paths": note_paths}
 
 

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -472,6 +472,14 @@ def vault_record_usage(note_paths: list[str]) -> dict:
         [(p,) for p in note_paths],
     )
     conn.commit()
+
+    # Implicit-feedback loop (issue #66): a deliberate use is the click signal —
+    # attribute it back to the search that surfaced it. Opt-in, non-blocking.
+    from ..config import get_config
+    cfg = get_config()
+    if cfg.feedback_enabled:
+        from ..feedback import attribute_use
+        attribute_use(conn, note_paths, cfg.feedback_window_seconds)
     return {"recorded": len(note_paths), "paths": note_paths}
 
 

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -121,3 +121,32 @@ between the sweep and `config.py`:
 
 The offline unit tests are `tests/test_tune.py`; the tuner is
 `src/neurostack/tune.py`.
+
+## Learning from real usage (`--feedback`, issue #66)
+
+Auto-labels reflect content, not behaviour, so they can't judge usage signals
+like hotness (that's why `--autolabel --tune` freezes it). The implicit-feedback
+loop closes the gap by labelling from what actually gets used:
+
+1. **Capture** (opt-in, `feedback_enabled`) — every search logs what it surfaced;
+   when a surfaced note is then deliberately used (`vault_record_usage` /
+   `vault_read_file`) within `feedback_window_seconds`, that use is attributed
+   back to the query as a `search_feedback` event, tagged with the note's rank.
+2. **Inspect** — `neurostack feedback` shows volume, distinct queries, and how
+   many uses were of a *non-top* result (the informative ones).
+3. **Tune** — `neurostack eval --feedback --tune` builds labels from the events
+   and tunes against them. Hotness is **not** frozen here: the labels are real
+   usage, so the confound that skewed the hand labels doesn't apply.
+
+```bash
+neurostack feedback --db /tmp/neurostack-copy.db          # how much has accumulated
+neurostack eval --db /tmp/neurostack-copy.db --feedback --tune
+```
+
+Enable capture in `config.toml` (`feedback_enabled = true`) or via
+`NEUROSTACK_FEEDBACK_ENABLED=true`. It's off by default — turning it on adds a
+lightweight write to the search and record-usage paths, and every capture call
+swallows its own errors so it can never disrupt retrieval. The signal is
+position-biased and small at first; the #66 commit gate (label quality +
+out-of-sample) still stands before any weight lands in `config.py`. The module is
+`src/neurostack/feedback.py`; tests are `tests/test_feedback.py`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,3 +133,22 @@ class TestRankingWeights:
         assert cfg.convergence_weight == 0.25
         assert cfg.inhibition_strength == 0.15
         assert cfg.hotness_weight == 0.2  # untouched key keeps default
+
+
+class TestFeedbackConfig:
+    """Implicit-feedback loop config (issue #66)."""
+
+    def test_defaults_off(self):
+        cfg = Config()
+        assert cfg.feedback_enabled is False
+        assert cfg.feedback_window_seconds == 1800.0
+        assert cfg.feedback_log_retention == 5000
+
+    def test_env_enable(self):
+        with patch.dict(os.environ, {
+            "NEUROSTACK_FEEDBACK_ENABLED": "true",
+            "NEUROSTACK_FEEDBACK_WINDOW_SECONDS": "600",
+        }):
+            cfg = load_config()
+        assert cfg.feedback_enabled is True
+        assert cfg.feedback_window_seconds == 600.0

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,146 @@
+"""Tests for neurostack.feedback — the implicit-feedback loop (issue #66).
+
+Offline: capture (log/attribute), harvest (labels/stats), and the v18 schema
+migration, all against a real on-disk SQLite DB.
+"""
+
+import json
+
+import pytest
+
+from neurostack import feedback as fb
+from neurostack.schema import SCHEMA_VERSION, get_db
+
+
+def _table_exists(conn, name):
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone() is not None
+
+
+def _event(conn, query, shown, chosen):
+    """Log a search and attribute a chosen result — one feedback event."""
+    fb.log_search(conn, query, shown)
+    fb.attribute_use(conn, [chosen], 1800)
+
+
+@pytest.fixture
+def fb_db(tmp_path):
+    return get_db(tmp_path / "fb.db")
+
+
+# ── schema / migration ──────────────────────────────────────────────────────
+
+
+def test_fresh_db_has_feedback_tables(fb_db):
+    assert _table_exists(fb_db, "search_log")
+    assert _table_exists(fb_db, "search_feedback")
+    v = fb_db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+    assert v == SCHEMA_VERSION == 18
+
+
+def test_migration_recreates_tables(tmp_path):
+    db = tmp_path / "m.db"
+    conn = get_db(db)
+    conn.execute("DROP TABLE search_log")
+    conn.execute("DROP TABLE search_feedback")
+    # _run_migrations reads MAX(version) — clear it so the DB reads as v17.
+    conn.execute("DELETE FROM schema_version")
+    conn.execute("INSERT INTO schema_version VALUES (17)")
+    conn.commit()
+    conn.close()
+    conn2 = get_db(db)  # reopening runs migrations
+    assert _table_exists(conn2, "search_log")
+    assert _table_exists(conn2, "search_feedback")
+    assert conn2.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == 18
+
+
+# ── log_search ──────────────────────────────────────────────────────────────
+
+
+def test_log_search_inserts(fb_db):
+    fb.log_search(fb_db, "how to configure retries", ["a.md", "b.md", "c.md"])
+    row = fb_db.execute("SELECT query, shown_paths FROM search_log").fetchone()
+    assert row[0] == "how to configure retries"
+    assert json.loads(row[1]) == ["a.md", "b.md", "c.md"]
+
+
+def test_log_search_ignores_empty(fb_db):
+    fb.log_search(fb_db, "", ["a.md"])
+    fb.log_search(fb_db, "q", [])
+    assert fb_db.execute("SELECT COUNT(*) FROM search_log").fetchone()[0] == 0
+
+
+# ── attribute_use ───────────────────────────────────────────────────────────
+
+
+def test_attribute_links_to_search_with_rank(fb_db):
+    fb.log_search(fb_db, "retry config", ["guides/a.md", "guides/b.md", "guides/c.md"])
+    assert fb.attribute_use(fb_db, ["guides/b.md"], window_seconds=1800) == 1
+    row = fb_db.execute(
+        "SELECT query, chosen_path, rank FROM search_feedback"
+    ).fetchone()
+    assert (row[0], row[1], row[2]) == ("retry config", "guides/b.md", 2)
+
+
+def test_attribute_ignores_unsurfaced_path(fb_db):
+    fb.log_search(fb_db, "q", ["a.md", "b.md"])
+    assert fb.attribute_use(fb_db, ["z.md"], 1800) == 0
+    assert fb_db.execute("SELECT COUNT(*) FROM search_feedback").fetchone()[0] == 0
+
+
+def test_attribute_respects_window(fb_db):
+    fb_db.execute(
+        "INSERT INTO search_log (query, shown_paths, searched_at) "
+        "VALUES (?, ?, datetime('now', '-2 hours'))",
+        ("old q", json.dumps(["a.md"])),
+    )
+    fb_db.commit()
+    assert fb.attribute_use(fb_db, ["a.md"], window_seconds=1800) == 0
+
+
+def test_attribute_picks_most_recent_search(fb_db):
+    fb.log_search(fb_db, "old query", ["x.md", "a.md"])
+    fb.log_search(fb_db, "new query", ["a.md", "y.md"])
+    fb.attribute_use(fb_db, ["a.md"], 1800)
+    row = fb_db.execute("SELECT query, rank FROM search_feedback").fetchone()
+    assert row[0] == "new query"  # tiebreak by search_id
+    assert row[1] == 1
+
+
+# ── harvest ─────────────────────────────────────────────────────────────────
+
+
+def test_feedback_labels_aggregate(fb_db):
+    _event(fb_db, "q1", ["a.md", "b.md"], "a.md")
+    _event(fb_db, "q1", ["a.md", "c.md"], "a.md")
+    _event(fb_db, "q2", ["d.md"], "d.md")
+    labels = fb.feedback_labels(fb_db, min_count=1)
+    by_q = {label.query: label for label in labels}
+    assert set(by_q) == {"q1", "q2"}
+    assert by_q["q1"].targets == ["a.md"]
+    assert by_q["q1"].category == "feedback"
+
+
+def test_feedback_labels_min_count(fb_db):
+    _event(fb_db, "q", ["a.md", "b.md"], "a.md")
+    assert fb.feedback_labels(fb_db, min_count=2) == []  # chosen only once
+
+
+def test_feedback_stats(fb_db):
+    fb.log_search(fb_db, "q", ["a.md", "b.md", "c.md"])
+    fb.attribute_use(fb_db, ["c.md"], 1800)  # rank 3
+    s = fb.feedback_stats(fb_db)
+    assert s["searches_logged"] == 1
+    assert s["feedback_events"] == 1
+    assert s["distinct_queries"] == 1
+    assert s["distinct_chosen_notes"] == 1
+    assert s["avg_chosen_rank"] == 3.0
+    assert s["informative_events"] == 1  # rank 3 > 1
+
+
+def test_stats_empty_db(fb_db):
+    s = fb.feedback_stats(fb_db)
+    assert s["searches_logged"] == 0
+    assert s["feedback_events"] == 0
+    assert s["avg_chosen_rank"] is None

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -99,6 +99,15 @@ def test_attribute_respects_window(fb_db):
     assert fb.attribute_use(fb_db, ["a.md"], window_seconds=1800) == 0
 
 
+def test_attribute_dedups_same_use_within_window(fb_db):
+    # A read + a record-usage for the same note (a normal pairing) must be one
+    # event, not two.
+    fb.log_search(fb_db, "q", ["a.md", "b.md"])
+    assert fb.attribute_use(fb_db, ["a.md"], 1800) == 1
+    assert fb.attribute_use(fb_db, ["a.md"], 1800) == 0  # deduped
+    assert fb_db.execute("SELECT COUNT(*) FROM search_feedback").fetchone()[0] == 1
+
+
 def test_attribute_picks_most_recent_search(fb_db):
     fb.log_search(fb_db, "old query", ["x.md", "a.md"])
     fb.log_search(fb_db, "new query", ["a.md", "y.md"])


### PR DESCRIPTION
Closes the gap auto-labels leave: they reflect content, so `--autolabel --tune`
freezes hotness. This adds a usage-grounded label source that **can** judge it —
capture which surfaced note a search led to being used, and tune against it.

## What

- **schema v18** — `search_log` (what each search surfaced) + `search_feedback`
  (a surfaced note deliberately used, attributed back to the query with its rank).
  Additive migration; existing DBs migrate on next open.
- **`feedback.py`** — `log_search` / `attribute_use` (capture, non-blocking) and
  `feedback_labels` / `feedback_stats` (harvest). A use is linked to the most
  recent search within a window whose result set contained the note.
- **capture hooks (opt-in, `feedback_enabled` default off, failure-isolated)** —
  `hybrid_search` logs on its record path; `vault_record_usage` and
  `vault_read_file` attribute a use. **Off by default → zero production change.**
- **config** — `feedback_enabled` / `feedback_window_seconds` /
  `feedback_log_retention` (TOML + env).
- **CLI** — `neurostack feedback` (stats) and `neurostack eval --feedback [--tune]`.
  Under `--feedback`, hotness is **not** frozen: the labels are real usage.

## Verification

- `uv run pytest` green (`tests/test_feedback.py` added), ruff clean.
- End-to-end on a prod snapshot: v17 auto-migrates to v18, 24 searches log, uses
  attribute with correct ranks, 24 labels harvest, and `--feedback --tune` runs
  with hotness unfrozen. The out-of-sample split correctly flagged the (arbitrary,
  simulated) feedback as an overfit — no weight worth committing, which is the
  gate working. No weights committed. Part of #66.