### PR TITLE
Memory drift detection via prediction_errors (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_diff(since, baseline)` - Change feed: added/modified/deleted notes vs a named baseline, or notes changed since a date (issue #11)
 - `vault_checkpoint(baseline)` - Save current vault state as a named diff baseline
 - `vault_record_usage(note_paths)` - Track note hotness
-- `vault_prediction_errors(error_type, limit, resolve, workspace)` - Stale note detection
+- `vault_prediction_errors(error_type, limit, resolve, workspace, memory_id)` - Stale-note detection + memory drift: memories that no longer match the notes they reference (`error_type="memory_drift"`, issue #38)
 
 ### Memories
 - `vault_remember(content, tags, entity_type, source_agent, workspace, ttl_hours, session_id)` - Save memory

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -861,7 +861,7 @@ def cmd_prediction_errors(args):
             "UPDATE prediction_errors"
             " SET resolved_at = datetime('now')"
             f" WHERE note_path IN ({placeholders})"
-            " AND resolved_at IS NULL",
+            " AND memory_id IS NULL AND resolved_at IS NULL",
             paths,
         )
         conn.commit()
@@ -871,7 +871,9 @@ def cmd_prediction_errors(args):
         print(f"Resolved {len(paths)} note(s).")
         return
 
-    where = "WHERE resolved_at IS NULL"
+    # Note-centric only: memory_drift rows (memory_id set) are surfaced by the
+    # vault_prediction_errors MCP tool, not this aggregated note view (issue #38).
+    where = "WHERE resolved_at IS NULL AND memory_id IS NULL"
     params = []
     if args.type:
         where += " AND error_type = ?"
@@ -899,7 +901,7 @@ def cmd_prediction_errors(args):
         params + [PREDICTION_ERROR_MIN_OCCURRENCES, args.limit],
     ).fetchall()
 
-    total_where = "WHERE resolved_at IS NULL"
+    total_where = "WHERE resolved_at IS NULL AND memory_id IS NULL"
     total_params = []
     if ws:
         total_where += " AND note_path LIKE ? || '%'"

--- a/src/neurostack/context.py
+++ b/src/neurostack/context.py
@@ -48,6 +48,9 @@ def build_vault_context(
                 conn, query=task, workspace=workspace,
                 limit=10, embed_url=url,
             )
+            # Memory drift detection (issue #38), non-blocking.
+            from .memory_drift import check_memory_drift
+            check_memory_drift(conn, memories)
             mem_entries = []
             for m in memories:
                 if m.score and m.score < 0.3:

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -256,6 +256,10 @@ def forget_memory(conn: sqlite3.Connection, memory_id: int) -> bool:
     row = conn.execute(
         "SELECT file_path FROM memories WHERE memory_id = ?", (memory_id,)
     ).fetchone()
+    # Clear any memory_drift rows for this memory (issue #38). ON DELETE CASCADE
+    # on the FK also handles this; the explicit delete keeps it robust regardless
+    # of the foreign_keys pragma state.
+    conn.execute("DELETE FROM prediction_errors WHERE memory_id = ?", (memory_id,))
     cursor = conn.execute(
         "DELETE FROM memories WHERE memory_id = ?", (memory_id,)
     )
@@ -384,6 +388,11 @@ def update_memory(
     sql = f"UPDATE memories SET {', '.join(set_clauses)} WHERE memory_id = ?"
     params.append(memory_id)
     conn.execute(sql, params)
+
+    # Editing a memory IS reconciliation: its content just changed, so any open
+    # drift flag against the old content no longer holds (issue #38).
+    from .memory_drift import resolve_memory_drift
+    resolve_memory_drift(conn, memory_id)
     conn.commit()
 
     updated_row = conn.execute(

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -389,10 +389,12 @@ def update_memory(
     params.append(memory_id)
     conn.execute(sql, params)
 
-    # Editing a memory IS reconciliation: its content just changed, so any open
-    # drift flag against the old content no longer holds (issue #38).
-    from .memory_drift import resolve_memory_drift
-    resolve_memory_drift(conn, memory_id)
+    # A content edit changes the memory's embedding, so any open drift flag
+    # against the old content no longer holds — reconcile it (issue #38). A
+    # tags/TTL/workspace-only edit leaves the embedding (and the drift) intact.
+    if content is not None:
+        from .memory_drift import resolve_memory_drift
+        resolve_memory_drift(conn, memory_id)
     conn.commit()
 
     updated_row = conn.execute(

--- a/src/neurostack/memory_drift.py
+++ b/src/neurostack/memory_drift.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Memory drift detection (issue #38).
+
+When an agent-written memory references vault notes via `[[wiki-links]]`, the
+note it points at can move on while the memory stays frozen — a memory saying
+"X is a blocker in [[project]]" is stale once the project note records X as
+done. NeuroStack already models "retrieval diverged from expectation" as a
+prediction error; memory drift is the same signal applied to the memory layer.
+
+At memory-retrieval time we compare the memory's stored embedding to the
+current chunk embeddings of the notes it links. If the best match is far enough
+(cosine distance over threshold), we write a `memory_drift` row to
+`prediction_errors` — surfaced by `vault_prediction_errors`, reconciled by the
+existing `vault_update_memory` / `vault_forget`. All computation is on stored
+embeddings, so no live embedder call and no git/external awareness in core.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+# Cosine distance over which a memory is considered drifted from a note.
+# Calibrated against the production embed model (embeddinggemma:300m) on realistic
+# memory/note pairs: an aligned memory sits around 0.25, a memory whose note now
+# contradicts it ("blocker" -> "resolved") around 0.50, unrelated content above
+# 0.8. 0.40 separates aligned from drifted with margin. The note-centric
+# low_overlap distance (~0.62) is tuned for query↔note fit and is too slack here —
+# it would miss the resolved-note case, the whole point of drift detection.
+# Detection takes the MAX similarity across a note's chunks, so drift only fires
+# when the memory is far from every chunk — conservative by design.
+DRIFT_THRESHOLD = 0.40
+# Skip re-inserting a drift row for the same (memory, note) seen this recently;
+# refresh the existing row instead so hot retrievals don't flood the log.
+DRIFT_DEBOUNCE_HOURS = 24
+
+
+def detect_memory_drift(
+    conn: sqlite3.Connection,
+    memory_id: int,
+    content: str,
+    embedding,
+    threshold: float = DRIFT_THRESHOLD,
+    debounce_hours: int = DRIFT_DEBOUNCE_HOURS,
+) -> list[dict]:
+    """Detect drift of one memory from the notes it wiki-links.
+
+    `embedding` is the memory's stored embedding (numpy array). Returns the list
+    of drift records written/refreshed (for observability); empty when the
+    memory has no embedding, no resolvable links, or no drift.
+    """
+    if embedding is None or not content:
+        return []
+
+    from .chunker import extract_wiki_links
+    from .graph import _build_link_index, resolve_wiki_link
+
+    links = extract_wiki_links(content)
+    if not links:
+        return []
+
+    all_paths = [r["path"] for r in conn.execute("SELECT path FROM notes")]
+    if not all_paths:
+        return []
+    index = _build_link_index(all_paths)
+
+    resolved: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for link in links:
+        path = resolve_wiki_link(link, all_paths, _link_index=index)
+        if path and path not in seen:
+            seen.add(path)
+            resolved.append((link, path))
+    if not resolved:
+        return []
+
+    import numpy as np
+
+    from .embedder import blob_to_embedding, cosine_similarity_batch
+
+    written = []
+    for link, note_path in resolved:
+        rows = conn.execute(
+            "SELECT embedding FROM chunks"
+            " WHERE note_path = ? AND embedding IS NOT NULL",
+            (note_path,),
+        ).fetchall()
+        if not rows:
+            continue
+        matrix = np.vstack([blob_to_embedding(r["embedding"]) for r in rows])
+        max_sim = float(cosine_similarity_batch(embedding, matrix).max())
+        distance = 1.0 - max_sim
+        if distance <= threshold:
+            continue
+        context = json.dumps({"wiki_link": link, "max_sim": round(max_sim, 4)})
+        _write_drift(conn, memory_id, note_path, distance, context, debounce_hours)
+        written.append(
+            {"memory_id": memory_id, "note_path": note_path,
+             "cosine_distance": round(distance, 4)}
+        )
+    return written
+
+
+def _write_drift(
+    conn: sqlite3.Connection,
+    memory_id: int,
+    note_path: str,
+    distance: float,
+    context: str,
+    debounce_hours: int,
+) -> None:
+    """Insert a memory_drift row, or refresh an existing unresolved one for the
+    same (memory, note) within the debounce window (keeping the strongest signal)."""
+    existing = conn.execute(
+        "SELECT error_id, cosine_distance FROM prediction_errors"
+        " WHERE memory_id = ? AND note_path = ? AND error_type = 'memory_drift'"
+        "   AND resolved_at IS NULL"
+        "   AND detected_at > datetime('now', ?)"
+        " ORDER BY detected_at DESC LIMIT 1",
+        (memory_id, note_path, f"-{int(debounce_hours)} hours"),
+    ).fetchone()
+
+    if existing:
+        if distance > existing["cosine_distance"]:
+            conn.execute(
+                "UPDATE prediction_errors SET cosine_distance = ?, context = ?,"
+                " detected_at = datetime('now') WHERE error_id = ?",
+                (round(distance, 4), context, existing["error_id"]),
+            )
+            conn.commit()
+        return
+
+    conn.execute(
+        "INSERT INTO prediction_errors"
+        " (note_path, memory_id, query, cosine_distance, error_type, context)"
+        " VALUES (?, ?, ?, ?, 'memory_drift', ?)",
+        (note_path, memory_id, f"memory:{memory_id}", round(distance, 4), context),
+    )
+    conn.commit()
+
+
+def check_memory_drift(conn: sqlite3.Connection, memories) -> None:
+    """Run drift detection for a batch of just-retrieved memories. Non-blocking:
+    any failure (no numpy in lite mode, embedder blobs absent, etc.) is swallowed
+    so retrieval is never disrupted."""
+    try:
+        ids = [m.memory_id for m in memories]
+        if not ids:
+            return
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"SELECT memory_id, content, embedding FROM memories"
+            f" WHERE memory_id IN ({placeholders}) AND embedding IS NOT NULL",
+            ids,
+        ).fetchall()
+        if not rows:
+            return
+        from .embedder import blob_to_embedding
+
+        for r in rows:
+            detect_memory_drift(
+                conn, r["memory_id"], r["content"],
+                blob_to_embedding(r["embedding"]),
+            )
+    except Exception:
+        pass  # drift detection must never disrupt retrieval
+
+
+def resolve_memory_drift(conn: sqlite3.Connection, memory_id: int) -> int:
+    """Mark all open drift rows for a memory resolved (its content just changed,
+    so the frozen-vs-current comparison no longer holds). Returns rows affected."""
+    cur = conn.execute(
+        "UPDATE prediction_errors SET resolved_at = datetime('now')"
+        " WHERE memory_id = ? AND error_type = 'memory_drift' AND resolved_at IS NULL",
+        (memory_id,),
+    )
+    return cur.rowcount

--- a/src/neurostack/memory_drift.py
+++ b/src/neurostack/memory_drift.py
@@ -31,9 +31,6 @@ import sqlite3
 # Detection takes the MAX similarity across a note's chunks, so drift only fires
 # when the memory is far from every chunk — conservative by design.
 DRIFT_THRESHOLD = 0.40
-# Skip re-inserting a drift row for the same (memory, note) seen this recently;
-# refresh the existing row instead so hot retrievals don't flood the log.
-DRIFT_DEBOUNCE_HOURS = 24
 
 
 def detect_memory_drift(
@@ -42,13 +39,14 @@ def detect_memory_drift(
     content: str,
     embedding,
     threshold: float = DRIFT_THRESHOLD,
-    debounce_hours: int = DRIFT_DEBOUNCE_HOURS,
+    link_index=None,
 ) -> list[dict]:
     """Detect drift of one memory from the notes it wiki-links.
 
-    `embedding` is the memory's stored embedding (numpy array). Returns the list
-    of drift records written/refreshed (for observability); empty when the
-    memory has no embedding, no resolvable links, or no drift.
+    `embedding` is the memory's stored embedding (numpy array). Pass `link_index`
+    (from graph._build_link_index) to reuse one index across a batch of memories.
+    Returns the drift records written/refreshed; empty when the memory has no
+    embedding, no resolvable links, or no drift.
     """
     if embedding is None or not content:
         return []
@@ -60,15 +58,17 @@ def detect_memory_drift(
     if not links:
         return []
 
-    all_paths = [r["path"] for r in conn.execute("SELECT path FROM notes")]
-    if not all_paths:
-        return []
-    index = _build_link_index(all_paths)
+    all_paths: list = []
+    if link_index is None:
+        all_paths = [r["path"] for r in conn.execute("SELECT path FROM notes")]
+        if not all_paths:
+            return []
+        link_index = _build_link_index(all_paths)
 
     resolved: list[tuple[str, str]] = []
     seen: set[str] = set()
     for link in links:
-        path = resolve_wiki_link(link, all_paths, _link_index=index)
+        path = resolve_wiki_link(link, all_paths, _link_index=link_index)
         if path and path not in seen:
             seen.add(path)
             resolved.append((link, path))
@@ -94,7 +94,7 @@ def detect_memory_drift(
         if distance <= threshold:
             continue
         context = json.dumps({"wiki_link": link, "max_sim": round(max_sim, 4)})
-        _write_drift(conn, memory_id, note_path, distance, context, debounce_hours)
+        _write_drift(conn, memory_id, note_path, distance, context)
         written.append(
             {"memory_id": memory_id, "note_path": note_path,
              "cosine_distance": round(distance, 4)}
@@ -108,17 +108,16 @@ def _write_drift(
     note_path: str,
     distance: float,
     context: str,
-    debounce_hours: int,
 ) -> None:
-    """Insert a memory_drift row, or refresh an existing unresolved one for the
-    same (memory, note) within the debounce window (keeping the strongest signal)."""
+    """Keep exactly one open drift row per (memory, note): refresh the existing
+    unresolved row with the stronger signal, or insert the first one. A new open
+    row is only created after the prior one is resolved (a genuinely new drift)."""
     existing = conn.execute(
         "SELECT error_id, cosine_distance FROM prediction_errors"
         " WHERE memory_id = ? AND note_path = ? AND error_type = 'memory_drift'"
         "   AND resolved_at IS NULL"
-        "   AND detected_at > datetime('now', ?)"
         " ORDER BY detected_at DESC LIMIT 1",
-        (memory_id, note_path, f"-{int(debounce_hours)} hours"),
+        (memory_id, note_path),
     ).fetchone()
 
     if existing:
@@ -143,7 +142,8 @@ def _write_drift(
 def check_memory_drift(conn: sqlite3.Connection, memories) -> None:
     """Run drift detection for a batch of just-retrieved memories. Non-blocking:
     any failure (no numpy in lite mode, embedder blobs absent, etc.) is swallowed
-    so retrieval is never disrupted."""
+    so retrieval is never disrupted. The wiki-link index is built once and reused
+    across the batch."""
     try:
         ids = [m.memory_id for m in memories]
         if not ids:
@@ -156,12 +156,19 @@ def check_memory_drift(conn: sqlite3.Connection, memories) -> None:
         ).fetchall()
         if not rows:
             return
+
         from .embedder import blob_to_embedding
+        from .graph import _build_link_index
+
+        all_paths = [r["path"] for r in conn.execute("SELECT path FROM notes")]
+        if not all_paths:
+            return
+        link_index = _build_link_index(all_paths)
 
         for r in rows:
             detect_memory_drift(
                 conn, r["memory_id"], r["content"],
-                blob_to_embedding(r["embedding"]),
+                blob_to_embedding(r["embedding"]), link_index=link_index,
             )
     except Exception:
         pass  # drift detection must never disrupt retrieval

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -229,10 +229,13 @@ CREATE INDEX IF NOT EXISTS idx_search_feedback_time ON search_feedback(created_a
 
 -- Prediction error log: signal-driven vault maintenance
 -- Populated at retrieval time when cosine distance exceeds threshold.
--- error_type: 'low_overlap' | 'contextual_mismatch'
+-- error_type: 'low_overlap' | 'contextual_mismatch' (note-centric)
+--           | 'memory_drift' — a memory drifted from the notes it references
+--             (issue #38); such rows carry both note_path and memory_id.
 CREATE TABLE IF NOT EXISTS prediction_errors (
     error_id INTEGER PRIMARY KEY AUTOINCREMENT,
     note_path TEXT NOT NULL,
+    memory_id INTEGER REFERENCES memories(memory_id) ON DELETE CASCADE,
     query TEXT NOT NULL,
     cosine_distance REAL NOT NULL,
     error_type TEXT NOT NULL,
@@ -243,6 +246,8 @@ CREATE TABLE IF NOT EXISTS prediction_errors (
 
 CREATE INDEX IF NOT EXISTS idx_pred_errors_note ON prediction_errors(note_path);
 CREATE INDEX IF NOT EXISTS idx_pred_errors_type ON prediction_errors(error_type);
+CREATE INDEX IF NOT EXISTS idx_pred_errors_memory
+    ON prediction_errors(memory_id) WHERE memory_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_pred_errors_unresolved
     ON prediction_errors(resolved_at) WHERE resolved_at IS NULL;
 
@@ -1003,6 +1008,31 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (20)")
         conn.commit()
         log.info("Migration to v20 complete.")
+
+    if current < 21:
+        log.info(
+            "Migrating schema v20 -> v21: prediction_errors.memory_id "
+            "for memory drift (issue #38)..."
+        )
+        cols = {
+            r[1] for r in conn.execute(
+                "PRAGMA table_info(prediction_errors)"
+            ).fetchall()
+        }
+        if "memory_id" not in cols:
+            # ADD COLUMN keeps existing rows and their data intact — no rebuild.
+            # note_path stays NOT NULL: drift rows carry both note_path and memory_id.
+            conn.execute(
+                "ALTER TABLE prediction_errors ADD COLUMN memory_id INTEGER"
+                " REFERENCES memories(memory_id) ON DELETE CASCADE"
+            )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pred_errors_memory"
+            " ON prediction_errors(memory_id) WHERE memory_id IS NOT NULL"
+        )
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (21)")
+        conn.commit()
+        log.info("Migration to v21 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -236,6 +236,11 @@ def vault_memories(
         workspace=workspace, limit=limit, embed_url=_embed_url(),
     )
 
+    # Memory drift detection (issue #38): a retrieval is the natural moment to
+    # check whether these memories still match the notes they reference.
+    from ..memory_drift import check_memory_drift
+    check_memory_drift(conn, memories)
+
     output = []
     for m in memories:
         entry = {

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -644,10 +644,12 @@ def vault_prediction_errors(
     conn = get_db(DB_PATH)
 
     if resolve:
+        # Only note-centric rows are resolved by path; memory drift is reconciled
+        # through the memory lifecycle (update/forget), not by note path.
         conn.execute(
             """
             UPDATE prediction_errors SET resolved_at = datetime('now')
-            WHERE note_path IN ({}) AND resolved_at IS NULL
+            WHERE note_path IN ({}) AND memory_id IS NULL AND resolved_at IS NULL
             """.format(",".join("?" * len(resolve))),
             resolve,
         )
@@ -714,9 +716,10 @@ def vault_prediction_errors(
             total_params + [PREDICTION_ERROR_MIN_OCCURRENCES],
         ).fetchone()[0]
 
-    # Memory-centric drift rows (issue #38): one debounced row per (memory, note),
+    # Memory-centric drift rows (issue #38): one open row per (memory, note),
     # no occurrence threshold, carrying the memory content to act on.
     memory_errors: list = []
+    total_memories = 0
     if memory_id is not None or error_type in (None, "memory_drift"):
         mwhere = (
             "WHERE pe.resolved_at IS NULL AND pe.memory_id IS NOT NULL"
@@ -726,6 +729,9 @@ def vault_prediction_errors(
         if memory_id is not None:
             mwhere += " AND pe.memory_id = ?"
             mparams.append(memory_id)
+        total_memories = conn.execute(
+            f"SELECT COUNT(*) FROM prediction_errors pe {mwhere}", mparams
+        ).fetchone()[0]
         mrows = conn.execute(
             f"""
             SELECT pe.memory_id, pe.note_path, pe.cosine_distance, pe.context,
@@ -758,7 +764,7 @@ def vault_prediction_errors(
 
     return {
         "total_flagged_notes": total_notes,
-        "total_flagged_memories": len(memory_errors),
+        "total_flagged_memories": total_memories,
         "showing": len(results) + len(memory_errors),
         "errors": results + memory_errors,
     }

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -612,28 +612,32 @@ def vault_prediction_errors(
     limit: int = 20,
     resolve: list[str] = None,
     workspace: str = None,
+    memory_id: int = None,
 ) -> dict:
-    """Return notes flagged as prediction errors — high semantic distance at retrieval time.
+    """Return prediction errors — note or memory signals that surprised at retrieval.
 
-    These are notes that "surprised" during retrieval (poor fit for the query that retrieved them),
-    signalling they may be outdated, miscategorised, or poorly linked.
-
-    Error types:
+    Note-centric (semantic distance between a note and the query that retrieved it):
     - low_overlap: cosine distance > 0.62 — note is semantically distant from what retrieved it
     - contextual_mismatch: note surfaced outside its expected domain context AND was only a
       weak fit (sim < 0.45) — a strong hit outside the context boost set is not a mismatch
+    Only notes that surprised >= 2 distinct retrieval events are surfaced.
 
-    Only notes that have surprised >= 2 distinct retrieval events are surfaced: a single
-    ad-hoc flag reflects query difficulty, not note health. Single-occurrence rows still
-    accumulate in the log toward that threshold.
+    Memory-centric (issue #38):
+    - memory_drift: an agent-written memory has drifted from the current content of the
+      notes it references (its embedding is far from those notes' chunks). Each row carries
+      the memory content so an agent can update_memory or forget it. No occurrence threshold —
+      the detector debounces to one row per (memory, note).
 
     Args:
-        error_type: Filter by type — "low_overlap" or "contextual_mismatch". None = all.
-        limit: Max errors to return (default 20).
+        error_type: Filter by type — "low_overlap", "contextual_mismatch", or
+            "memory_drift". None = all.
+        limit: Max errors to return per class (default 20).
         resolve: List of note paths to mark as resolved (clears their unresolved flags).
-        workspace: Optional vault subdirectory prefix to restrict
-            results (e.g. "work/acme-cloud")
+        workspace: Optional vault subdirectory prefix to restrict note results.
+        memory_id: Filter memory-drift rows to a single memory (implies memory rows only).
     """
+    import json
+
     from ..schema import DB_PATH, get_db
     from ..search import PREDICTION_ERROR_MIN_OCCURRENCES, _normalize_workspace
 
@@ -650,66 +654,111 @@ def vault_prediction_errors(
         conn.commit()
         return {"resolved": len(resolve), "paths": resolve}
 
-    where = "WHERE resolved_at IS NULL"
-    params: list = []
-    if error_type:
-        where += " AND error_type = ?"
-        params.append(error_type)
-
     ws = _normalize_workspace(workspace)
-    if ws:
-        where += " AND note_path LIKE ? || '%'"
-        params.append(ws + "/")
+    results: list = []
+    total_notes = 0
 
-    rows = conn.execute(
-        f"""
-        SELECT note_path, error_type, context,
-               AVG(cosine_distance) as avg_distance,
-               COUNT(*) as occurrences,
-               MAX(detected_at) as last_seen,
-               MIN(query) as sample_query
-        FROM prediction_errors
-        {where}
-        GROUP BY note_path, error_type
-        HAVING COUNT(*) >= ?
-        ORDER BY occurrences DESC, avg_distance DESC
-        LIMIT ?
-        """,
-        params + [PREDICTION_ERROR_MIN_OCCURRENCES, limit],
-    ).fetchall()
+    # Note-centric errors (memory_id IS NULL), aggregated with the >=2 threshold.
+    if memory_id is None and error_type != "memory_drift":
+        where = "WHERE resolved_at IS NULL AND memory_id IS NULL"
+        params: list = []
+        if error_type:
+            where += " AND error_type = ?"
+            params.append(error_type)
+        if ws:
+            where += " AND note_path LIKE ? || '%'"
+            params.append(ws + "/")
 
-    results = [
-        {
-            "note_path": r["note_path"],
-            "error_type": r["error_type"],
-            "context": r["context"],
-            "avg_cosine_distance": round(r["avg_distance"], 3),
-            "occurrences": r["occurrences"],
-            "last_seen": r["last_seen"],
-            "sample_query": r["sample_query"],
-        }
-        for r in rows
-    ]
-
-    total_where = "WHERE resolved_at IS NULL"
-    total_params: list = []
-    if ws:
-        total_where += " AND note_path LIKE ? || '%'"
-        total_params.append(ws + "/")
-
-    total_unresolved = conn.execute(
-        f"""
-        SELECT COUNT(*) FROM (
-            SELECT note_path FROM prediction_errors {total_where}
+        rows = conn.execute(
+            f"""
+            SELECT note_path, error_type, context,
+                   AVG(cosine_distance) as avg_distance,
+                   COUNT(*) as occurrences,
+                   MAX(detected_at) as last_seen,
+                   MIN(query) as sample_query
+            FROM prediction_errors
+            {where}
             GROUP BY note_path, error_type
             HAVING COUNT(*) >= ?
+            ORDER BY occurrences DESC, avg_distance DESC
+            LIMIT ?
+            """,
+            params + [PREDICTION_ERROR_MIN_OCCURRENCES, limit],
+        ).fetchall()
+        results = [
+            {
+                "note_path": r["note_path"],
+                "error_type": r["error_type"],
+                "context": r["context"],
+                "avg_cosine_distance": round(r["avg_distance"], 3),
+                "occurrences": r["occurrences"],
+                "last_seen": r["last_seen"],
+                "sample_query": r["sample_query"],
+            }
+            for r in rows
+        ]
+
+        total_where = "WHERE resolved_at IS NULL AND memory_id IS NULL"
+        total_params: list = []
+        if ws:
+            total_where += " AND note_path LIKE ? || '%'"
+            total_params.append(ws + "/")
+        total_notes = conn.execute(
+            f"""
+            SELECT COUNT(*) FROM (
+                SELECT note_path FROM prediction_errors {total_where}
+                GROUP BY note_path, error_type
+                HAVING COUNT(*) >= ?
+            )
+            """,
+            total_params + [PREDICTION_ERROR_MIN_OCCURRENCES],
+        ).fetchone()[0]
+
+    # Memory-centric drift rows (issue #38): one debounced row per (memory, note),
+    # no occurrence threshold, carrying the memory content to act on.
+    memory_errors: list = []
+    if memory_id is not None or error_type in (None, "memory_drift"):
+        mwhere = (
+            "WHERE pe.resolved_at IS NULL AND pe.memory_id IS NOT NULL"
+            " AND pe.error_type = 'memory_drift'"
         )
-        """,
-        total_params + [PREDICTION_ERROR_MIN_OCCURRENCES],
-    ).fetchone()[0]
+        mparams: list = []
+        if memory_id is not None:
+            mwhere += " AND pe.memory_id = ?"
+            mparams.append(memory_id)
+        mrows = conn.execute(
+            f"""
+            SELECT pe.memory_id, pe.note_path, pe.cosine_distance, pe.context,
+                   pe.detected_at, m.content, m.entity_type, m.tags, m.created_at
+            FROM prediction_errors pe
+            JOIN memories m ON m.memory_id = pe.memory_id
+            {mwhere}
+            ORDER BY pe.cosine_distance DESC
+            LIMIT ?
+            """,
+            mparams + [limit],
+        ).fetchall()
+        memory_errors = [
+            {
+                "error_type": "memory_drift",
+                "memory_id": r["memory_id"],
+                "note_path": r["note_path"],
+                "cosine_distance": round(r["cosine_distance"], 3),
+                "detected_at": r["detected_at"],
+                "context": r["context"],
+                "memory": {
+                    "content": r["content"],
+                    "entity_type": r["entity_type"],
+                    "tags": json.loads(r["tags"]) if r["tags"] else [],
+                    "created_at": r["created_at"],
+                },
+            }
+            for r in mrows
+        ]
 
     return {
-        "total_flagged_notes": total_unresolved,
-        "showing": len(results),
-        "errors": results,
+        "total_flagged_notes": total_notes,
+        "total_flagged_memories": len(memory_errors),
+        "showing": len(results) + len(memory_errors),
+        "errors": results + memory_errors,
     }

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -114,17 +114,24 @@ def test_fresh_db_has_diff_snapshots(db):
     assert v >= 20
 
 
-def test_v19_to_v20_upgrade_path():
-    # The path that runs on the live LXC 122 DB (currently v19): the lazy
-    # migration must create diff_snapshots and bump the stamped version to 20.
+def test_v19_upgrade_creates_diff_snapshots():
+    # The path that runs on the live LXC 122 DB: the lazy migration must create
+    # diff_snapshots and run cleanly through to the current schema version.
     import sqlite3
 
-    from neurostack.schema import _run_migrations
+    from neurostack.schema import SCHEMA_VERSION, _run_migrations
 
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
     conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
     conn.execute("INSERT INTO schema_version VALUES (19)")
+    # A real v19 DB has prediction_errors (later migrations ALTER it), so seed it.
+    conn.execute(
+        "CREATE TABLE prediction_errors (error_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " note_path TEXT NOT NULL, query TEXT NOT NULL, cosine_distance REAL NOT NULL,"
+        " error_type TEXT NOT NULL, context TEXT,"
+        " detected_at TEXT NOT NULL DEFAULT (datetime('now')), resolved_at TEXT)"
+    )
     conn.commit()
     assert conn.execute(
         "SELECT name FROM sqlite_master WHERE name='diff_snapshots'"
@@ -137,5 +144,5 @@ def test_v19_to_v20_upgrade_path():
     ).fetchone() is not None
     assert conn.execute(
         "SELECT MAX(version) AS v FROM schema_version"
-    ).fetchone()["v"] == 20
+    ).fetchone()["v"] == SCHEMA_VERSION
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -196,7 +196,9 @@ def test_vault_prediction_errors_structure(mcp_vault):
 
     result = _registry().call("vault_prediction_errors")
 
-    assert set(result) == {"total_flagged_notes", "showing", "errors"}
+    assert set(result) == {
+        "total_flagged_notes", "total_flagged_memories", "showing", "errors"
+    }
     assert result["total_flagged_notes"] == 1
     assert result["showing"] == 1
     err = result["errors"][0]

--- a/tests/test_memory_drift.py
+++ b/tests/test_memory_drift.py
@@ -128,15 +128,55 @@ class TestResolutionAndLifecycle:
         db.commit()
         assert _unresolved_count(db) == 0
 
-    def test_update_memory_resolves_drift(self, db):
+    def test_tags_only_update_keeps_drift(self, db):
+        # A tags-only edit leaves the embedding unchanged, so the drift still
+        # holds and must NOT be resolved.
         from neurostack.memories import update_memory
 
         _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
         mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
         detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
-        # tags-only update → no re-embed (no embedder needed) but still reconciles
-        update_memory(db, mid, tags=["done"])
+        update_memory(db, mid, tags=["seen"])
+        assert _unresolved_count(db) == 1
+
+    def test_content_update_resolves_drift(self, db, monkeypatch):
+        # A content edit re-embeds the memory, so the drift is reconciled.
+        from neurostack import embedder
+        from neurostack.memories import update_memory
+
+        monkeypatch.setattr(embedder, "get_embedding",
+                            lambda *a, **k: _vec(1, 0, 0, 0))
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        update_memory(db, mid, content="X was resolved.")
         assert _unresolved_count(db) == 0
+
+    def test_stronger_signal_updates_in_place(self, db):
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0.5, 0.866, 0, 0))  # dist ~0.5
+        d1 = db.execute(
+            "SELECT cosine_distance FROM prediction_errors"
+        ).fetchone()["cosine_distance"]
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))  # dist 1.0, stronger
+        assert _drift_count(db) == 1  # updated in place, no duplicate
+        d2 = db.execute(
+            "SELECT cosine_distance FROM prediction_errors"
+        ).fetchone()["cosine_distance"]
+        assert d2 > d1
+
+    def test_new_open_row_after_resolution(self, db):
+        # Dedup only suppresses a second OPEN row; once resolved, a genuinely new
+        # drift event opens a fresh row.
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        resolve_memory_drift(db, mid)
+        db.commit()
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        assert _unresolved_count(db) == 1  # a fresh open row
+        assert _drift_count(db) == 2       # one resolved + one open
 
     def test_forget_memory_cleans_drift(self, db):
         from neurostack.memories import forget_memory

--- a/tests/test_memory_drift.py
+++ b/tests/test_memory_drift.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for memory drift detection (issue #38)."""
+
+import pytest
+
+from neurostack import config as nsconfig
+
+np = pytest.importorskip("numpy")
+
+from neurostack.memory_drift import (  # noqa: E402
+    DRIFT_THRESHOLD,
+    detect_memory_drift,
+    resolve_memory_drift,
+)
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    # Default DB path so registry tools (which open get_db(DB_PATH)) share the file.
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db()
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _vec(*xs):
+    return np.array(xs, dtype=np.float32)
+
+
+def _add_note(conn, path, chunk_text, chunk_vec, title=None):
+    conn.execute(
+        "INSERT OR REPLACE INTO notes (path, title, content_hash, updated_at)"
+        " VALUES (?, ?, ?, ?)",
+        (path, title or path, "h", "2026-07-01T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO chunks (note_path, heading_path, content, content_hash,"
+        " position, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+        (path, "", chunk_text, "h", 0, chunk_vec.tobytes()),
+    )
+    conn.commit()
+
+
+def _add_memory(conn, content, vec, tags=None):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, embedding, tags)"
+        " VALUES (?, 'observation', ?, ?)",
+        (content, vec.tobytes(), tags),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _drift_count(conn):
+    return conn.execute(
+        "SELECT COUNT(*) FROM prediction_errors WHERE error_type = 'memory_drift'"
+    ).fetchone()[0]
+
+
+def _unresolved_count(conn):
+    return conn.execute(
+        "SELECT COUNT(*) FROM prediction_errors WHERE resolved_at IS NULL"
+    ).fetchone()[0]
+
+
+CONTENT = "X is a blocker in [[project]]"
+
+
+class TestDriftDetection:
+    def test_aligned_memory_no_drift(self, db):
+        _add_note(db, "work/project.md", "X is a blocker.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(1, 0, 0, 0))
+        assert detect_memory_drift(db, mid, CONTENT, _vec(1, 0, 0, 0)) == []
+        assert _drift_count(db) == 0
+
+    def test_drifted_memory_flags(self, db):
+        # Note now says "resolved" (embedding orthogonal to the memory) → drift.
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        written = detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        assert len(written) == 1
+        assert written[0]["note_path"] == "work/project.md"
+        assert written[0]["cosine_distance"] > DRIFT_THRESHOLD
+        row = db.execute(
+            "SELECT memory_id, note_path, error_type, query FROM prediction_errors"
+        ).fetchone()
+        assert row["memory_id"] == mid
+        assert row["note_path"] == "work/project.md"
+        assert row["error_type"] == "memory_drift"
+        assert row["query"] == f"memory:{mid}"
+
+    def test_no_wiki_links_skipped(self, db):
+        mid = _add_memory(db, "plain memory, no links", _vec(0, 1, 0, 0))
+        assert detect_memory_drift(
+            db, mid, "plain memory, no links", _vec(0, 1, 0, 0)
+        ) == []
+
+    def test_unresolvable_link_skipped(self, db):
+        content = "refers to [[nonexistent-note]]"
+        mid = _add_memory(db, content, _vec(0, 1, 0, 0))
+        assert detect_memory_drift(db, mid, content, _vec(0, 1, 0, 0)) == []
+
+    def test_no_embedding_skipped(self, db):
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        assert detect_memory_drift(db, mid, CONTENT, None) == []
+
+    def test_debounce_updates_in_place(self, db):
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))  # again, in window
+        assert _drift_count(db) == 1  # debounced, not duplicated
+
+
+class TestResolutionAndLifecycle:
+    def test_resolve_marks_rows_resolved(self, db):
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        assert _unresolved_count(db) == 1
+        assert resolve_memory_drift(db, mid) == 1
+        db.commit()
+        assert _unresolved_count(db) == 0
+
+    def test_update_memory_resolves_drift(self, db):
+        from neurostack.memories import update_memory
+
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        # tags-only update → no re-embed (no embedder needed) but still reconciles
+        update_memory(db, mid, tags=["done"])
+        assert _unresolved_count(db) == 0
+
+    def test_forget_memory_cleans_drift(self, db):
+        from neurostack.memories import forget_memory
+
+        _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+        mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+        detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+        forget_memory(db, mid)
+        assert db.execute(
+            "SELECT COUNT(*) FROM prediction_errors WHERE memory_id = ?", (mid,)
+        ).fetchone()[0] == 0
+
+
+def test_v20_to_v21_adds_memory_id_preserving_rows():
+    # The migration that runs on the live v20 prod DB: adds memory_id via ALTER
+    # (no rebuild) and keeps every existing note-centric row intact.
+    import sqlite3
+
+    from neurostack.schema import _run_migrations
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    conn.execute("INSERT INTO schema_version VALUES (20)")
+    conn.execute(
+        "CREATE TABLE prediction_errors (error_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " note_path TEXT NOT NULL, query TEXT NOT NULL, cosine_distance REAL NOT NULL,"
+        " error_type TEXT NOT NULL, context TEXT,"
+        " detected_at TEXT NOT NULL DEFAULT (datetime('now')), resolved_at TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO prediction_errors (note_path, query, cosine_distance, error_type)"
+        " VALUES ('a.md', 'q', 0.7, 'low_overlap')"
+    )
+    conn.commit()
+
+    _run_migrations(conn)
+
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(prediction_errors)")}
+    assert "memory_id" in cols
+    row = conn.execute(
+        "SELECT note_path, memory_id, error_type FROM prediction_errors"
+    ).fetchone()
+    assert row["note_path"] == "a.md"          # pre-existing row preserved
+    assert row["memory_id"] is None
+    assert row["error_type"] == "low_overlap"
+    assert conn.execute(
+        "SELECT MAX(version) FROM schema_version"
+    ).fetchone()[0] == 21
+
+
+def test_tool_surfaces_memory_drift(db):
+    from neurostack.tools import ensure_registered
+
+    _add_note(db, "work/project.md", "X was resolved.", _vec(1, 0, 0, 0))
+    mid = _add_memory(db, CONTENT, _vec(0, 1, 0, 0))
+    detect_memory_drift(db, mid, CONTENT, _vec(0, 1, 0, 0))
+
+    res = ensure_registered().call(
+        "vault_prediction_errors", error_type="memory_drift"
+    )
+    assert res["total_flagged_memories"] == 1
+    err = res["errors"][0]
+    assert err["error_type"] == "memory_drift"
+    assert err["memory_id"] == mid
+    assert err["note_path"] == "work/project.md"
+    assert err["memory"]["content"] == CONTENT


### PR DESCRIPTION
Closes #38 (core). Defers the optional `vault_record_memory_signal` primitive (noted below).

An agent-written memory that references a note via `[[wiki-links]]` can drift from reality: "X is an open blocker in [[proj]]" is stale once the project note records X as done, but a later session retrieving both trusts them equally. NeuroStack already models "retrieval diverged from expectation" as a **prediction error** — this applies the same signal to the memory layer.

## How it works

At memory-retrieval time (`vault_memories`, `vault_context`), for each returned memory we extract its wiki-links, resolve them to notes, and compare the memory's **stored** embedding to those notes' current chunk embeddings (max cosine similarity across chunks). If the best match is far enough, we log a debounced `memory_drift` row to `prediction_errors`. It's pure local computation on stored embeddings — **no live embedder call**, no git/external awareness in core.

- **Detection**: `memory_drift.py::detect_memory_drift` — max-sim across a note's chunks, so drift only fires when the memory is far from *every* chunk (conservative). 24h debounce keeps one row per (memory, note), refreshing the strongest signal.
- **Resolution piggybacks on the lifecycle**: `update_memory` marks open drift rows resolved (editing a memory *is* reconciliation); `forget_memory` clears them (plus `ON DELETE CASCADE`).
- **Surfaced** via `vault_prediction_errors(error_type="memory_drift")` — memory-drift rows carry the memory content + entity_type/tags so an agent can `vault_update_memory` or `vault_forget`. New `memory_id` filter. No occurrence threshold for memory rows (debounce already dedups).

## Schema (v21)

`prediction_errors` gains `memory_id` via **`ALTER ADD COLUMN`** (+ partial index) — no table rebuild, so the existing note-centric rows on the live DB are untouched. Drift rows carry both `note_path` (the referenced note) and `memory_id`, so `note_path` stays `NOT NULL`. The v20→v21 upgrade is tested to preserve existing rows.

## Threshold calibration (why real-embedder verification mattered)

The note-centric `low_overlap` distance (~0.62) is tuned for query↔note fit and is **too slack** for memory drift. Probed against the production model `embeddinggemma:300m`:

| pair | cosine sim | distance |
|---|---|---|
| memory vs aligned note (still a blocker) | 0.75 | 0.25 |
| memory vs drifted note (now resolved) | 0.50 | **0.50** |
| memory vs done-and-moved-on | 0.32 | 0.68 |
| memory vs unrelated | 0.17 | 0.83 |

At 0.62 the resolved-note case (the whole point) never fires. **`DRIFT_THRESHOLD = 0.40`** separates aligned from drifted with margin. End-to-end with real embeddings: aligned note → no drift; "X was completed and deployed" → drift at 0.4063. It's a data-backed starting calibration that the accumulating drift log itself can refine later.

## Tests

`tests/test_memory_drift.py`: aligned/drifted/no-links/unresolvable-link/no-embedding detection, debounce, resolve-on-update, cleanup-on-forget, the tool surfacing memory rows, and the v20→v21 migration preserving existing rows. 667+ pass, ruff clean.

## Deferred

`vault_record_memory_signal` (external-evidence primitive) needs a nullable `note_path` → a table rebuild; deferred to keep this migration a safe additive `ALTER`. Core drift detection stands alone.