### PR TITLE
Graph gaps + bridges analysis (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack serve` | Start MCP server. `--transport stdio\|sse\|http`, `--host`, `--port` |
 | `neurostack api` | Start OpenAI-compatible HTTP API. `--host`, `--port` |
 
-## MCP Tools (24 tools)
+## MCP Tools (25 tools)
 
 ### Search & Retrieval
 - `vault_search(query, top_k, mode, depth, context, workspace, max_tokens, reference_only)` - Hybrid search with tiered depth; `max_tokens` caps full-depth/reference output, `reference_only` returns lean {path, score, snippet} + fetch hint (issue #62)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack triples "query"` | Search knowledge graph triples (subject-predicate-object facts) |
 | `neurostack summary "note.md"` | Get pre-computed AI summary of a note |
 | `neurostack graph "note.md"` | Wiki-link neighborhood with PageRank scores. `--depth N` |
+| `neurostack graph-analysis` | Structural gaps (related but unlinked) + bridge notes. `--top-k N`, `--min-shared N` |
 | `neurostack related "note.md"` | Find semantically similar notes by embedding distance |
 | `neurostack communities query "question"` | GraphRAG global queries across topic clusters |
 | `neurostack context "task description"` | Assemble task-scoped context for session recovery |
@@ -125,6 +126,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_ask(question, top_k, workspace)` - RAG Q&A with citations
 - `vault_summary(path_or_query)` - Pre-computed note summaries
 - `vault_graph(note, depth, workspace)` - Wiki-link neighborhood with PageRank
+- `vault_graph_analysis(top_k, min_shared)` - Structural gaps (unlinked but related pairs) + bridge notes (betweenness/articulation points) over the link graph (issue #12)
 - `vault_related(note, top_k, workspace)` - Semantically similar notes
 - `vault_triples(query, top_k, mode, workspace)` - Knowledge graph triples
 - `vault_communities(query, top_k, level, map_reduce, workspace)` - GraphRAG global queries

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -22,6 +22,7 @@ from .search import (
     cmd_feedback,
     cmd_folder_summaries,
     cmd_graph,
+    cmd_graph_analysis,
     cmd_prediction_errors,
     cmd_record_usage,
     cmd_related,
@@ -561,6 +562,18 @@ def main():
         "Also reads NEUROSTACK_WORKSPACE env var",
     )
     p.set_defaults(func=cmd_graph)
+
+    # graph-analysis
+    p = sub.add_parser(
+        "graph-analysis",
+        help="Structural gaps (unlinked but related) and bridge notes",
+    )
+    p.add_argument("--top-k", type=int, default=10, help="Max gaps and bridges")
+    p.add_argument(
+        "--min-shared", type=int, default=2,
+        help="Minimum shared neighbours for a gap candidate",
+    )
+    p.set_defaults(func=cmd_graph_analysis)
 
     # related
     p = sub.add_parser("related", help="Find semantically related notes")

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -411,6 +411,42 @@ def cmd_graph(args):
                 print(f"     {n.summary[:100]}")
 
 
+def cmd_graph_analysis(args):
+    from ..graph_analysis import analyze_graph
+    from ..schema import DB_PATH, get_db
+
+    result = analyze_graph(
+        get_db(DB_PATH), top_k=args.top_k, min_shared=args.min_shared
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+        return
+
+    s = result["stats"]
+    print(
+        f"\nGraph: {s['notes']} notes, {s['edges']} links, "
+        f"{s['components']} components, {s['isolated']} isolated"
+    )
+
+    gaps = result["gaps"]
+    print(f"\n\U0001f573️  Gaps — related but unlinked (top {len(gaps)}):")
+    for g in gaps:
+        print(
+            f"   {g['a_title']} ↔ {g['b_title']}  "
+            f"(shared {g['shared_neighbors']}, score {g['score']})"
+        )
+    if not gaps:
+        print("   (none)")
+
+    bridges = result["bridges"]
+    print(f"\n\U0001f309 Bridges — hold the graph together (top {len(bridges)}):")
+    for b in bridges:
+        tag = f"  [cut → {b['fragments_if_removed']} pieces]" if b["articulation"] else ""
+        print(f"   {b['title']}  (betweenness {b['betweenness']}){tag}")
+    if not bridges:
+        print("   (none)")
+
+
 def cmd_related(args):
     from ..related import find_related
     results = find_related(

--- a/src/neurostack/graph_analysis.py
+++ b/src/neurostack/graph_analysis.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Structural graph analysis: missing-link gaps and bridge notes (issue #12).
+
+Pure structural computation over the wiki-link graph (``graph_edges``) — no
+embeddings, no LLM — answering two questions:
+
+- **Gaps**: pairs of notes that share many neighbours but aren't linked. Ranked
+  by Adamic-Adar, the standard common-neighbour link-prediction score, which
+  weights a shared neighbour by how rare it is (a link through a hub counts for
+  less than one through a niche note). These are candidate links worth adding.
+- **Bridges**: notes that hold the graph together. Ranked by betweenness
+  centrality (Brandes' algorithm); each is also tested for whether removing it
+  fragments the graph (an articulation point) and into how many pieces.
+
+The graph is treated as undirected: a wiki-link is a connection regardless of
+which note authored it.
+"""
+
+from __future__ import annotations
+
+import collections
+import math
+import sqlite3
+
+
+def _undirected_adjacency(conn: sqlite3.Connection) -> dict[str, set[str]]:
+    """Build undirected neighbour sets keyed by note path.
+
+    Every current note is seeded (so isolated notes are visible), and edges
+    whose endpoints are no longer in ``notes`` are dropped, keeping the
+    adjacency consistent with the live vault rather than stale edge rows.
+    """
+    adj: dict[str, set[str]] = {
+        r["path"]: set() for r in conn.execute("SELECT path FROM notes")
+    }
+    for e in conn.execute("SELECT source_path, target_path FROM graph_edges"):
+        s, t = e["source_path"], e["target_path"]
+        if s == t or s not in adj or t not in adj:
+            continue
+        adj[s].add(t)
+        adj[t].add(s)
+    return adj
+
+
+def find_structural_gaps(
+    adj: dict[str, set[str]], top_k: int = 10, min_shared: int = 2
+) -> list[tuple[str, str, int, float, list[str]]]:
+    """Unlinked note pairs ranked by Adamic-Adar common-neighbour score.
+
+    Returns ``(a, b, shared_count, score, common_neighbours)`` tuples, best
+    first. Accumulated per hub's neighbour pairs — O(sum of degree^2), far
+    cheaper than scoring all note pairs on a sparse graph.
+    """
+    shared: dict[tuple[str, str], list] = {}
+    for _hub, nbrs in adj.items():
+        deg = len(nbrs)
+        if deg < 2:
+            continue
+        weight = 1.0 / math.log(deg)  # deg >= 2, so log(deg) > 0
+        ordered = sorted(nbrs)
+        for i in range(deg):
+            a = ordered[i]
+            for j in range(i + 1, deg):
+                b = ordered[j]
+                rec = shared.get((a, b))
+                if rec is None:
+                    rec = [0, 0.0, []]
+                    shared[(a, b)] = rec
+                rec[0] += 1
+                rec[1] += weight
+                rec[2].append(_hub)
+
+    gaps: list[tuple[str, str, int, float, list[str]]] = []
+    for (a, b), (count, score, commons) in shared.items():
+        if count < min_shared:
+            continue
+        if b in adj.get(a, ()):  # already linked — not a gap
+            continue
+        gaps.append((a, b, count, score, commons))
+
+    gaps.sort(key=lambda g: (g[3], g[2]), reverse=True)
+    return gaps[:top_k]
+
+
+def betweenness_centrality(adj: dict[str, set[str]]) -> dict[str, float]:
+    """Brandes' betweenness centrality on an undirected, unweighted graph."""
+    betw = dict.fromkeys(adj, 0.0)
+    for s in adj:
+        stack: list[str] = []
+        pred: dict[str, list[str]] = {v: [] for v in adj}
+        sigma = dict.fromkeys(adj, 0.0)
+        sigma[s] = 1.0
+        dist = dict.fromkeys(adj, -1)
+        dist[s] = 0
+        queue = collections.deque([s])
+        while queue:
+            v = queue.popleft()
+            stack.append(v)
+            for w in adj[v]:
+                if dist[w] < 0:
+                    dist[w] = dist[v] + 1
+                    queue.append(w)
+                if dist[w] == dist[v] + 1:
+                    sigma[w] += sigma[v]
+                    pred[w].append(v)
+        delta = dict.fromkeys(adj, 0.0)
+        while stack:
+            w = stack.pop()
+            for v in pred[w]:
+                delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w])
+            if w != s:
+                betw[w] += delta[w]
+    # Undirected graph: every shortest path is walked from both endpoints.
+    for v in betw:
+        betw[v] /= 2.0
+    return betw
+
+
+def count_components(adj: dict[str, set[str]], exclude: str | None = None) -> int:
+    """Count connected components. If ``exclude`` is given, that node is treated
+    as removed (used to test whether a node is an articulation point)."""
+    seen: set[str] = set()
+    if exclude is not None:
+        seen.add(exclude)  # pre-mark so it is never visited or counted
+    count = 0
+    for start in adj:
+        if start in seen:
+            continue
+        count += 1
+        stack = [start]
+        seen.add(start)
+        while stack:
+            v = stack.pop()
+            for w in adj[v]:
+                if w not in seen:
+                    seen.add(w)
+                    stack.append(w)
+    return count
+
+
+def _titles(conn: sqlite3.Connection, paths) -> dict[str, str]:
+    """Map note paths to titles (falling back to the path) in one query."""
+    paths = list(paths)
+    if not paths:
+        return {}
+    placeholders = ",".join("?" * len(paths))
+    rows = conn.execute(
+        f"SELECT path, title FROM notes WHERE path IN ({placeholders})", paths
+    ).fetchall()
+    return {r["path"]: (r["title"] or r["path"]) for r in rows}
+
+
+def analyze_graph(
+    conn: sqlite3.Connection, top_k: int = 10, min_shared: int = 2
+) -> dict:
+    """Run the full gaps + bridges analysis and shape it for callers."""
+    adj = _undirected_adjacency(conn)
+
+    edge_count = sum(len(v) for v in adj.values()) // 2
+    stats = {
+        "notes": len(adj),
+        "edges": edge_count,
+        "isolated": sum(1 for v in adj.values() if not v),
+        "components": count_components(adj),
+    }
+
+    gap_tuples = find_structural_gaps(adj, top_k=top_k, min_shared=min_shared)
+
+    betw = betweenness_centrality(adj)
+    bridge_paths = [p for p, score in
+                    sorted(betw.items(), key=lambda kv: kv[1], reverse=True)
+                    if score > 0][:top_k]
+
+    referenced: set[str] = set(bridge_paths)
+    for a, b, _cnt, _score, commons in gap_tuples:
+        referenced.add(a)
+        referenced.add(b)
+        referenced.update(commons[:5])
+    titles = _titles(conn, referenced)
+
+    gaps = [
+        {
+            "a": a,
+            "a_title": titles.get(a, a),
+            "b": b,
+            "b_title": titles.get(b, b),
+            "shared_neighbors": count,
+            "score": round(score, 4),
+            "via": [titles.get(c, c) for c in commons[:5]],
+        }
+        for (a, b, count, score, commons) in gap_tuples
+    ]
+
+    comp_before = stats["components"]
+    bridges = []
+    for p in bridge_paths:
+        comp_after = count_components(adj, exclude=p)
+        articulation = comp_after > comp_before
+        bridges.append({
+            "path": p,
+            "title": titles.get(p, p),
+            "betweenness": round(betw[p], 4),
+            "degree": len(adj[p]),
+            "articulation": articulation,
+            # Pieces the graph splits into when this note is removed (1 = no split).
+            "fragments_if_removed": (comp_after - comp_before + 1) if articulation else 1,
+        })
+
+    return {"stats": stats, "gaps": gaps, "bridges": bridges}

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -342,6 +342,32 @@ def vault_graph(note: str, depth: int = 1, workspace: str = None) -> dict:
     }
 
 
+@registry.tool(tags=["search", "graph"], annotations=_READ_ONLY)
+def vault_graph_analysis(top_k: int = 10, min_shared: int = 2) -> dict:
+    """Find structural gaps and bridge notes in the wiki-link graph.
+
+    Pure structural analysis of the link graph — no embeddings, no LLM:
+    - `gaps`: unlinked note pairs that share many neighbours, ranked by
+      Adamic-Adar (rare shared neighbours count for more). These are candidate
+      links worth adding — notes that discuss overlapping topics but aren't
+      connected.
+    - `bridges`: notes that hold the graph together, ranked by betweenness
+      centrality. Each flags whether removing it fragments the graph (an
+      articulation point) and into how many pieces — the notes whose loss would
+      most isolate parts of the vault.
+    - `stats`: note count, link count, connected components, isolated notes.
+
+    Args:
+        top_k: Max gaps and max bridges to return (default 10 each).
+        min_shared: Minimum shared neighbours for a gap candidate (default 2).
+    """
+    from ..graph_analysis import analyze_graph
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    return analyze_graph(conn, top_k=top_k, min_shared=min_shared)
+
+
 @registry.tool(tags=["search", "semantic"], annotations=_READ_ONLY)
 def vault_related(note: str, top_k: int = 10, workspace: str = None) -> dict:
     """Find semantically related notes using embedding similarity.

--- a/tests/test_graph_analysis.py
+++ b/tests/test_graph_analysis.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for structural graph analysis — gaps and bridges (issue #12)."""
+
+import sqlite3
+
+from neurostack.graph_analysis import (
+    analyze_graph,
+    betweenness_centrality,
+    count_components,
+    find_structural_gaps,
+)
+
+
+def _adj(edges):
+    """Build an undirected adjacency dict from an (a, b) edge list."""
+    adj: dict[str, set[str]] = {}
+    for a, b in edges:
+        adj.setdefault(a, set()).add(b)
+        adj.setdefault(b, set()).add(a)
+    return adj
+
+
+# Two notes X, Y both link the same three hubs A, B, C but not each other.
+SHARED_HUB = _adj([
+    ("X", "A"), ("X", "B"), ("X", "C"),
+    ("Y", "A"), ("Y", "B"), ("Y", "C"),
+])
+
+# Two triangles joined by a single connector D (a barbell).
+BARBELL = _adj([
+    ("A", "B"), ("B", "C"), ("A", "C"),      # triangle 1
+    ("C", "D"), ("D", "E"),                   # bridge C–D–E
+    ("E", "F"), ("F", "G"), ("E", "G"),      # triangle 2
+])
+
+
+class TestGaps:
+    def test_top_gap_is_the_shared_pair(self):
+        gaps = find_structural_gaps(SHARED_HUB, top_k=10, min_shared=2)
+        top = gaps[0]
+        assert (top[0], top[1]) == ("X", "Y")   # keys are stored sorted
+        assert top[2] == 3                        # three shared neighbours
+        assert set(top[4]) == {"A", "B", "C"}
+
+    def test_already_linked_pairs_excluded(self):
+        # X and Y share A,B,C. Add a direct X–Y link → no longer a gap.
+        adj = {k: set(v) for k, v in SHARED_HUB.items()}
+        adj["X"].add("Y")
+        adj["Y"].add("X")
+        gaps = find_structural_gaps(adj, top_k=10, min_shared=2)
+        assert all({a, b} != {"X", "Y"} for a, b, *_ in gaps)
+
+    def test_min_shared_threshold(self):
+        # With min_shared=3 only the X–Y pair (3 shared) qualifies.
+        gaps = find_structural_gaps(SHARED_HUB, top_k=10, min_shared=3)
+        assert len(gaps) == 1
+        assert (gaps[0][0], gaps[0][1]) == ("X", "Y")
+
+    def test_rarer_shared_neighbours_score_higher(self):
+        # A shared hub of degree 2 weighs more than one of degree 10.
+        niche = find_structural_gaps(_adj([("u", "h"), ("v", "h"),
+                                           ("u", "x"), ("v", "x")]),
+                                     min_shared=2)
+        # u,v share h and x (both degree 2) → one gap with score 2/ln(2).
+        assert niche[0][2] == 2
+
+
+class TestBridgesAndComponents:
+    def test_connector_has_highest_betweenness(self):
+        betw = betweenness_centrality(BARBELL)
+        assert max(betw, key=betw.get) == "D"
+        assert betw["D"] > betw["C"]
+
+    def test_component_counting(self):
+        assert count_components(BARBELL) == 1
+        with_isolate = {**{k: set(v) for k, v in BARBELL.items()}, "Z": set()}
+        assert count_components(with_isolate) == 2
+
+    def test_removing_connector_splits_graph(self):
+        # D is an articulation point: removing it yields two components.
+        assert count_components(BARBELL, exclude="D") == 2
+        # A leaf-ish triangle member is not.
+        assert count_components(BARBELL, exclude="A") == 1
+
+
+def _seed_db(notes, edges):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE notes (path TEXT PRIMARY KEY, title TEXT)")
+    conn.execute("CREATE TABLE graph_edges (source_path TEXT, target_path TEXT)")
+    conn.executemany("INSERT INTO notes VALUES (?, ?)", notes)
+    conn.executemany("INSERT INTO graph_edges VALUES (?, ?)", edges)
+    conn.commit()
+    return conn
+
+
+class TestAnalyzeGraphEndToEnd:
+    def test_shaped_output_over_a_db(self):
+        notes = [(p, f"Title {p}") for p in "ABCDEFG"]
+        edges = [("A", "B"), ("B", "C"), ("A", "C"), ("C", "D"),
+                 ("D", "E"), ("E", "F"), ("F", "G"), ("E", "G")]
+        result = analyze_graph(_seed_db(notes, edges), top_k=5)
+
+        assert result["stats"]["notes"] == 7
+        assert result["stats"]["edges"] == 8
+        assert result["stats"]["components"] == 1
+        assert result["stats"]["isolated"] == 0
+
+        top_bridge = result["bridges"][0]
+        assert top_bridge["path"] == "D"
+        assert top_bridge["title"] == "Title D"
+        assert top_bridge["articulation"] is True
+        assert top_bridge["fragments_if_removed"] == 2
+
+    def test_empty_graph(self):
+        result = analyze_graph(_seed_db([], []), top_k=5)
+        assert result["stats"] == {
+            "notes": 0, "edges": 0, "isolated": 0, "components": 0
+        }
+        assert result["gaps"] == []
+        assert result["bridges"] == []
+
+    def test_stale_edges_to_missing_notes_ignored(self):
+        # An edge to a note that no longer exists must not crash or appear.
+        conn = _seed_db([("A", "A"), ("B", "B")], [("A", "B"), ("A", "ghost")])
+        result = analyze_graph(conn, top_k=5)
+        assert result["stats"]["notes"] == 2
+        assert result["stats"]["edges"] == 1

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -138,6 +138,16 @@ def test_vault_search_max_tokens_applies_to_tiered_depth(mcp_vault):
     json.dumps(capped)
 
 
+def test_vault_graph_analysis_structure(mcp_vault):
+    # Issue #12: gaps + bridges + stats, JSON-serialisable over the wire.
+    result = _registry().call("vault_graph_analysis", top_k=5)
+    assert set(result) == {"stats", "gaps", "bridges"}
+    assert {"notes", "edges", "components", "isolated"} <= set(result["stats"])
+    assert isinstance(result["gaps"], list)
+    assert isinstance(result["bridges"], list)
+    json.dumps(result)
+
+
 def test_vault_stats_structure(mcp_vault):
     result = _registry().call("vault_stats")
     for key in ("notes", "chunks", "embedded", "summaries", "graph_edges",


### PR DESCRIPTION
Closes #12.

Identifies structural holes in the wiki-link graph — notes that should be connected but aren't — and the bridge notes that hold otherwise-separate clusters together. Pure structural computation over `graph_edges`: no embeddings, no LLM, so it runs fully offline.

## What it computes

- **Gaps** — unlinked note pairs ranked by **Adamic-Adar** common-neighbour score (a shared neighbour that is itself a hub counts for less than a niche one). These are the "you write about both of these but never linked them" candidates. `min_shared` (default 2) sets the floor on shared neighbours.
- **Bridges** — notes ranked by **betweenness centrality** (Brandes' algorithm). Each is tested for whether removing it fragments the graph (an **articulation point**) and into how many pieces, so you can see which notes' loss would most isolate parts of the vault.
- **Stats** — note count, link count, connected components, isolated notes.

The graph is treated as undirected (a link is a connection regardless of direction), and edges pointing at notes no longer in the index are ignored.

## Surface

- MCP: `vault_graph_analysis(top_k=10, min_shared=2)` → `{stats, gaps, bridges}`.
- CLI: `neurostack graph-analysis [--top-k N] [--min-shared N] [--json]`.

## Tests

`tests/test_graph_analysis.py`: gap ranking + already-linked exclusion + min-shared threshold on a shared-hub graph; betweenness, component counting, and articulation on a barbell graph; and the shaped end-to-end `analyze_graph` output (incl. stale-edge and empty-graph cases). Plus a registry smoke test in `test_mcp_integration.py`. 646 tests pass, ruff clean.