### PR TITLE
Persist co-occurrence reinforcement across full reindex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ When enabled, searches are logged and a subsequent deliberate use of a surfaced 
 | `feedback_window_seconds` | `1800.0` | `NEUROSTACK_FEEDBACK_WINDOW_SECONDS` |
 | `feedback_log_retention` | `5000` | `NEUROSTACK_FEEDBACK_LOG_RETENTION` |
 
-Inspect accumulated feedback with `neurostack feedback`. The module is `src/neurostack/feedback.py`; data lives in the `search_log` and `search_feedback` tables (schema v18).
+Inspect accumulated feedback with `neurostack feedback`. The module is `src/neurostack/feedback.py`; data lives in the `search_log` and `search_feedback` tables (added in schema v18).
 
 ## Architecture
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "neurostack",
   "display_name": "NeuroStack",
-  "version": "0.15.0",
+  "version": "0.19.0",
   "description": "Neuroscience-grounded knowledge management for your Markdown vault. Semantic search, knowledge graphs, AI memory, stale note detection, and 21 MCP tools.",
   "author": {
     "name": "Raphael Southall"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neurostack",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Build, maintain, and search your knowledge vault with AI",
   "bin": {
     "neurostack": "bin/neurostack.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurostack"
-version = "0.18.0"
+version = "0.19.0"
 description = "Build, maintain, and search your knowledge vault. CLI + MCP server with stale note detection, semantic search, and neuroscience-grounded memory."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/raphasouthall/neurostack",
     "source": "github"
   },
-  "version": "0.15.0",
+  "version": "0.19.0",
   "websiteUrl": "https://github.com/raphasouthall/neurostack",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "neurostack",
-      "version": "0.15.0",
+      "version": "0.19.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/neurostack/__init__.py
+++ b/src/neurostack/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2024-2026 Raphael Southall
 """NeuroStack — AI-provider-agnostic, neuroscience-grounded knowledge management."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -433,7 +433,8 @@ def main():
     p.add_argument(
         "--db", default=None,
         help="SQLite index to evaluate. Default: the configured DB. "
-        "Use a COPY of the prod index — eval reads only, but point it at a copy.",
+        "Use a COPY of the prod index — opening it runs pending schema "
+        "migrations in place, so never point this at a treasured snapshot.",
     )
     p.add_argument(
         "--cache", default=None,

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -1026,9 +1026,16 @@ def cmd_cooccurrence(args):
 
     print(
         f"\n  Co-occurrence: {stats['pairs']} pairs"
-        f" ({stats['total_weight']:.1f} total weight)"
+        f" ({stats['total_weight']:.1f} total weight,"
+        f" {stats['reinforced_pairs']} reinforced,"
+        f" {stats['total_reinforcement']:.1f} total reinforcement)"
     )
-    print(f"\n  Top {args.limit} entity pairs by weight:")
+    print(f"\n  Top {args.limit} entity pairs by weight + reinforcement:")
     for p in pairs:
         last = p["last_seen"][:10] if len(p["last_seen"]) >= 10 else p["last_seen"]
-        print(f"    {p['weight']:>8.2f}  {p['entity_a']} <-> {p['entity_b']}  (last: {last})")
+        blended = p["weight"] + p["reinforcement"]
+        tag = f" [+{p['reinforcement']:.2f} reinf]" if p["reinforcement"] > 0 else ""
+        print(
+            f"    {blended:>8.2f}  {p['entity_a']} <-> {p['entity_b']}"
+            f"  (last: {last}){tag}"
+        )

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -722,6 +722,8 @@ def cmd_stats(args):
             "triple_coverage": f"{triple_pct}%",
             "cooccurrence_pairs": cooc["pairs"],
             "cooccurrence_total_weight": cooc["total_weight"],
+            "cooccurrence_reinforced_pairs": cooc["reinforced_pairs"],
+            "cooccurrence_total_reinforcement": cooc["total_reinforcement"],
             "community_build": community,
         }
         print(json.dumps(output, indent=2, default=str))
@@ -749,7 +751,8 @@ def cmd_stats(args):
     )
     print(
         f"Co-occurrence: {cooc['pairs']} pairs"
-        f" ({cooc['total_weight']:.1f} total weight)"
+        f" ({cooc['total_weight']:.1f} total weight,"
+        f" {cooc['reinforced_pairs']} reinforced)"
     )
     if community["built"]:
         flag = " \033[33m[STALE]\033[0m" if community["stale"] else ""

--- a/src/neurostack/cooccurrence.py
+++ b/src/neurostack/cooccurrence.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 
 log = logging.getLogger("neurostack")
 
+# Caps the reinforcement (usage) signal; structural weights are raw counts
 MAX_COOCCURRENCE_WEIGHT = 100.0
 
 
@@ -110,7 +111,8 @@ def persist_cooccurrence(conn: sqlite3.Connection) -> int:
     Structural weights are fully replaced; the ``reinforcement`` column is
     never touched, so accumulated search reinforcement survives the rebuild
     (issue #60). Rows with neither structural weight nor reinforcement are
-    swept away.
+    swept away. When the triples table yields no pairs the function returns
+    early and the table is left untouched (historical behaviour).
 
     Returns the number of structural entity pairs persisted.
     """
@@ -249,17 +251,17 @@ def upsert_cooccurrence_for_note(conn: sqlite3.Connection, note_path: str) -> in
             upserts,
         )
 
