### PR TITLE
Add neurostack export: dump index data to JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack index` | Full re-index. `--skip-summary`, `--skip-triples` |
 | `neurostack watch` | File watcher - auto-indexes on vault changes |
 | `neurostack reembed-chunks` | Re-embed all chunks with contextual text |
+| `neurostack export` | Dump indexed notes (path, title, pagerank, summary) as JSON. `--include triples`, `--output FILE` |
 | `neurostack backfill` | Backfill missing summaries and/or triples |
 | `neurostack folder-summaries` | Build folder-level summaries for context boosting |
 | `neurostack communities build` | Run attractor basin community detection |

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ neurostack prediction-errors             # stale note detection
 neurostack backfill [summaries|triples|all]
 neurostack communities build             # rebuild topic clusters
 neurostack reembed-chunks                # re-embed all chunks
+neurostack export --include triples -o dump.json  # dump index data as JSON
 
 # Memories
 neurostack memories add "text" --type observation

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .. import __version__
 from ..config import get_config
 from .api import cmd_api, cmd_bundle, cmd_serve
-from .index import cmd_backfill, cmd_index, cmd_reembed_chunks, cmd_watch
+from .index import cmd_backfill, cmd_export, cmd_index, cmd_reembed_chunks, cmd_watch
 from .memories import cmd_memories
 from .search import (
     cmd_ask,
@@ -381,6 +381,21 @@ def main():
              "(default: prune orphaned notes from the index)",
     )
     p.set_defaults(func=cmd_index)
+
+    # export (issue #4)
+    p = sub.add_parser(
+        "export",
+        help="Dump indexed notes (path, title, pagerank, summary) as JSON",
+    )
+    p.add_argument(
+        "--include", action="append", choices=["triples"], default=None,
+        help="Extra data to include per note (repeatable)",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Write JSON to a file instead of stdout",
+    )
+    p.set_defaults(func=cmd_export)
 
     # search
     p = sub.add_parser("search", help="Search the vault")

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -807,6 +807,9 @@ def main():
     _skip_preflight = {
         "init", "install", "uninstall", "doctor", "status", "demo", "update",
         "setup-desktop", "setup-client", "bundle",
+        # export reads only the SQLite index — it must keep working when the
+        # vault dir is gone but the DB survives (the get-my-data-out case)
+        "export",
     }
     vault_path = Path(args.vault)
     if args.command not in _skip_preflight and not vault_path.exists():

--- a/src/neurostack/cli/index.py
+++ b/src/neurostack/cli/index.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024-2026 Raphael Southall
 """Indexing and maintenance CLI commands."""
 
+import json
 import os
 from pathlib import Path
 
@@ -68,9 +69,6 @@ def cmd_backfill(args):
 
 
 def cmd_export(args):
-    import json
-    import sys
-
     from ..export import export_notes
     from ..schema import DB_PATH, get_db
     db_path = Path(os.environ.get("NEUROSTACK_DB_PATH", DB_PATH))
@@ -79,8 +77,10 @@ def cmd_export(args):
     notes = export_notes(conn, include_triples="triples" in include)
     text = json.dumps(notes, indent=2, default=str)
     if args.output:
-        Path(args.output).write_text(text + "\n")
-        print(f"Exported {len(notes)} notes to {args.output}", file=sys.stderr)
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text + "\n")
+        print(f"Exported {len(notes)} notes to {args.output}")
     else:
         print(text)
 

--- a/src/neurostack/cli/index.py
+++ b/src/neurostack/cli/index.py
@@ -67,6 +67,24 @@ def cmd_backfill(args):
         print(f"Memory embedding backfill: {n} memories (re-)embedded.")
 
 
+def cmd_export(args):
+    import json
+    import sys
+
+    from ..export import export_notes
+    from ..schema import DB_PATH, get_db
+    db_path = Path(os.environ.get("NEUROSTACK_DB_PATH", DB_PATH))
+    conn = get_db(db_path)
+    include = set(args.include or [])
+    notes = export_notes(conn, include_triples="triples" in include)
+    text = json.dumps(notes, indent=2, default=str)
+    if args.output:
+        Path(args.output).write_text(text + "\n")
+        print(f"Exported {len(notes)} notes to {args.output}", file=sys.stderr)
+    else:
+        print(text)
+
+
 def cmd_watch(args):
     from ..watcher import run_watcher
     run_watcher(

--- a/src/neurostack/export.py
+++ b/src/neurostack/export.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Export index data as JSON-serialisable structures (issue #4)."""
+
+import sqlite3
+
+
+def export_notes(
+    conn: sqlite3.Connection, include_triples: bool = False
+) -> list[dict]:
+    """Export all indexed notes with title, PageRank, and summary.
+
+    Args:
+        conn: Database connection
+        include_triples: Attach each note's triples as a ``triples`` key
+
+    Returns:
+        List of note dicts sorted by path. ``summary`` is None when no
+        summary has been computed; ``pagerank`` is 0.0 when the graph
+        stats have not been built.
+    """
+    rows = conn.execute(
+        """
+        SELECT n.path, n.title, g.pagerank, s.summary_text
+        FROM notes n
+        LEFT JOIN graph_stats g ON g.note_path = n.path
+        LEFT JOIN summaries s ON s.note_path = n.path
+        ORDER BY n.path
+        """
+    ).fetchall()
+
+    notes = [
+        {
+            "path": row["path"],
+            "title": row["title"],
+            "pagerank": row["pagerank"] if row["pagerank"] is not None else 0.0,
+            "summary": row["summary_text"],
+        }
+        for row in rows
+    ]
+
+    if include_triples:
+        triples_by_note: dict[str, list[dict]] = {}
+        for t in conn.execute(
+            "SELECT note_path, subject, predicate, object"
+            " FROM triples ORDER BY triple_id"
+        ):
+            triples_by_note.setdefault(t["note_path"], []).append(
+                {
+                    "subject": t["subject"],
+                    "predicate": t["predicate"],
+                    "object": t["object"],
+                }
+            )
+        for note in notes:
+            note["triples"] = triples_by_note.get(note["path"], [])
+
+    return notes

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
 """Tests for neurostack.export — JSON index export (issue #4)."""
 
 import argparse
@@ -111,3 +113,10 @@ def test_cmd_export_stdout_and_file(tmp_path, monkeypatch, capsys):
     cmd_export(args)
     data = json.loads(out_file.read_text())
     assert data[0]["triples"] == []
+    assert "Exported 1 notes" in capsys.readouterr().out
+
+    # --output into a directory that does not exist yet
+    nested = tmp_path / "missing" / "dir" / "export.json"
+    args = argparse.Namespace(include=None, output=str(nested))
+    cmd_export(args)
+    assert json.loads(nested.read_text())[0]["path"] == "a.md"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,113 @@
+"""Tests for neurostack.export — JSON index export (issue #4)."""
+
+import argparse
+import json
+
+from neurostack.export import export_notes
+
+
+def _add_note(conn, path, title, pagerank=None, summary=None):
+    conn.execute(
+        "INSERT INTO notes (path, title, content_hash, updated_at) "
+        "VALUES (?, ?, ?, ?)",
+        (path, title, "hash", "2026-01-01"),
+    )
+    if pagerank is not None:
+        conn.execute(
+            "INSERT INTO graph_stats (note_path, pagerank) VALUES (?, ?)",
+            (path, pagerank),
+        )
+    if summary is not None:
+        conn.execute(
+            "INSERT INTO summaries (note_path, summary_text, content_hash, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            (path, summary, "hash", "2026-01-01"),
+        )
+    conn.commit()
+
+
+def _add_triple(conn, note_path, subject, predicate, obj):
+    conn.execute(
+        "INSERT INTO triples (note_path, subject, predicate, object, triple_text) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (note_path, subject, predicate, obj, f"{subject} {predicate} {obj}"),
+    )
+    conn.commit()
+
+
+def test_export_basic(in_memory_db):
+    """Each note exports path, title, pagerank, summary."""
+    conn = in_memory_db
+    _add_note(conn, "a.md", "Note A", pagerank=0.42, summary="Summary of A")
+    _add_note(conn, "b.md", "Note B")
+
+    notes = export_notes(conn)
+
+    assert [n["path"] for n in notes] == ["a.md", "b.md"]
+    a, b = notes
+    assert a == {
+        "path": "a.md",
+        "title": "Note A",
+        "pagerank": 0.42,
+        "summary": "Summary of A",
+    }
+    # No graph stats / summary computed → defaults
+    assert b["pagerank"] == 0.0
+    assert b["summary"] is None
+    assert "triples" not in b
+
+
+def test_export_empty_index(in_memory_db):
+    assert export_notes(in_memory_db) == []
+
+
+def test_export_include_triples(in_memory_db):
+    conn = in_memory_db
+    _add_note(conn, "a.md", "Note A")
+    _add_note(conn, "b.md", "Note B")
+    _add_triple(conn, "a.md", "Alpha", "relates_to", "Beta")
+    _add_triple(conn, "a.md", "Alpha", "part_of", "Gamma")
+
+    notes = export_notes(conn, include_triples=True)
+
+    a = next(n for n in notes if n["path"] == "a.md")
+    b = next(n for n in notes if n["path"] == "b.md")
+    assert a["triples"] == [
+        {"subject": "Alpha", "predicate": "relates_to", "object": "Beta"},
+        {"subject": "Alpha", "predicate": "part_of", "object": "Gamma"},
+    ]
+    assert b["triples"] == []
+
+
+def test_export_is_json_serialisable(in_memory_db):
+    conn = in_memory_db
+    _add_note(conn, "a.md", "Note A", pagerank=0.1, summary="s")
+    _add_triple(conn, "a.md", "X", "is", "Y")
+
+    text = json.dumps(export_notes(conn, include_triples=True))
+
+    assert json.loads(text)[0]["path"] == "a.md"
+
+
+def test_cmd_export_stdout_and_file(tmp_path, monkeypatch, capsys):
+    """CLI wrapper: stdout by default, --output writes a file."""
+    from neurostack.cli.index import cmd_export
+    from neurostack.schema import get_db
+
+    db_path = tmp_path / "test.db"
+    conn = get_db(db_path)
+    _add_note(conn, "a.md", "Note A", pagerank=0.5)
+    conn.close()
+    monkeypatch.setenv("NEUROSTACK_DB_PATH", str(db_path))
+
+    args = argparse.Namespace(include=None, output=None)
+    cmd_export(args)
+    out = json.loads(capsys.readouterr().out)
+    assert out[0]["path"] == "a.md"
+    assert out[0]["pagerank"] == 0.5
+
+    out_file = tmp_path / "export.json"
+    args = argparse.Namespace(include=["triples"], output=str(out_file))
+    cmd_export(args)
+    data = json.loads(out_file.read_text())
+    assert data[0]["triples"] == []


### PR DESCRIPTION
Closes #4.

Adds a small export module plus CLI wiring:

- `neurostack export` prints a JSON array of indexed notes to stdout. Each entry carries `path`, `title`, `pagerank` (0.0 when graph stats are absent) and `summary` (null when not computed).
- `--output FILE` writes the JSON to a file and reports the note count on stderr.
- `--include triples` attaches each note's subject/predicate/object triples.
- The wrapper honours `NEUROSTACK_DB_PATH`, matching `cmd_index`.

Community assignments were left out: `community_members` keys on entity names, not note paths, so a per-note mapping is not derivable today.

Tested with unit tests over in-memory fixtures, a CLI-level test via `NEUROSTACK_DB_PATH`, and a live run against the dev index (539 notes).