### PR TITLE
docs(skills): steer vault usage toward the #66 ranking/feedback features

### DIFF
--- a/src/neurostack/skills/vault-audit.md
+++ b/src/neurostack/skills/vault-audit.md
@@ -27,4 +27,18 @@ Review summaries for outdated information. Notes with old summaries may need re-
 ```
 vault_record_usage(note_paths=["path/to/note.md"])
 ```
-Call this when a note was genuinely useful. Boosts it in future search via hotness scoring.
+Call this when a note was genuinely useful. Two signals: **hotness** (boosts it in
+future search — always on) and, when `feedback_enabled` is set, the
+**implicit-feedback loop** that tunes ranking from real usage (issue #66).
+
+## Measure and tune retrieval quality (issue #66)
+```
+neurostack feedback                  # accumulated implicit-feedback stats
+neurostack eval --autolabel          # benchmark ranking on THIS vault (no hand labels)
+neurostack eval --feedback --tune    # tune weights from real usage (hotness included)
+```
+`--autolabel` builds a benchmark from the vault's own notes (summaries as
+queries); `--feedback` learns from recorded `vault_record_usage` events. Ranking
+weights are tunable (`convergence_weight`, `hotness_weight`, lateral-inhibition,
+etc.) but ship at defaults — a swept weight is a candidate: check the
+out-of-sample delta before pinning it in `config.toml`.

--- a/src/neurostack/skills/vault-search.md
+++ b/src/neurostack/skills/vault-search.md
@@ -29,3 +29,16 @@ NeuroStack has multiple retrieval tools. Pick the right one:
 5. Need a cited answer? -> vault_ask
 6. Want to explore connections from a note? -> vault_graph
 7. Want similar notes? -> vault_related
+
+## After retrieval: record what you used
+
+When retrieved notes genuinely informed your answer, record them:
+```
+vault_record_usage(note_paths=["path/a.md", "path/b.md"])
+```
+This is how the vault learns to rank better for you. It drives two signals:
+**hotness** (frequently-used notes rank higher — always on) and the
+**implicit-feedback loop** (which result answered which query, used to tune
+ranking — opt-in via `feedback_enabled`). Record the notes that actually helped,
+not incidental or irrelevant hits. Skipping it isn't wrong, but the ranking only
+improves from the uses you record.


### PR DESCRIPTION
Doc-only. Updates the bundled vault-search and vault-audit skills so agents record note usage (which feeds hotness + the opt-in implicit-feedback loop) and know about the new ranking-quality tooling (`neurostack feedback`, `eval --autolabel`, `eval --feedback --tune`). Part of #66.