-    # Pairs that no longer co-occur structurally: keep the row (weight 0)
-    # while it still carries reinforcement, drop it otherwise
+    # Pairs that no longer co-occur structurally: drop unreinforced rows,
+    # keep reinforced ones at weight 0
     if deletes:
-        conn.executemany(
-            "UPDATE entity_cooccurrence SET weight = 0.0 "
-            "WHERE entity_a = ? AND entity_b = ?",
-            deletes,
-        )
         conn.executemany(
             "DELETE FROM entity_cooccurrence "
             "WHERE entity_a = ? AND entity_b = ? AND reinforcement <= 0",
+            deletes,
+        )
+        conn.executemany(
+            "UPDATE entity_cooccurrence SET weight = 0.0 "
+            "WHERE entity_a = ? AND entity_b = ?",
             deletes,
         )
 
@@ -278,7 +280,7 @@ def get_cooccurrence_stats(conn: sqlite3.Connection) -> dict:
     """
     row = conn.execute(
         "SELECT COUNT(*) AS pairs, COALESCE(SUM(weight), 0.0) AS total_weight, "
-        "COUNT(*) FILTER (WHERE reinforcement > 0) AS reinforced_pairs, "
+        "COALESCE(SUM(reinforcement > 0), 0) AS reinforced_pairs, "
         "COALESCE(SUM(reinforcement), 0.0) AS total_reinforcement "
         "FROM entity_cooccurrence"
     ).fetchone()

--- a/src/neurostack/cooccurrence.py
+++ b/src/neurostack/cooccurrence.py
@@ -2,9 +2,17 @@
 # Copyright (c) 2024-2026 Raphael Southall
 """Entity co-occurrence persistence for NeuroStack.
 
