### PR TITLE
Lean reference mode + size-bounded reads (#62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 ## MCP Tools (24 tools)
 
 ### Search & Retrieval
-- `vault_search(query, top_k, mode, depth, context, workspace)` - Hybrid search with tiered depth
+- `vault_search(query, top_k, mode, depth, context, workspace, max_tokens, reference_only)` - Hybrid search with tiered depth; `max_tokens` caps full-depth/reference output, `reference_only` returns lean {path, score, snippet} + fetch hint (issue #62)
 - `vault_ask(question, top_k, workspace)` - RAG Q&A with citations
 - `vault_summary(path_or_query)` - Pre-computed note summaries
 - `vault_graph(note, depth, workspace)` - Wiki-link neighborhood with PageRank
@@ -149,7 +149,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_session_end(session_id, summarize, auto_harvest)` - End session
 
 ### Vault Files (raw markdown CRUD over MCP)
-- `vault_read_file(path)` - Read a .md file under vault_root
+- `vault_read_file(path, offset, limit)` - Read a .md file under vault_root; `offset`/`limit` (characters) page through large notes and report `truncated` (issue #62)
 - `vault_list_files(directory, pattern, recursive)` - List .md files (hidden segments excluded)
 - `vault_write_file(path, content, commit_message)` - Create/overwrite a .md file; commits + pushes origin/main. Hard-rejects writes without required frontmatter (`date`, `tags`, `type`). On push conflict: `git pull --rebase --autostash` + retry once, then rollback.
 - `vault_delete_file(path, commit_message)` - Delete a .md file; commits + pushes origin/main

--- a/src/neurostack/budget.py
+++ b/src/neurostack/budget.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Shared token-budget estimation for size-bounded retrieval (issue #62).
+
+One ~4-chars-per-token estimator so vault_context and vault_search agree on how
+big a result is before it lands in the caller's context window, instead of each
+tool inlining its own `len(json.dumps(x)) // 4`.
+"""
+
+from __future__ import annotations
+
+import json
+
+CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(obj) -> int:
+    """Approximate the token cost of a JSON-serialisable object (~4 chars/token).
+
+    Strings are measured as-is; anything else is measured by its JSON encoding,
+    which is what actually crosses the wire to the caller.
+    """
+    if isinstance(obj, str):
+        text = obj
+    else:
+        try:
+            text = json.dumps(obj, default=str)
+        except (TypeError, ValueError):
+            text = str(obj)
+    return len(text) // CHARS_PER_TOKEN
+
+
+def trim_to_budget(entries, max_tokens: int | None):
+    """Keep the longest prefix of `entries` whose cumulative token estimate fits.
+
+    Args:
+        entries: An iterable of JSON-serialisable result entries.
+        max_tokens: Token ceiling, or None to keep everything.
+
+    Returns a ``(kept, tokens_used, truncated)`` tuple. At least one entry is
+    always kept when the input is non-empty, so a caller with a tiny budget still
+    gets a usable result rather than an empty list. `truncated` is True when any
+    entry was dropped to stay within budget.
+    """
+    entries = list(entries)
+    if max_tokens is None:
+        return entries, sum(estimate_tokens(e) for e in entries), False
+
+    kept: list = []
+    used = 0
+    for entry in entries:
+        cost = estimate_tokens(entry)
+        if kept and used + cost > max_tokens:
+            break
+        kept.append(entry)
+        used += cost
+    return kept, used, len(kept) < len(entries)

--- a/src/neurostack/context.py
+++ b/src/neurostack/context.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
+
+from .budget import estimate_tokens
 
 log = logging.getLogger("neurostack")
 
@@ -34,7 +35,8 @@ def build_vault_context(
 
     sections: dict = {}
     tokens_used = 0
-    # Rough estimate: 1 token ~ 4 chars
+    # Token cost is estimated via budget.estimate_tokens (~4 chars/token) so this
+    # allocator and vault_search agree on how big a result is (issue #62).
 
     # 1. Relevant memories (budget: ~40% of total)
     if include_memories:
@@ -57,7 +59,7 @@ def build_vault_context(
                     "tags": m.tags,
                     "created_at": m.created_at,
                 }
-                entry_tokens = len(json.dumps(entry)) // 4
+                entry_tokens = estimate_tokens(entry)
                 if tokens_used + entry_tokens > token_budget:
                     break
                 mem_entries.append(entry)
@@ -87,12 +89,12 @@ def build_vault_context(
                     "o": t.object,
                     "note": t.note_path,
                 }
-                entry_tokens = len(json.dumps(entry)) // 4
+                entry_tokens = estimate_tokens(entry)
                 if tokens_used + entry_tokens > token_budget:
                     break
                 triple_entries.append(entry)
                 tokens_used += entry_tokens
-                if sum(len(json.dumps(e)) // 4 for e in triple_entries) >= triple_budget:
+                if sum(estimate_tokens(e) for e in triple_entries) >= triple_budget:
                     break
             if triple_entries:
                 sections["triples"] = triple_entries
@@ -116,12 +118,12 @@ def build_vault_context(
                 "summary": r.summary or r.snippet[:200],
                 "score": round(r.score, 4),
             }
-            entry_tokens = len(json.dumps(entry)) // 4
+            entry_tokens = estimate_tokens(entry)
             if tokens_used + entry_tokens > token_budget:
                 break
             summary_entries.append(entry)
             tokens_used += entry_tokens
-            if sum(len(json.dumps(e)) // 4 for e in summary_entries) >= summary_budget:
+            if sum(estimate_tokens(e) for e in summary_entries) >= summary_budget:
                 break
         if summary_entries:
             sections["summaries"] = summary_entries
@@ -143,7 +145,7 @@ def build_vault_context(
                     "memory_count": s["memory_count"],
                 }
                 session_entries.append(entry)
-            entry_tokens = len(json.dumps(session_entries)) // 4
+            entry_tokens = estimate_tokens(session_entries)
             if tokens_used + entry_tokens <= token_budget:
                 sections["session_history"] = session_entries
                 tokens_used += entry_tokens

--- a/src/neurostack/tools/file_tools.py
+++ b/src/neurostack/tools/file_tools.py
@@ -315,10 +315,13 @@ def vault_read_file(path: str, offset: int = 0, limit: int | None = None) -> dic
     text = data.decode("utf-8")
 
     # Implicit-feedback loop (issue #66): opening a note is a deliberate use, so
-    # attribute it back to the search that surfaced it. Opt-in, non-blocking, and
-    # writes only to the index DB (not the vault) — the read stays read-only.
-    from ..feedback import capture_use
-    capture_use([path])
+    # attribute it back to the search that surfaced it. Only the first page
+    # (offset 0) counts as an open; continuation reads of the same note aren't a
+    # fresh use and must not inflate the signal. Opt-in, non-blocking, and writes
+    # only to the index DB (not the vault) — the read stays read-only.
+    if offset == 0:
+        from ..feedback import capture_use
+        capture_use([path])
 
     # Unbounded read: byte-for-byte the original response shape.
     if offset == 0 and limit is None:

--- a/src/neurostack/tools/file_tools.py
+++ b/src/neurostack/tools/file_tools.py
@@ -278,13 +278,22 @@ def _release_vault_lock(fh) -> None:
 
 
 @registry.tool(tags=["vault-files", "read"], annotations=_READ_ONLY)
-def vault_read_file(path: str) -> dict:
+def vault_read_file(path: str, offset: int = 0, limit: int | None = None) -> dict:
     """Read a markdown file from the vault.
+
+    By default returns the whole file. For a large note, pass `offset` and/or
+    `limit` (both measured in characters of the decoded text) to read a bounded
+    slice and page through it instead of pulling the whole body into context —
+    the footprint fix behind lean reference mode (issue #62). When a bound is
+    applied the result also carries `size_chars`, the `offset` used, and
+    `truncated` (True when content remains past the returned slice).
 
     Args:
         path: Relative path under vault_root (e.g. "home/projects/foo.md").
               Must end in .md. Absolute paths, '..', and dot-prefixed
               segments (.git, .obsidian, .trash, etc.) are rejected.
+        offset: Character offset to start reading from (default 0).
+        limit: Maximum characters to return (default None = read to the end).
     """
     vault_root = _vault_root()
     try:
@@ -295,7 +304,15 @@ def vault_read_file(path: str) -> dict:
     if not abs_path.is_file():
         return {"path": path, "exists": False, "size_bytes": 0, "content": ""}
 
+    if offset < 0 or (limit is not None and limit < 0):
+        return {
+            "path": path,
+            "exists": True,
+            "error": "offset and limit must be non-negative",
+        }
+
     data = abs_path.read_bytes()
+    text = data.decode("utf-8")
 
     # Implicit-feedback loop (issue #66): opening a note is a deliberate use, so
     # attribute it back to the search that surfaced it. Opt-in, non-blocking, and
@@ -303,11 +320,26 @@ def vault_read_file(path: str) -> dict:
     from ..feedback import capture_use
     capture_use([path])
 
+    # Unbounded read: byte-for-byte the original response shape.
+    if offset == 0 and limit is None:
+        return {
+            "path": path,
+            "exists": True,
+            "size_bytes": len(data),
+            "content": text,
+        }
+
+    total_chars = len(text)
+    start = min(offset, total_chars)
+    end = total_chars if limit is None else min(start + limit, total_chars)
     return {
         "path": path,
         "exists": True,
         "size_bytes": len(data),
-        "content": data.decode("utf-8"),
+        "size_chars": total_chars,
+        "offset": start,
+        "content": text[start:end],
+        "truncated": end < total_chars,
     }
 
 

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -113,11 +113,11 @@ def vault_search(
         workspace: Optional vault subdirectory prefix to restrict
             results (e.g. "work/acme-cloud")
         max_tokens: Optional size ceiling (~4 chars/token) on the returned
-            result list. Full-depth and reference results stop accumulating once
-            the estimate is hit; at least one result is always kept, and the
-            response carries "truncated": True when anything was dropped. The
-            tiered depths (triples/summaries/auto) are already compressed by
-            `depth`, so this budget does not apply to them.
+            results. Once the estimate is hit, results stop accumulating (at
+            least one is always kept) and the response carries "truncated": True.
+            `depth` is the primary footprint dial; max_tokens trims on top of it
+            across every depth and the reference list, so an explicit budget is
+            never a silent no-op.
         reference_only: If True, return a lean list of {path, score, snippet}
             with no summaries or bodies, plus a hint to fetch detail on demand
             via vault_read_file(path, offset, limit). Ignores `depth`. Lets an
@@ -162,6 +162,23 @@ def vault_search(
             embed_url=embed_url, context=context,
             workspace=workspace,
         )
+
+        if max_tokens is not None:
+            # Keep the budget meaningful whatever the depth (issue #62): trim the
+            # content lists against one shared ceiling so an explicit max_tokens
+            # never silently no-ops on the default depth="auto".
+            remaining = max_tokens
+            dropped = False
+            for key in ("triples", "summaries", "chunks"):
+                items = result.get(key)
+                if not items:
+                    continue
+                kept, used, trunc = trim_to_budget(items, remaining)
+                result[key] = kept
+                remaining = max(0, remaining - used)
+                dropped = dropped or trunc
+            if dropped:
+                result["truncated"] = True
 
         if depth in ("auto", "summaries"):
             memories = _search_memories_for_results(query, workspace, limit=3)

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -95,6 +95,8 @@ def vault_search(
     depth: str = "auto",
     context: str = None,
     workspace: str = None,
+    max_tokens: int = None,
+    reference_only: bool = False,
 ) -> dict:
     """Search the vault with tiered retrieval depth.
 
@@ -110,11 +112,47 @@ def vault_search(
         context: Optional project/domain context for boosting
         workspace: Optional vault subdirectory prefix to restrict
             results (e.g. "work/acme-cloud")
+        max_tokens: Optional size ceiling (~4 chars/token) on the returned
+            result list. Full-depth and reference results stop accumulating once
+            the estimate is hit; at least one result is always kept, and the
+            response carries "truncated": True when anything was dropped. The
+            tiered depths (triples/summaries/auto) are already compressed by
+            `depth`, so this budget does not apply to them.
+        reference_only: If True, return a lean list of {path, score, snippet}
+            with no summaries or bodies, plus a hint to fetch detail on demand
+            via vault_read_file(path, offset, limit). Ignores `depth`. Lets an
+            agent scan cheaply, pick a path, then do a bounded read.
 
     Use "triples" for quick factual lookups, "summaries" for overview,
     "full" when you need actual content, "auto" to let the system decide.
     """
+    from ..budget import trim_to_budget
+
     _, embed_url = _cfg()
+
+    # Lean reference mode (issue #62): IDs + snippets only, fetch bodies on demand.
+    if reference_only:
+        from ..search import hybrid_search
+
+        results = hybrid_search(
+            query, top_k=top_k, mode=mode,
+            embed_url=embed_url, context=context,
+            workspace=workspace,
+        )
+        refs = [
+            {"path": r.note_path, "score": round(r.score, 4), "snippet": r.snippet}
+            for r in results
+        ]
+        kept, _, truncated = trim_to_budget(refs, max_tokens)
+        result = {
+            "results": kept,
+            "reference_only": True,
+            "hint": "Reference mode: fetch a chosen path with "
+                    "vault_read_file(path, offset, limit) or vault_summary(path).",
+        }
+        if truncated:
+            result["truncated"] = True
+        return result
 
     if depth in ("triples", "summaries", "auto"):
         from ..search import tiered_search
@@ -154,7 +192,10 @@ def vault_search(
             entry["summary"] = r.summary
         output.append(entry)
 
-    result = {"results": output}
+    kept, _, truncated = trim_to_budget(output, max_tokens)
+    result = {"results": kept}
+    if truncated:
+        result["truncated"] = True
 
     memories = _search_memories_for_results(query, workspace, limit=3)
     if memories:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Unit tests for the shared token-budget helper (issue #62)."""
+
+from neurostack.budget import estimate_tokens, trim_to_budget
+
+
+class TestEstimateTokens:
+    def test_string_measured_directly(self):
+        assert estimate_tokens("a" * 40) == 10  # 40 chars / 4
+
+    def test_dict_measured_by_json_encoding(self):
+        entry = {"path": "a.md", "score": 0.5}
+        assert estimate_tokens(entry) == len(
+            '{"path": "a.md", "score": 0.5}'
+        ) // 4
+
+    def test_non_serialisable_falls_back_to_str(self):
+        assert estimate_tokens(object()) > 0  # does not raise
+
+
+class TestTrimToBudget:
+    def test_none_budget_keeps_everything(self):
+        entries = [{"n": i} for i in range(5)]
+        kept, used, truncated = trim_to_budget(entries, None)
+        assert kept == entries
+        assert truncated is False
+        assert used == sum(estimate_tokens(e) for e in entries)
+
+    def test_trims_and_flags_truncation(self):
+        entries = [{"pad": "x" * 400} for _ in range(5)]  # ~100 tokens each
+        kept, used, truncated = trim_to_budget(entries, max_tokens=250)
+        assert 0 < len(kept) < len(entries)
+        assert truncated is True
+        assert used <= 250 + estimate_tokens(entries[0])
+
+    def test_keeps_at_least_one_when_first_exceeds_budget(self):
+        entries = [{"pad": "x" * 4000}]  # ~1000 tokens, budget is 10
+        kept, _used, truncated = trim_to_budget(entries, max_tokens=10)
+        assert len(kept) == 1  # never return an empty, useless result
+        assert truncated is False  # nothing was dropped
+
+    def test_empty_input(self):
+        kept, used, truncated = trim_to_budget([], max_tokens=100)
+        assert kept == []
+        assert used == 0
+        assert truncated is False

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -145,6 +145,62 @@ class TestReadFile:
         assert result["exists"] is False
         assert "error" in result
 
+    def test_unbounded_read_has_no_paging_keys(self, tmp_vault_repo):
+        # Issue #62: the default call must stay byte-for-byte unchanged.
+        target = tmp_vault_repo / "home" / "note.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("hello world\n")
+        result = vault_read_file(path="home/note.md")
+        assert set(result) == {"path", "exists", "size_bytes", "content"}
+
+    def test_bounded_read_offset_and_limit(self, tmp_vault_repo):
+        target = tmp_vault_repo / "home" / "big.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("0123456789")
+        result = vault_read_file(path="home/big.md", offset=2, limit=3)
+        assert result["content"] == "234"
+        assert result["offset"] == 2
+        assert result["size_chars"] == 10
+        assert result["size_bytes"] == 10
+        assert result["truncated"] is True
+
+    def test_bounded_read_to_end_not_truncated(self, tmp_vault_repo):
+        target = tmp_vault_repo / "home" / "big.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("0123456789")
+        result = vault_read_file(path="home/big.md", offset=7, limit=100)
+        assert result["content"] == "789"
+        assert result["truncated"] is False
+
+    def test_bounded_read_pages_reassemble_to_whole(self, tmp_vault_repo):
+        body = "".join(str(i % 10) for i in range(250))
+        target = tmp_vault_repo / "home" / "long.md"
+        target.parent.mkdir(parents=True)
+        target.write_text(body)
+        pages, offset = [], 0
+        while True:
+            page = vault_read_file(path="home/long.md", offset=offset, limit=100)
+            pages.append(page["content"])
+            if not page["truncated"]:
+                break
+            offset += len(page["content"])
+        assert "".join(pages) == body
+
+    def test_negative_params_rejected(self, tmp_vault_repo):
+        target = tmp_vault_repo / "home" / "note.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("hello")
+        assert "error" in vault_read_file(path="home/note.md", offset=-1)
+        assert "error" in vault_read_file(path="home/note.md", limit=-5)
+
+    def test_offset_past_end_returns_empty(self, tmp_vault_repo):
+        target = tmp_vault_repo / "home" / "note.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("short")
+        result = vault_read_file(path="home/note.md", offset=999)
+        assert result["content"] == ""
+        assert result["truncated"] is False
+
 
 # --------------------------- vault_list_files --------------------------------
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -124,6 +124,20 @@ def test_vault_search_max_tokens_truncates(mcp_vault):
     json.dumps(capped)
 
 
+def test_vault_search_max_tokens_applies_to_tiered_depth(mcp_vault):
+    # The budget must not silently no-op just because depth defaults to "auto".
+    capped = _registry().call(
+        "vault_search", query="prediction", mode="keyword", depth="auto",
+        max_tokens=1,
+    )
+    # auto falls back to chunk search in the fixture (no triples/summaries), so
+    # the content list is capped to one entry and truncation is flagged.
+    assert capped.get("truncated") is True
+    total = sum(len(capped.get(k, [])) for k in ("triples", "summaries", "chunks"))
+    assert total == 1
+    json.dumps(capped)
+
+
 def test_vault_stats_structure(mcp_vault):
     result = _registry().call("vault_stats")
     for key in ("notes", "chunks", "embedded", "summaries", "graph_edges",

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -95,6 +95,35 @@ def test_vault_search_keyword(mcp_vault):
         assert {"path", "title", "score"} <= set(r), r
 
 
+def test_vault_search_reference_only(mcp_vault):
+    # Issue #62: reference mode returns lean {path, score, snippet} + a fetch hint.
+    result = _registry().call(
+        "vault_search", query="prediction", mode="keyword", reference_only=True,
+    )
+    assert result["reference_only"] is True
+    assert "vault_read_file" in result["hint"]
+    assert result["results"], "reference search should surface at least one path"
+    for r in result["results"]:
+        assert set(r) == {"path", "score", "snippet"}, r
+    json.dumps(result)
+
+
+def test_vault_search_max_tokens_truncates(mcp_vault):
+    # A generous budget keeps every hit; a 1-token budget keeps exactly one.
+    full = _registry().call(
+        "vault_search", query="prediction", mode="keyword", depth="full",
+    )
+    assert len(full["results"]) >= 2, "need >1 hit to prove truncation"
+
+    capped = _registry().call(
+        "vault_search", query="prediction", mode="keyword", depth="full",
+        max_tokens=1,
+    )
+    assert len(capped["results"]) == 1  # at least one always kept
+    assert capped["truncated"] is True
+    json.dumps(capped)
+
+
 def test_vault_stats_structure(mcp_vault):
     result = _registry().call("vault_stats")
     for key in ("notes", "chunks", "embedded", "summaries", "graph_edges",


### PR DESCRIPTION
Closes #62.

Cuts the caller-side context footprint of vault retrieval at the source. A downstream MCP hook can't help here: a tool result is already in the caller's window before any `PostToolUse` fires, and `PreToolUse` can't substitute a smaller result. So the fix has to live in NeuroStack.

Three backward-compatible additions; every default call is unchanged.

**A. Bounded reads on `vault_read_file`.** New `offset` / `limit` (characters). Reads a slice and reports `size_chars`, the `offset` used, and `truncated` so a caller can page a large note instead of pulling the whole body. The no-arg call returns the original `{path, exists, size_bytes, content}` byte-for-byte. The #66 `capture_use` open-signal fires only on the first page (offset 0), so paging doesn't inflate implicit feedback.

**B. Size budget on `vault_search`.** New `max_tokens` caps output: results stop accumulating once the ~4-chars/token estimate is hit, at least one result is always kept, and the response carries `truncated: true` when anything was dropped. `depth` stays the primary footprint dial, but the budget trims on top of it across **every depth** (the tiered content lists share one ceiling) and the reference list — so an explicit `max_tokens` is never a silent no-op on the default `depth="auto"`.

**C. Lean reference mode on `vault_search`.** New `reference_only` returns `[{path, score, snippet}]` only — no summaries, no bodies — plus a hint to fetch detail via `vault_read_file(path, offset, limit)`. Makes the round-trip explicit: reference search → pick a path → bounded read.

Budget estimation is now shared, not duplicated: `estimate_tokens` / `trim_to_budget` live in a new `budget.py`, and `context.py` uses `estimate_tokens` in place of its own inline `len(json.dumps(x)) // 4`.

## Acceptance criteria
- [x] `vault_read_file` accepts `offset`/`limit`, reports `truncated` and total size; no-arg call unchanged
- [x] `vault_search` accepts a size budget that caps output; default call unchanged
- [x] `vault_search` offers a reference mode returning IDs + snippets only
- [x] Budget estimation shared with `vault_context`, not duplicated
- [x] Tests cover bounded-read paging and budget truncation

## Review
Self-reviewed across three lenses (correctness/boundary, caller-tracing/removed-behavior, pitfalls/conventions): no positional callers break; adapter schema handles the new params exactly as the existing `str = None` ones; `context.py` `import json` cleanly removed. Two findings applied — the cross-depth budget (B) and first-page-only `capture_use` (A).

## Tests
635 passed (was 619): `test_budget.py` (helper units), bounded-read paging in `test_file_tools.py`, reference-mode + budget-truncation (full and auto depth) in `test_mcp_integration.py`. Ruff clean.