### PR TITLE
docs(skills): strip em-dashes from the #66 usage notes

### DIFF
--- a/src/neurostack/skills/vault-audit.md
+++ b/src/neurostack/skills/vault-audit.md
@@ -28,7 +28,7 @@ Review summaries for outdated information. Notes with old summaries may need re-
 vault_record_usage(note_paths=["path/to/note.md"])
 ```
 Call this when a note was genuinely useful. Two signals: **hotness** (boosts it in
-future search — always on) and, when `feedback_enabled` is set, the
+future search, always on) and, when `feedback_enabled` is set, the
 **implicit-feedback loop** that tunes ranking from real usage (issue #66).
 
 ## Measure and tune retrieval quality (issue #66)

--- a/src/neurostack/skills/vault-search.md
+++ b/src/neurostack/skills/vault-search.md
@@ -37,8 +37,8 @@ When retrieved notes genuinely informed your answer, record them:
 vault_record_usage(note_paths=["path/a.md", "path/b.md"])
 ```
 This is how the vault learns to rank better for you. It drives two signals:
-**hotness** (frequently-used notes rank higher — always on) and the
+**hotness** (frequently-used notes rank higher, always on) and the
 **implicit-feedback loop** (which result answered which query, used to tune
-ranking — opt-in via `feedback_enabled`). Record the notes that actually helped,
+ranking; opt-in via `feedback_enabled`). Record the notes that actually helped,
 not incidental or irrelevant hits. Skipping it isn't wrong, but the ranking only
 improves from the uses you record.


### PR DESCRIPTION
Prose cleanup on the vault-search/vault-audit additions from #75.