-Computes entity-entity co-occurrence from the triples table and persists
-weights to the entity_cooccurrence table. Two entities co-occur when they
-appear as subject or object in triples within the same note.
+Two separate signals live in the entity_cooccurrence table (issue #60):
+
+- ``weight`` — structural co-occurrence, recomputed from the triples table
+  on every full rebuild. Two entities co-occur when they appear as subject
+  or object in triples within the same note.
+- ``reinforcement`` — Hebbian usage signal, bumped on every search that
+  surfaces an entity pair and never touched by rebuilds, so it accumulates
+  across reindexes.
+
+Query time blends them as ``weight + reinforcement``. A row survives a
+rebuild while either signal is positive.
 """
 
 import logging
@@ -20,13 +28,14 @@ MAX_COOCCURRENCE_WEIGHT = 100.0
 def reinforce_cooccurrence(
     conn: sqlite3.Connection, entity_pairs: list[tuple[str, str]]
 ) -> int:
-    """Hebbian reinforcement: increase co-occurrence weight for entity pairs.
+    """Hebbian reinforcement: increase the usage signal for entity pairs.
 
-    For each pair, applies a multiplicative increment:
-        new_weight = min(existing_weight * 1.1, MAX_COOCCURRENCE_WEIGHT)
-
-    New pairs are seeded with weight 1.0. All pairs are stored in canonical
-    order (entity_a < entity_b).
+    Operates on the ``reinforcement`` column only, so the bump survives
+    structural rebuilds (issue #60). For each pair already reinforced:
+        new = min(reinforcement * 1.1, MAX_COOCCURRENCE_WEIGHT)
+    Pairs not yet reinforced (or not in the table at all) are seeded at
+    1.0; usage-only pairs get structural weight 0. All pairs are stored
+    in canonical order (entity_a < entity_b).
 
     Never raises -- wrapped in try/except to avoid disrupting callers.
     Returns the number of pairs reinforced.
@@ -47,9 +56,9 @@ def reinforce_cooccurrence(
 
         now = datetime.now(timezone.utc).isoformat()
 
-        # Batch-fetch existing weights in a single query
+        # Batch-fetch existing reinforcement in a single query
         canonical_list = sorted(canonical)
-        existing_weights: dict[tuple[str, str], float] = {}
+        existing: dict[tuple[str, str], float] = {}
         # SQLite has a variable limit; process in chunks of 500 pairs
         for chunk_start in range(0, len(canonical_list), 500):
             chunk = canonical_list[chunk_start:chunk_start + 500]
@@ -58,27 +67,29 @@ def reinforce_cooccurrence(
             )
             params = [v for pair in chunk for v in pair]
             rows = conn.execute(
-                f"SELECT entity_a, entity_b, weight FROM entity_cooccurrence "
-                f"WHERE {where_clauses}",
+                f"SELECT entity_a, entity_b, reinforcement "
+                f"FROM entity_cooccurrence WHERE {where_clauses}",
                 params,
             ).fetchall()
             for row in rows:
-                existing_weights[(row["entity_a"], row["entity_b"])] = row["weight"]
+                existing[(row["entity_a"], row["entity_b"])] = row["reinforcement"]
 
         updates: list[tuple[str, str, float, str]] = []
         for a, b in canonical_list:
-            old_weight = existing_weights.get((a, b))
-            if old_weight is not None:
-                new_weight = min(old_weight * 1.1, MAX_COOCCURRENCE_WEIGHT)
+            old = existing.get((a, b), 0.0)
+            if old > 0:
+                new = min(old * 1.1, MAX_COOCCURRENCE_WEIGHT)
             else:
-                new_weight = 1.0
-            updates.append((a, b, new_weight, now))
+                new = 1.0
+            updates.append((a, b, new, now))
 
         conn.executemany(
             "INSERT INTO entity_cooccurrence "
-            "(entity_a, entity_b, weight, last_seen) VALUES (?, ?, ?, ?) "
+            "(entity_a, entity_b, weight, reinforcement, last_seen) "
+            "VALUES (?, ?, 0.0, ?, ?) "
             "ON CONFLICT(entity_a, entity_b) DO UPDATE SET "
-            "weight = excluded.weight, last_seen = excluded.last_seen",
+            "reinforcement = excluded.reinforcement, "
+            "last_seen = excluded.last_seen",
             updates,
         )
         conn.commit()
@@ -89,16 +100,19 @@ def reinforce_cooccurrence(
 
 
 def persist_cooccurrence(conn: sqlite3.Connection) -> int:
-    """Compute and persist entity co-occurrence weights from triples.
+    """Compute and persist structural co-occurrence weights from triples.
 
     For each note, extracts all entities (subjects and objects from triples).
     For each pair of entities that appear in the same note, increments
-    their co-occurrence weight by 1.
+    their structural weight by 1.
 
     Entity pairs are stored in canonical order (entity_a < entity_b).
-    Existing weights are fully replaced (not incremented).
+    Structural weights are fully replaced; the ``reinforcement`` column is
+    never touched, so accumulated search reinforcement survives the rebuild
+    (issue #60). Rows with neither structural weight nor reinforcement are
+    swept away.
 
-    Returns the number of entity pairs persisted.
+    Returns the number of structural entity pairs persisted.
     """
     rows = conn.execute(
         "SELECT note_path, subject, object FROM triples"
@@ -129,16 +143,23 @@ def persist_cooccurrence(conn: sqlite3.Connection) -> int:
 
     now = datetime.now(timezone.utc).isoformat()
 
-    # Clear existing co-occurrence data and repopulate
-    conn.execute("DELETE FROM entity_cooccurrence")
+    # Rebuild the structural signal in place: zero it, upsert the fresh
+    # counts (leaving reinforcement untouched), then sweep rows that carry
+    # neither structural weight nor reinforcement.
+    conn.execute("UPDATE entity_cooccurrence SET weight = 0.0")
 
     conn.executemany(
         "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
-        "VALUES (?, ?, ?, ?)",
+        "VALUES (?, ?, ?, ?) "
+        "ON CONFLICT(entity_a, entity_b) DO UPDATE SET "
+        "weight = excluded.weight, last_seen = excluded.last_seen",
         [
             (pair[0], pair[1], weight, now)
             for pair, weight in pair_weights.items()
         ],
+    )
+    conn.execute(
+        "DELETE FROM entity_cooccurrence WHERE weight <= 0 AND reinforcement <= 0"
     )
     conn.commit()
 
@@ -151,10 +172,13 @@ def persist_cooccurrence(conn: sqlite3.Connection) -> int:
 def upsert_cooccurrence_for_note(conn: sqlite3.Connection, note_path: str) -> int:
     """Incrementally update co-occurrence for entities found in *note_path*.
 
-    Unlike ``persist_cooccurrence`` (which does a full DELETE+INSERT), this
-    function only touches pairs involving entities from the given note.
-    For each affected pair it recomputes the weight across ALL notes so
-    the result is always globally correct.
+    Unlike ``persist_cooccurrence`` (which rebuilds every structural
+    weight), this function only touches pairs involving entities from the
+    given note. For each affected pair it recomputes the structural weight
+    across ALL notes so the result is always globally correct. The
+    ``reinforcement`` column is never modified, and pairs that no longer
+    co-occur structurally are deleted only when they carry no
+    reinforcement (issue #60).
 
     Returns the number of pairs upserted.
     """
@@ -225,11 +249,17 @@ def upsert_cooccurrence_for_note(conn: sqlite3.Connection, note_path: str) -> in
             upserts,
         )
 
-    # Batch delete pairs that no longer co-occur
+    # Pairs that no longer co-occur structurally: keep the row (weight 0)
+    # while it still carries reinforcement, drop it otherwise
     if deletes:
         conn.executemany(
-            "DELETE FROM entity_cooccurrence "
+            "UPDATE entity_cooccurrence SET weight = 0.0 "
             "WHERE entity_a = ? AND entity_b = ?",
+            deletes,
+        )
+        conn.executemany(
+            "DELETE FROM entity_cooccurrence "
+            "WHERE entity_a = ? AND entity_b = ? AND reinforcement <= 0",
             deletes,
         )
 
@@ -242,26 +272,35 @@ def get_cooccurrence_stats(conn: sqlite3.Connection) -> dict:
 
     Returns dict with:
         pairs: int -- number of entity co-occurrence pairs
-        total_weight: float -- sum of all weights, rounded to 1 decimal
+        total_weight: float -- sum of structural weights, rounded to 1 decimal
+        reinforced_pairs: int -- pairs carrying accumulated search reinforcement
+        total_reinforcement: float -- sum of reinforcement, rounded to 1 decimal
     """
     row = conn.execute(
-        "SELECT COUNT(*) AS pairs, COALESCE(SUM(weight), 0.0) AS total_weight "
+        "SELECT COUNT(*) AS pairs, COALESCE(SUM(weight), 0.0) AS total_weight, "
+        "COUNT(*) FILTER (WHERE reinforcement > 0) AS reinforced_pairs, "
+        "COALESCE(SUM(reinforcement), 0.0) AS total_reinforcement "
         "FROM entity_cooccurrence"
     ).fetchone()
     return {
         "pairs": row["pairs"],
         "total_weight": round(float(row["total_weight"]), 1),
+        "reinforced_pairs": row["reinforced_pairs"],
+        "total_reinforcement": round(float(row["total_reinforcement"]), 1),
     }
 
 
 def get_top_pairs(conn: sqlite3.Connection, limit: int = 20) -> list[dict]:
-    """Return the top co-occurring entity pairs sorted by weight descending.
+    """Return the top entity pairs sorted by blended weight descending.
 
-    Each element: {"entity_a": str, "entity_b": str, "weight": float, "last_seen": str}
+    Each element: {"entity_a": str, "entity_b": str, "weight": float,
+    "reinforcement": float, "last_seen": str}. ``weight`` is the structural
+    signal; ordering uses weight + reinforcement, the same blend as search.
     """
     rows = conn.execute(
-        "SELECT entity_a, entity_b, weight, last_seen "
-        "FROM entity_cooccurrence ORDER BY weight DESC LIMIT ?",
+        "SELECT entity_a, entity_b, weight, reinforcement, last_seen "
+        "FROM entity_cooccurrence "
+        "ORDER BY weight + reinforcement DESC LIMIT ?",
         (limit,),
     ).fetchall()
     return [
@@ -269,6 +308,7 @@ def get_top_pairs(conn: sqlite3.Connection, limit: int = 20) -> list[dict]:
             "entity_a": r["entity_a"],
             "entity_b": r["entity_b"],
             "weight": float(r["weight"]),
+            "reinforcement": float(r["reinforcement"]),
             "last_seen": r["last_seen"],
         }
         for r in rows

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -324,6 +324,7 @@ CREATE TABLE IF NOT EXISTS entity_cooccurrence (
     entity_a TEXT NOT NULL,
     entity_b TEXT NOT NULL,
     weight REAL NOT NULL DEFAULT 0.0,
+    reinforcement REAL NOT NULL DEFAULT 0.0,
     last_seen TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (entity_a, entity_b)
 );
@@ -957,6 +958,29 @@ def _run_migrations(conn: sqlite3.Connection):
         )
         conn.commit()
         log.info("Migration to v18 complete.")
