### PR TITLE
Vault diff / change feed (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack summary "note.md"` | Get pre-computed AI summary of a note |
 | `neurostack graph "note.md"` | Wiki-link neighborhood with PageRank scores. `--depth N` |
 | `neurostack graph-analysis` | Structural gaps (related but unlinked) + bridge notes. `--top-k N`, `--min-shared N` |
+| `neurostack diff` | Change feed since a baseline or date. `--since DATE`, `--baseline NAME`, `--checkpoint` |
 | `neurostack related "note.md"` | Find semantically similar notes by embedding distance |
 | `neurostack communities query "question"` | GraphRAG global queries across topic clusters |
 | `neurostack context "task description"` | Assemble task-scoped context for session recovery |
@@ -119,7 +120,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack serve` | Start MCP server. `--transport stdio\|sse\|http`, `--host`, `--port` |
 | `neurostack api` | Start OpenAI-compatible HTTP API. `--host`, `--port` |
 
-## MCP Tools (25 tools)
+## MCP Tools (27 tools)
 
 ### Search & Retrieval
 - `vault_search(query, top_k, mode, depth, context, workspace, max_tokens, reference_only)` - Hybrid search with tiered depth; `max_tokens` caps full-depth/reference output, `reference_only` returns lean {path, score, snippet} + fetch hint (issue #62)
@@ -135,6 +136,8 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_context(task, token_budget, workspace, include_memories, include_triples)` - Task-scoped context recovery
 - `session_brief(workspace)` - Compact session briefing
 - `vault_stats()` - Index health
+- `vault_diff(since, baseline)` - Change feed: added/modified/deleted notes vs a named baseline, or notes changed since a date (issue #11)
+- `vault_checkpoint(baseline)` - Save current vault state as a named diff baseline
 - `vault_record_usage(note_paths)` - Track note hotness
 - `vault_prediction_errors(error_type, limit, resolve, workspace)` - Stale note detection
 

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -18,6 +18,7 @@ from .search import (
     cmd_context,
     cmd_cooccurrence,
     cmd_decay,
+    cmd_diff,
     cmd_eval,
     cmd_feedback,
     cmd_folder_summaries,
@@ -562,6 +563,23 @@ def main():
         "Also reads NEUROSTACK_WORKSPACE env var",
     )
     p.set_defaults(func=cmd_graph)
+
+    # diff
+    p = sub.add_parser(
+        "diff", help="Show vault changes since a baseline or a date"
+    )
+    p.add_argument(
+        "--since", default=None,
+        help="ISO date/datetime; date mode (added + modified, no deletions)",
+    )
+    p.add_argument(
+        "--baseline", default="default", help="Named baseline to diff against"
+    )
+    p.add_argument(
+        "--checkpoint", action="store_true",
+        help="Save current state as the baseline after diffing",
+    )
+    p.set_defaults(func=cmd_diff)
 
     # graph-analysis
     p = sub.add_parser(

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -447,6 +447,47 @@ def cmd_graph_analysis(args):
         print("   (none)")
 
 
+def cmd_diff(args):
+    from ..diff import compute_diff, save_checkpoint
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    result = compute_diff(conn, since=args.since, baseline=args.baseline)
+    if args.checkpoint and not args.since:
+        result["checkpoint"] = save_checkpoint(conn, baseline=args.baseline)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+        return
+
+    if result["mode"] == "since_date":
+        print(f"\nChanged since {result['since']} ({result['changed_count']}):")
+        for c in result["changed"]:
+            print(f"   ~ {c['title']} ({c['path']})  {c['updated_at']}")
+        print("   (date mode: additions + modifications combined; "
+              "deletions need a baseline)")
+        return
+
+    if not result["has_baseline"]:
+        print(f"\nNo baseline '{result['baseline']}' saved yet — "
+              f"everything reads as new. Run with --checkpoint to set one.")
+    else:
+        print(f"\nChanges since baseline '{result['baseline']}' "
+              f"(saved {result['baseline_saved_at']}):")
+    print(f"   + {result['added_count']} added, "
+          f"~ {result['modified_count']} modified, "
+          f"- {result['deleted_count']} deleted")
+    for a in result["added"]:
+        print(f"   + {a['title']} ({a['path']})")
+    for m in result["modified"]:
+        print(f"   ~ {m['title']} ({m['path']})")
+    for d in result["deleted"]:
+        print(f"   - {d['path']}")
+    if result.get("checkpoint"):
+        ck = result["checkpoint"]
+        print(f"\nCheckpoint saved: {ck['notes']} notes @ {ck['saved_at']}")
+
+
 def cmd_related(args):
     from ..related import find_related
     results = find_related(

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -448,13 +448,22 @@ def cmd_graph_analysis(args):
 
 
 def cmd_diff(args):
+    import sys
+
     from ..diff import compute_diff, save_checkpoint
     from ..schema import DB_PATH, get_db
 
     conn = get_db(DB_PATH)
     result = compute_diff(conn, since=args.since, baseline=args.baseline)
-    if args.checkpoint and not args.since:
-        result["checkpoint"] = save_checkpoint(conn, baseline=args.baseline)
+    if args.checkpoint:
+        if args.since:
+            print(
+                "Note: --checkpoint is ignored in date mode (--since); "
+                "baselines apply to baseline mode only.",
+                file=sys.stderr,
+            )
+        else:
+            result["checkpoint"] = save_checkpoint(conn, baseline=args.baseline)
 
     if args.json:
         print(json.dumps(result, indent=2, default=str))

--- a/src/neurostack/diff.py
+++ b/src/neurostack/diff.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Vault diff / change feed: what changed since a baseline or a date (issue #11).
+
+The notes table carries no created_at and deletions are hard deletes, so
+additions and deletions can only be recovered by comparing the current index
+against a stored baseline. ``diff_snapshots`` holds named baselines of
+``{path -> content_hash}``: ``save_checkpoint`` records one, ``compute_diff``
+reports the delta. A date mode (``since``) needs no baseline but can only
+surface added-or-modified notes via ``updated_at``, not deletions.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+DEFAULT_BASELINE = "default"
+
+
+def _titles(conn: sqlite3.Connection, paths) -> dict[str, str]:
+    """Map note paths to titles (falling back to the path) in one query."""
+    paths = list(paths)
+    if not paths:
+        return {}
+    placeholders = ",".join("?" * len(paths))
+    rows = conn.execute(
+        f"SELECT path, title FROM notes WHERE path IN ({placeholders})", paths
+    ).fetchall()
+    return {r["path"]: (r["title"] or r["path"]) for r in rows}
+
+
+def compute_diff(
+    conn: sqlite3.Connection, since: str | None = None, baseline: str = DEFAULT_BASELINE
+) -> dict:
+    """Report vault changes. Read-only — never writes a baseline.
+
+    Date mode (``since`` given): notes with ``updated_at > since`` (additions and
+    modifications combined; deletions aren't detectable this way). Baseline mode
+    (default): added / modified / deleted vs the named stored baseline.
+    """
+    if since:
+        rows = conn.execute(
+            "SELECT path, title, updated_at FROM notes"
+            " WHERE updated_at > ? ORDER BY updated_at DESC",
+            (since,),
+        ).fetchall()
+        changed = [
+            {
+                "path": r["path"],
+                "title": r["title"] or r["path"],
+                "updated_at": r["updated_at"],
+            }
+            for r in rows
+        ]
+        return {
+            "mode": "since_date",
+            "since": since,
+            "changed": changed,
+            "changed_count": len(changed),
+            "note": "Date mode combines additions and modifications (updated_at);"
+                    " deletions need baseline mode.",
+        }
+
+    current = {
+        r["path"]: r["content_hash"]
+        for r in conn.execute("SELECT path, content_hash FROM notes")
+    }
+    snap_rows = conn.execute(
+        "SELECT path, content_hash, saved_at FROM diff_snapshots WHERE baseline = ?",
+        (baseline,),
+    ).fetchall()
+    snapshot = {r["path"]: r["content_hash"] for r in snap_rows}
+
+    added = sorted(p for p in current if p not in snapshot)
+    deleted = sorted(p for p in snapshot if p not in current)
+    modified = sorted(
+        p for p in current if p in snapshot and current[p] != snapshot[p]
+    )
+    titles = _titles(conn, added + modified)
+
+    return {
+        "mode": "baseline",
+        "baseline": baseline,
+        "baseline_saved_at": snap_rows[0]["saved_at"] if snap_rows else None,
+        "has_baseline": bool(snap_rows),
+        "added": [{"path": p, "title": titles.get(p, p)} for p in added],
+        "modified": [{"path": p, "title": titles.get(p, p)} for p in modified],
+        "deleted": [{"path": p} for p in deleted],
+        "added_count": len(added),
+        "modified_count": len(modified),
+        "deleted_count": len(deleted),
+    }
+
+
+def save_checkpoint(
+    conn: sqlite3.Connection, baseline: str = DEFAULT_BASELINE
+) -> dict:
+    """Save the current index state as the named baseline.
+
+    Overwrites any prior snapshot for that name. A later ``compute_diff`` against
+    this baseline reports what changed since. Returns the note count and the
+    save timestamp.
+    """
+    current = conn.execute("SELECT path, content_hash FROM notes").fetchall()
+    now = conn.execute("SELECT datetime('now') AS t").fetchone()["t"]
+    conn.execute("DELETE FROM diff_snapshots WHERE baseline = ?", (baseline,))
+    conn.executemany(
+        "INSERT INTO diff_snapshots (baseline, path, content_hash, saved_at)"
+        " VALUES (?, ?, ?, ?)",
+        [(baseline, r["path"], r["content_hash"], now) for r in current],
+    )
+    conn.commit()
+    return {"baseline": baseline, "saved_at": now, "notes": len(current)}

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -98,6 +98,17 @@ CREATE TABLE IF NOT EXISTS graph_stats (
     in_degree INTEGER DEFAULT 0,
     out_degree INTEGER DEFAULT 0,
     pagerank REAL DEFAULT 0.0
+);
+
+-- Diff baselines: named snapshots of {path -> content_hash} for the change
+-- feed (issue #11). additions/deletions are only recoverable by comparing the
+-- current index against a stored baseline (notes has no created_at, hard deletes).
+CREATE TABLE IF NOT EXISTS diff_snapshots (
+    baseline TEXT NOT NULL,
+    path TEXT NOT NULL,
+    content_hash TEXT,
+    saved_at TEXT NOT NULL,
+    PRIMARY KEY (baseline, path)
 );
 
 -- Knowledge graph triples (Phase 2: structured encoding)
@@ -981,6 +992,17 @@ def _run_migrations(conn: sqlite3.Connection):
         )
         conn.commit()
         log.info("Migration to v19 complete.")
+
+    if current < 20:
+        log.info("Migrating schema v19 -> v20: adding diff_snapshots (issue #11)...")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS diff_snapshots ("
+            " baseline TEXT NOT NULL, path TEXT NOT NULL, content_hash TEXT,"
+            " saved_at TEXT NOT NULL, PRIMARY KEY (baseline, path))"
+        )
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (20)")
+        conn.commit()
+        log.info("Migration to v20 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -465,6 +465,46 @@ def vault_communities(
     return result
 
 
+@registry.tool(tags=["search", "diff"], annotations=_READ_ONLY)
+def vault_diff(since: str = None, baseline: str = "default") -> dict:
+    """Show what changed in the vault: additions, modifications, deletions.
+
+    Two modes:
+    - Baseline (default): diff the current index against a named stored baseline
+      (saved via vault_checkpoint). Reports added / modified / deleted notes —
+      deletions and additions are only visible this way. `has_baseline` is False
+      until you checkpoint at least once (until then every note reads as added).
+    - Date (`since` given): notes with `updated_at` after an ISO date/datetime.
+      Combines additions and modifications; cannot surface deletions.
+
+    Args:
+        since: Optional ISO date/datetime (e.g. "2026-07-01") to enable date mode.
+        baseline: Named baseline to diff against in baseline mode (default "default").
+    """
+    from ..diff import compute_diff
+    from ..schema import DB_PATH, get_db
+
+    return compute_diff(get_db(DB_PATH), since=since, baseline=baseline)
+
+
+@registry.tool(tags=["search", "diff"], annotations=_WRITE_ADDITIVE)
+def vault_checkpoint(baseline: str = "default") -> dict:
+    """Record the current vault state as a named diff baseline.
+
+    Saves `{path -> content_hash}` for every indexed note under `baseline`,
+    overwriting any previous snapshot of that name. A later vault_diff(baseline=…)
+    then reports what changed since this checkpoint. Use distinct names for
+    independent cursors (e.g. one per autonomous loop).
+
+    Args:
+        baseline: Baseline name to save under (default "default").
+    """
+    from ..diff import save_checkpoint
+    from ..schema import DB_PATH, get_db
+
+    return save_checkpoint(get_db(DB_PATH), baseline=baseline)
+
+
 @registry.tool(tags=["search", "stats"], annotations=_READ_ONLY)
 def vault_stats() -> dict:
     """Get index health: note count, embedding coverage, graph stats, triple stats."""

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for the vault diff / change feed (issue #11)."""
+
+import pytest
+
+from neurostack import config as nsconfig
+from neurostack.diff import compute_diff, save_checkpoint
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db(tmp_path / "t.db")
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _add(conn, path, content_hash, title=None,
+         updated_at="2026-07-01T00:00:00+00:00"):
+    conn.execute(
+        "INSERT OR REPLACE INTO notes (path, title, content_hash, updated_at)"
+        " VALUES (?, ?, ?, ?)",
+        (path, title or path, content_hash, updated_at),
+    )
+    conn.commit()
+
+
+class TestBaselineMode:
+    def test_no_baseline_everything_is_added(self, db):
+        _add(db, "a.md", "h1")
+        _add(db, "b.md", "h2")
+        d = compute_diff(db)
+        assert d["mode"] == "baseline"
+        assert d["has_baseline"] is False
+        assert d["added_count"] == 2
+        assert {x["path"] for x in d["added"]} == {"a.md", "b.md"}
+        assert d["modified_count"] == 0 and d["deleted_count"] == 0
+
+    def test_checkpoint_then_no_changes(self, db):
+        _add(db, "a.md", "h1")
+        ck = save_checkpoint(db)
+        assert ck["notes"] == 1
+        d = compute_diff(db)
+        assert d["has_baseline"] is True
+        assert d["added_count"] == d["modified_count"] == d["deleted_count"] == 0
+        assert d["baseline_saved_at"] == ck["saved_at"]
+
+    def test_add_modify_delete(self, db):
+        _add(db, "keep.md", "h1")
+        _add(db, "gone.md", "h2")
+        _add(db, "edit.md", "h3")
+        save_checkpoint(db)
+        db.execute("DELETE FROM notes WHERE path = ?", ("gone.md",))
+        db.execute(
+            "UPDATE notes SET content_hash = ? WHERE path = ?", ("h3b", "edit.md")
+        )
+        _add(db, "new.md", "h4")
+        d = compute_diff(db)
+        assert {x["path"] for x in d["added"]} == {"new.md"}
+        assert {x["path"] for x in d["modified"]} == {"edit.md"}
+        assert {x["path"] for x in d["deleted"]} == {"gone.md"}
+        # unchanged note must not appear anywhere
+        touched = {x["path"] for x in d["added"] + d["modified"]} | {
+            x["path"] for x in d["deleted"]
+        }
+        assert "keep.md" not in touched
+
+    def test_named_baselines_are_independent(self, db):
+        _add(db, "a.md", "h1")
+        save_checkpoint(db, baseline="loop-a")
+        _add(db, "b.md", "h2")  # added after loop-a's checkpoint
+        da = compute_diff(db, baseline="loop-a")
+        assert {x["path"] for x in da["added"]} == {"b.md"}
+        db_fresh = compute_diff(db, baseline="loop-b")  # never checkpointed
+        assert db_fresh["has_baseline"] is False
+        assert db_fresh["added_count"] == 2
+
+    def test_checkpoint_overwrites(self, db):
+        _add(db, "a.md", "h1")
+        save_checkpoint(db)
+        _add(db, "b.md", "h2")
+        save_checkpoint(db)  # baseline now includes both
+        assert compute_diff(db)["added_count"] == 0
+
+
+class TestDateMode:
+    def test_since_filters_by_updated_at(self, db):
+        _add(db, "old.md", "h1", updated_at="2026-06-01T00:00:00+00:00")
+        _add(db, "new.md", "h2", updated_at="2026-07-04T00:00:00+00:00")
+        d = compute_diff(db, since="2026-07-01")
+        assert d["mode"] == "since_date"
+        assert {x["path"] for x in d["changed"]} == {"new.md"}
+        assert d["changed_count"] == 1
+
+    def test_since_ignores_baseline_keys(self, db):
+        _add(db, "n.md", "h1", updated_at="2026-07-04T00:00:00+00:00")
+        d = compute_diff(db, since="2026-01-01", baseline="whatever")
+        assert d["mode"] == "since_date"
+        assert "added" not in d and "deleted" not in d
+
+
+def test_fresh_db_has_diff_snapshots(db):
+    # A fresh get_db stamps v20 via SCHEMA_SQL; the table must exist.
+    row = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='diff_snapshots'"
+    ).fetchone()
+    assert row is not None
+    v = db.execute("SELECT MAX(version) AS v FROM schema_version").fetchone()["v"]
+    assert v >= 20
+
+
+def test_v19_to_v20_upgrade_path():
+    # The path that runs on the live LXC 122 DB (currently v19): the lazy
+    # migration must create diff_snapshots and bump the stamped version to 20.
+    import sqlite3
+
+    from neurostack.schema import _run_migrations
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    conn.execute("INSERT INTO schema_version VALUES (19)")
+    conn.commit()
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE name='diff_snapshots'"
+    ).fetchone() is None
+
+    _run_migrations(conn)
+
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE name='diff_snapshots'"
+    ).fetchone() is not None
+    assert conn.execute(
+        "SELECT MAX(version) AS v FROM schema_version"
+    ).fetchone()["v"] == 20
+

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -138,6 +138,23 @@ def test_vault_search_max_tokens_applies_to_tiered_depth(mcp_vault):
     json.dumps(capped)
 
 
+def test_vault_diff_and_checkpoint(mcp_vault):
+    # Issue #11: no baseline → all added; checkpoint → next diff is clean.
+    reg = _registry()
+    d0 = reg.call("vault_diff")
+    assert d0["mode"] == "baseline"
+    assert d0["has_baseline"] is False
+    assert d0["added_count"] == 4  # fixture vault: 3 notes + index.md
+
+    ck = reg.call("vault_checkpoint")
+    assert ck["notes"] == 4
+
+    d1 = reg.call("vault_diff")
+    assert d1["has_baseline"] is True
+    assert d1["added_count"] == d1["modified_count"] == d1["deleted_count"] == 0
+    json.dumps(d1)
+
+
 def test_vault_graph_analysis_structure(mcp_vault):
     # Issue #12: gaps + bridges + stats, JSON-serialisable over the wire.
     result = _registry().call("vault_graph_analysis", top_k=5)


### PR DESCRIPTION
Closes #11.

Shows what changed in the vault — additions, modifications, and deletions. The `notes` table has no `created_at` and deletions are hard deletes, so adds/deletes can only be recovered by comparing the current index against a stored baseline. This adds a lightweight baseline mechanism plus a date-based mode.

## Design

- **schema v20** — new `diff_snapshots` table holding named baselines of `{path → content_hash}`. Additive migration; the v19→v20 upgrade path is tested (it runs on the live LXC 122 DB on deploy).
- **`vault_diff(since=None, baseline="default")`** (read-only) — baseline mode reports `added` / `modified` / `deleted` vs the named baseline; date mode (`since`) lists notes with `updated_at` after an ISO date (adds+mods combined; deletions need a baseline). `has_baseline` is False until the first checkpoint, so the "everything looks new" first run is explicit rather than misleading.
- **`vault_checkpoint(baseline="default")`** (write) — saves the current state as a named baseline. Read and write are split into two tools so the MCP annotations stay honest (diff never mutates). Distinct baseline names give independent cursors — one per autonomous loop, say, so each consumer tracks "what changed since I last looked" without stepping on the others.
- **CLI** — `neurostack diff [--since DATE] [--baseline NAME] [--checkpoint] [--json]`.

This pairs naturally with the #62 lean-retrieval work: a context-windowed loop can checkpoint each iteration and ask "what changed since" on the next.

## Tests

`tests/test_diff.py`: add/modify/delete detection, unchanged-note exclusion, named-baseline independence, checkpoint overwrite, date mode, fresh-DB table presence, and the **v19→v20 migration upgrade path**. Plus a `vault_diff`/`vault_checkpoint` round-trip in `test_mcp_integration.py`. 655 tests pass, ruff clean.