+
+    if current < 19:
+        log.info(
+            "Migrating schema v18 -> v19: "
+            "adding entity_cooccurrence.reinforcement (issue #60)..."
+        )
+        # ALTER TABLE doesn't support IF NOT EXISTS -
+        # check column existence first
+        cols = {
+            r[1] for r in conn.execute(
+                "PRAGMA table_info(entity_cooccurrence)"
+            ).fetchall()
+        }
+        if "reinforcement" not in cols:
+            conn.execute(
+                "ALTER TABLE entity_cooccurrence ADD COLUMN"
+                " reinforcement REAL NOT NULL DEFAULT 0.0"
+            )
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version VALUES (19)"
+        )
+        conn.commit()
+        log.info("Migration to v19 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -905,10 +905,14 @@ def hybrid_search(
                 # Step 2: Find co-occurring entities and their weights
                 cooc_entities = {}  # entity -> max co-occurrence weight
                 for qe in query_entities:
+                    # Blend structural weight with accumulated search
+                    # reinforcement (issue #60)
                     rows = conn.execute(
-                        "SELECT entity_b, weight FROM entity_cooccurrence WHERE entity_a = ? "
+                        "SELECT entity_b, weight + reinforcement AS w "
+                        "FROM entity_cooccurrence WHERE entity_a = ? "
                         "UNION ALL "
-                        "SELECT entity_a, weight FROM entity_cooccurrence WHERE entity_b = ?",
+                        "SELECT entity_a, weight + reinforcement AS w "
+                        "FROM entity_cooccurrence WHERE entity_b = ?",
                         (qe, qe),
                     ).fetchall()
                     for r in rows:

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -449,6 +449,8 @@ def vault_stats() -> dict:
         },
         "cooccurrence_pairs": cooc_stats["pairs"],
         "cooccurrence_total_weight": cooc_stats["total_weight"],
+        "cooccurrence_reinforced_pairs": cooc_stats["reinforced_pairs"],
+        "cooccurrence_total_reinforcement": cooc_stats["total_reinforcement"],
         "memories": mem_stats,
     }
     return result

--- a/tests/test_cooccurrence.py
+++ b/tests/test_cooccurrence.py
@@ -351,7 +351,7 @@ def test_reinforce_creates_new_pair(in_memory_db):
 
 
 def test_reinforce_bounded(in_memory_db):
-    """Reinforcement cannot push weight above MAX_COOCCURRENCE_WEIGHT (100.0)."""
+    """Reinforcement cannot grow above MAX_COOCCURRENCE_WEIGHT (100.0)."""
     conn = in_memory_db
     # Insert pair with reinforcement at 99.0
     conn.execute(

--- a/tests/test_cooccurrence.py
+++ b/tests/test_cooccurrence.py
@@ -292,12 +292,13 @@ def test_cooccurrence_stats_with_data(in_memory_db):
 
 
 def test_reinforce_basic(in_memory_db):
-    """Reinforcing an existing pair with weight 2.0 increases it via multiplicative formula."""
+    """Reinforcing a pair with reinforcement 2.0 grows it multiplicatively."""
     conn = in_memory_db
     conn.execute(
-        "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
-        "VALUES (?, ?, ?, ?)",
-        ("Alpha", "Beta", 2.0, "2026-01-01"),
+        "INSERT INTO entity_cooccurrence "
+        "(entity_a, entity_b, weight, reinforcement, last_seen) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("Alpha", "Beta", 3.0, 2.0, "2026-01-01"),
     )
     conn.commit()
 
@@ -305,11 +306,32 @@ def test_reinforce_basic(in_memory_db):
 
     assert n == 1
     row = conn.execute(
-        "SELECT weight FROM entity_cooccurrence "
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
         "WHERE entity_a = 'Alpha' AND entity_b = 'Beta'"
     ).fetchone()
     expected = min(2.0 * 1.1, MAX_COOCCURRENCE_WEIGHT)
-    assert abs(row["weight"] - expected) < 1e-9
+    assert abs(row["reinforcement"] - expected) < 1e-9
+    assert row["weight"] == 3.0  # structural signal untouched
+
+
+def test_reinforce_seeds_structural_pair(in_memory_db):
+    """First reinforcement of a structural-only pair seeds reinforcement at 1.0."""
+    conn = in_memory_db
+    conn.execute(
+        "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
+        "VALUES (?, ?, ?, ?)",
+        ("Alpha", "Beta", 5.0, "2026-01-01"),
+    )
+    conn.commit()
+
+    reinforce_cooccurrence(conn, [("Alpha", "Beta")])
+
+    row = conn.execute(
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
+        "WHERE entity_a = 'Alpha' AND entity_b = 'Beta'"
+    ).fetchone()
+    assert row["reinforcement"] == 1.0
+    assert row["weight"] == 5.0
 
 
 def test_reinforce_creates_new_pair(in_memory_db):
@@ -320,26 +342,29 @@ def test_reinforce_creates_new_pair(in_memory_db):
 
     assert n == 1
     row = conn.execute(
-        "SELECT weight FROM entity_cooccurrence "
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
         "WHERE entity_a = 'X' AND entity_b = 'Y'"
     ).fetchone()
     assert row is not None
-    assert row["weight"] == 1.0
+    assert row["reinforcement"] == 1.0
+    assert row["weight"] == 0.0  # usage-only pair carries no structural signal
 
 
 def test_reinforce_bounded(in_memory_db):
     """Reinforcement cannot push weight above MAX_COOCCURRENCE_WEIGHT (100.0)."""
     conn = in_memory_db
-    # Insert pair at 99.0
+    # Insert pair with reinforcement at 99.0
     conn.execute(
-        "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
-        "VALUES (?, ?, ?, ?)",
+        "INSERT INTO entity_cooccurrence "
+        "(entity_a, entity_b, weight, reinforcement, last_seen) "
+        "VALUES (?, ?, 0.0, ?, ?)",
         ("Alpha", "Beta", 99.0, "2026-01-01"),
     )
     # Insert pair already at 100.0
     conn.execute(
-        "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
-        "VALUES (?, ?, ?, ?)",
+        "INSERT INTO entity_cooccurrence "
+        "(entity_a, entity_b, weight, reinforcement, last_seen) "
+        "VALUES (?, ?, 0.0, ?, ?)",
         ("Gamma", "Delta", 100.0, "2026-01-01"),
     )
     conn.commit()
@@ -347,19 +372,19 @@ def test_reinforce_bounded(in_memory_db):
     reinforce_cooccurrence(conn, [("Alpha", "Beta"), ("Gamma", "Delta")])
 
     row_99 = conn.execute(
-        "SELECT weight FROM entity_cooccurrence "
+        "SELECT reinforcement FROM entity_cooccurrence "
         "WHERE entity_a = 'Alpha' AND entity_b = 'Beta'"
     ).fetchone()
-    assert row_99["weight"] <= MAX_COOCCURRENCE_WEIGHT
+    assert row_99["reinforcement"] <= MAX_COOCCURRENCE_WEIGHT
     # 99.0 * 1.1 = 108.9 -> capped to 100.0
-    assert row_99["weight"] == MAX_COOCCURRENCE_WEIGHT
+    assert row_99["reinforcement"] == MAX_COOCCURRENCE_WEIGHT
 
     row_100 = conn.execute(
-        "SELECT weight FROM entity_cooccurrence "
+        "SELECT reinforcement FROM entity_cooccurrence "
         "WHERE entity_a = 'Gamma' AND entity_b = 'Delta'"
     ).fetchone()
     # Already at max, should not increase
-    assert row_100["weight"] == MAX_COOCCURRENCE_WEIGHT
+    assert row_100["reinforcement"] == MAX_COOCCURRENCE_WEIGHT
 
 
 def test_reinforce_canonical_order(in_memory_db):
@@ -386,3 +411,104 @@ def test_reinforce_noop_no_entities(in_memory_db):
         "SELECT COUNT(*) as c FROM entity_cooccurrence"
     ).fetchone()["c"]
     assert count == 0
+
+
+# --- issue #60: reinforcement survives rebuilds ---
+
+
+def test_persist_preserves_reinforcement(in_memory_db):
+    """Full rebuild recomputes structural weight but keeps reinforcement."""
+    conn = in_memory_db
+    _insert_triple(conn, "note1.md", "Alpha", "Beta")
+    persist_cooccurrence(conn)
+    reinforce_cooccurrence(conn, [("Alpha", "Beta")])  # seeds 1.0
+    reinforce_cooccurrence(conn, [("Alpha", "Beta")])  # 1.0 -> 1.1
+
+    persist_cooccurrence(conn)  # the reindex that used to wipe it
+
+    row = conn.execute(
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
+        "WHERE entity_a = 'Alpha' AND entity_b = 'Beta'"
+    ).fetchone()
+    assert row["weight"] == 1.0
+    assert abs(row["reinforcement"] - 1.1) < 1e-9
+
+
+def test_persist_keeps_usage_only_pairs(in_memory_db):
+    """A pair known only from search reinforcement survives a rebuild at weight 0."""
+    conn = in_memory_db
+    _insert_triple(conn, "note1.md", "Alpha", "Beta")
+    reinforce_cooccurrence(conn, [("Gamma", "Delta")])  # not in any triple
+
+    persist_cooccurrence(conn)
+
+    row = conn.execute(
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
+        "WHERE entity_a = 'Delta' AND entity_b = 'Gamma'"
+    ).fetchone()
+    assert row is not None
+    assert row["weight"] == 0.0
+    assert row["reinforcement"] == 1.0
+
+
+def test_persist_sweeps_dead_pairs(in_memory_db):
+    """Pairs with no structural weight and no reinforcement are removed."""
+    conn = in_memory_db
+    _insert_triple(conn, "note1.md", "Alpha", "Beta")
+    persist_cooccurrence(conn)
+    conn.execute("DELETE FROM triples")
+    conn.commit()
+    _insert_triple(conn, "note2.md", "Gamma", "Delta")
+
+    persist_cooccurrence(conn)
+
+    rows = conn.execute(
+        "SELECT entity_a, entity_b FROM entity_cooccurrence"
+    ).fetchall()
+    assert [(r["entity_a"], r["entity_b"]) for r in rows] == [("Delta", "Gamma")]
+
+
+def test_upsert_preserves_reinforcement(in_memory_db):
+    """Incremental upsert recomputes structure without touching reinforcement."""
+    conn = in_memory_db
+    _insert_triple(conn, "note1.md", "Alpha", "Beta")
+    upsert_cooccurrence_for_note(conn, "note1.md")
+    reinforce_cooccurrence(conn, [("Alpha", "Beta")])
+
+    upsert_cooccurrence_for_note(conn, "note1.md")
+
+    row = conn.execute(
+        "SELECT weight, reinforcement FROM entity_cooccurrence "
+        "WHERE entity_a = 'Alpha' AND entity_b = 'Beta'"
+    ).fetchone()
+    assert row["weight"] == 1.0
+    assert row["reinforcement"] == 1.0
+
+
+def test_upsert_keeps_reinforced_pair_when_structure_vanishes(in_memory_db):
+    """When a pair stops co-occurring, only unreinforced rows are dropped."""
+    conn = in_memory_db
+    _insert_triple(conn, "note1.md", "Alpha", "Beta")
+    _insert_triple(conn, "note1.md", "Alpha", "Ceta")
+    upsert_cooccurrence_for_note(conn, "note1.md")  # pairs AB, AC, BC
+    reinforce_cooccurrence(conn, [("Alpha", "Beta")])
+
+    # note1 rewritten: Beta and Ceta gone, Zeta appears
+    conn.execute("DELETE FROM triples WHERE note_path = 'note1.md'")
+    conn.commit()
+    _insert_triple(conn, "note1.md", "Alpha", "Zeta")
+
+    upsert_cooccurrence_for_note(conn, "note1.md")
+
+    rows = {
+        (r["entity_a"], r["entity_b"]): (r["weight"], r["reinforcement"])
+        for r in conn.execute(
+            "SELECT entity_a, entity_b, weight, reinforcement "
+            "FROM entity_cooccurrence"
+        )
+    }
+    # reinforced pair survives at weight 0; unreinforced dead pairs are gone
+    assert rows[("Alpha", "Beta")] == (0.0, 1.0)
+    assert ("Alpha", "Ceta") not in rows
+    assert ("Beta", "Ceta") not in rows
+    assert rows[("Alpha", "Zeta")][0] == 1.0

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -36,7 +36,7 @@ def test_fresh_db_has_feedback_tables(fb_db):
     assert _table_exists(fb_db, "search_log")
     assert _table_exists(fb_db, "search_feedback")
     v = fb_db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
-    assert v == SCHEMA_VERSION == 18
+    assert v == SCHEMA_VERSION
 
 
 def test_migration_recreates_tables(tmp_path):
@@ -52,7 +52,9 @@ def test_migration_recreates_tables(tmp_path):
     conn2 = get_db(db)  # reopening runs migrations
     assert _table_exists(conn2, "search_log")
     assert _table_exists(conn2, "search_feedback")
-    assert conn2.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == 18
+    assert conn2.execute(
+        "SELECT MAX(version) FROM schema_version"
+    ).fetchone()[0] == SCHEMA_VERSION
 
 
 # ── log_search ──────────────────────────────────────────────────────────────

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -248,3 +248,53 @@ def test_migration_v12_idempotent(in_memory_db):
 
     row = conn.execute("SELECT MAX(version) as v FROM schema_version").fetchone()
     assert row["v"] == SCHEMA_VERSION
+
+
+def test_migration_v18_to_v19(in_memory_db):
+    """v19 adds entity_cooccurrence.reinforcement, preserving existing rows."""
+    conn = in_memory_db
+    # Simulate the v18 table shape (no reinforcement column)
+    conn.executescript("""
+        DROP TABLE entity_cooccurrence;
+        CREATE TABLE entity_cooccurrence (
+            entity_a TEXT NOT NULL,
+            entity_b TEXT NOT NULL,
+            weight REAL NOT NULL DEFAULT 0.0,
+            last_seen TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (entity_a, entity_b)
+        );
+    """)
+    conn.execute(
+        "INSERT INTO entity_cooccurrence (entity_a, entity_b, weight, last_seen) "
+        "VALUES ('Alpha', 'Beta', 5.0, '2026-01-01')"
+    )
+    conn.execute("DELETE FROM schema_version")
+    conn.execute("INSERT INTO schema_version VALUES (18)")
+    conn.commit()
+
+    _run_migrations(conn)
+
+    row = conn.execute(
+        "SELECT weight, reinforcement FROM entity_cooccurrence"
+    ).fetchone()
+    assert row["weight"] == 5.0
+    assert row["reinforcement"] == 0.0
+    v = conn.execute("SELECT MAX(version) as v FROM schema_version").fetchone()["v"]
+    assert v == SCHEMA_VERSION
+
+
+def test_migration_v19_idempotent(in_memory_db):
+    """Re-running the v19 migration on a table that has the column is a no-op."""
+    conn = in_memory_db
+    conn.execute("DELETE FROM schema_version")
+    conn.execute("INSERT INTO schema_version VALUES (18)")
+    conn.commit()
+    _run_migrations(conn)
+
+    conn.execute("DELETE FROM schema_version")
+    conn.execute("INSERT INTO schema_version VALUES (18)")
+    conn.commit()
+    _run_migrations(conn)  # column already present -- must not raise
+
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(entity_cooccurrence)")]
+    assert cols.count("reinforcement") == 1

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -501,6 +501,43 @@ class TestCooccurrenceBoost:
             f"{scores['noteA.md']} > {scores['noteB.md']}"
         )
 
+    def test_cooccurrence_boost_uses_reinforcement(self, in_memory_db, monkeypatch):
+        """A reinforcement-only association drives the boost (issue #60 blend)."""
+        conn = in_memory_db
+        self._setup_cooccurrence_scenario(conn)
+        # Convert the structural beta<->gamma association into a pure
+        # usage signal: no structural weight, reinforcement only
+        conn.execute(
+            "UPDATE entity_cooccurrence SET weight = 0.0, reinforcement = 3.0 "
+            "WHERE entity_a = 'beta' AND entity_b = 'gamma'"
+        )
+        conn.commit()
+
+        import neurostack.config as config_mod
+        import neurostack.search as search_mod
+
+        monkeypatch.setattr(search_mod, "get_db", lambda path: conn)
+
+        import numpy as np
+        fake_emb = np.array([0.5] * 768, dtype=np.float32)
+        monkeypatch.setattr(search_mod, "get_embedding", lambda q, base_url=None: fake_emb)
+
+        original_config = config_mod._config
+        try:
+            cfg = Config()
+            cfg.cooccurrence_boost_weight = 0.5
+            config_mod._config = cfg
+
+            results = hybrid_search("gamma", top_k=10, embed_url="http://fake")
+            scores = {r.note_path: r.score for r in results}
+        finally:
+            config_mod._config = original_config
+
+        assert scores["noteA.md"] > scores["noteB.md"], (
+            "reinforcement-only co-occurrence should still boost noteA: "
+            f"{scores['noteA.md']} > {scores['noteB.md']}"
+        )
+
     def test_cooccurrence_boost_with_hybrid_scoring(self, in_memory_db, monkeypatch):
         """In hybrid mode, boosted note scores higher than unboosted note."""
         conn = in_memory_db
@@ -729,7 +766,7 @@ class TestReinforcementFromSearch:
 
         # Check initial state: no co-occurrence for (alpha, beta) from reinforcement
         initial = conn.execute(
-            "SELECT weight FROM entity_cooccurrence "
+            "SELECT weight, reinforcement FROM entity_cooccurrence "
             "WHERE entity_a = 'alpha' AND entity_b = 'beta'"
         ).fetchone()
 
@@ -757,13 +794,13 @@ class TestReinforcementFromSearch:
         # After search, reinforcement should have created/increased the
         # co-occurrence between alpha (query entity) and beta (result-note entity)
         after = conn.execute(
-            "SELECT weight FROM entity_cooccurrence "
+            "SELECT weight, reinforcement FROM entity_cooccurrence "
             "WHERE entity_a = 'alpha' AND entity_b = 'beta'"
         ).fetchone()
         assert after is not None, "Reinforcement should have created (alpha, beta) pair"
-        initial_weight = initial["weight"] if initial else 0.0
-        assert after["weight"] > initial_weight, (
-            f"Weight should have increased from {initial_weight}"
+        initial_reinf = initial["reinforcement"] if initial else 0.0
+        assert after["reinforcement"] > initial_reinf, (
+            f"Reinforcement should have increased from {initial_reinf}"
         )
 
     def test_reinforce_noop_no_entities_in_search(self, in_memory_db, monkeypatch):


### PR DESCRIPTION
Closes #60.

The bug: `persist_cooccurrence` (run on every full reindex and `communities build`) did `DELETE FROM entity_cooccurrence` and repopulated from triples at raw counts, discarding every Hebbian bump `reinforce_cooccurrence` had written on the search path. The incremental path had the same defect in miniature: `upsert_cooccurrence_for_note` overwrote reinforced weights with recomputed structural counts for every touched pair.

This takes option 2 from the issue — separate the two signals:

- `weight` stays the structural co-occurrence count, recomputed freely on rebuild.
- New `reinforcement` column (schema v19) carries the accumulated search signal. Rebuilds never touch it. Seeded at 1.0, grows ×1.1 per reinforcement, capped at 100 as before.
- Query time blends `weight + reinforcement`; the boost normalisation is unchanged.
- A row survives a rebuild while either signal is positive: usage-only pairs (reinforced but structurally absent) persist at weight 0; dead rows (0, 0) are swept.
- `neurostack cooccurrence` and `vault_stats` now report reinforced pairs and total reinforcement.

Rebuild mechanics: zero all structural weights, upsert fresh counts (touching only `weight`/`last_seen`), sweep `weight <= 0 AND reinforcement <= 0`. No DELETE-all anywhere.

Version bumped to 0.19.0 (schema change). Migration is an idempotent `ALTER TABLE ADD COLUMN` with a PRAGMA guard.

Tested: 619 tests green including new regression tests for rebuild survival, usage-only pairs, dead-row sweep, incremental-path preservation, migration idempotency, and a reinforcement-only ranking boost. Also verified end-to-end on a `.backup` snapshot of the production DB (192,936 pairs): lazy v19 migration, three reinforcements, full rebuild, reinforcement intact.