### PR TITLE
Strengthen harvest dedup with cosine similarity (#36 parts 2, 5)

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -542,8 +542,37 @@ def _extract_tags(text: str) -> list[str]:
     return sorted(tags)[:5]
 
 
-def _is_duplicate(conn, content: str, entity_type: str) -> bool:
-    """Check if a substantially similar memory already exists via FTS5."""
+# Cosine similarity at/above which two same-type memories are treated as
+# duplicates during harvest (issue #36).
+DEDUP_COSINE_THRESHOLD = 0.88
+
+
+def _is_duplicate(
+    conn, content: str, entity_type: str, embed_url: str | None = None
+) -> bool:
+    """True if a substantially similar memory already exists.
+
+    Prefers semantic (cosine) similarity so paraphrases with different wording
+    are caught — FTS5's strict all-terms match lets "three Harrods supply-chain
+    paraphrases" through as distinct (issue #36). Keeps the FTS5 keyword floor as
+    a fallback so dedup still works when embeddings are unavailable (lite mode /
+    embedder down) rather than silently switching off.
+    """
+    try:
+        from .memories import find_similar_memories
+
+        if find_similar_memories(
+            conn, content, entity_type=entity_type,
+            threshold=DEDUP_COSINE_THRESHOLD, limit=1, embed_url=embed_url,
+        ):
+            return True
+    except Exception:
+        pass
+    return _fts_duplicate(conn, content, entity_type)
+
+
+def _fts_duplicate(conn, content: str, entity_type: str) -> bool:
+    """FTS5 keyword-overlap duplicate check — the pre-cosine floor."""
     words = re.findall(r"\b\w{4,}\b", content.lower())
     if not words:
         return False
@@ -763,7 +792,7 @@ def harvest_sessions(
             record = {"content": summary, "entity_type": etype, "tags": tags,
                       "ttl_hours": ttl, "provider": session.provider}
 
-            if _is_duplicate(conn, summary, etype):
+            if _is_duplicate(conn, summary, etype, embed_url=url):
                 record["status"] = "skipped (duplicate)"
                 skipped.append(record)
                 continue

--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -554,9 +554,11 @@ def _is_duplicate(
 
     Prefers semantic (cosine) similarity so paraphrases with different wording
     are caught — FTS5's strict all-terms match lets "three Harrods supply-chain
-    paraphrases" through as distinct (issue #36). Keeps the FTS5 keyword floor as
-    a fallback so dedup still works when embeddings are unavailable (lite mode /
-    embedder down) rather than silently switching off.
+    paraphrases" through as distinct (issue #36). The FTS5 keyword match stays as
+    a floor: it runs whenever the cosine check doesn't flag a duplicate — both
+    when embeddings are unavailable (lite mode / embedder down) and when a
+    keyword-overlapping pair falls below the cosine threshold — so dedup never
+    silently switches off.
     """
     try:
         from .memories import find_similar_memories

--- a/src/neurostack/skills/memory-management.md
+++ b/src/neurostack/skills/memory-management.md
@@ -38,9 +38,21 @@ vault_memories(query="terraform", entity_type="decision", workspace="work/acme")
 ```
 
 ## Memory types guide
-- **decision**: Architectural or strategic choices made
-- **convention**: Patterns or rules established
-- **learning**: Insights discovered through experience
-- **bug**: Root causes and fixes found
-- **observation**: General observations (noisy, not written to vault)
-- **context**: Ephemeral context (credentials, URLs, config state)
+
+Pick by durability and intent. Defaulting everything to `observation` buries real
+insight in noise, so reach for a more specific type whenever one fits.
+
+- **decision**: An architectural or strategic choice made, and why ("chose X over Y because Z").
+- **convention**: A rule or pattern to always follow ("always run the full sync before restart").
+- **learning**: An insight discovered through experience — the durable takeaway, not the raw
+  event ("the strict all-terms match misses paraphrases; semantic similarity catches them").
+  Prefer this over `observation` whenever you've actually concluded something.
+- **bug**: A root cause and its fix, with concrete identifiers.
+- **context**: Ephemeral current-state that goes stale fast — credentials, endpoints, URLs, config
+  values, "X is currently at version N". Harvest gives these a 168h TTL by default. Not for
+  durable handoffs or long-lived facts; those aren't ephemeral state.
+- **observation**: A durable fact that isn't yet a synthesised insight. Use sparingly — if you can
+  phrase it as a learning or decision, do that. Raw observations are the noisiest, least useful bucket.
+
+When several related observations pile up, promote them into one consolidated `learning`
+(via `vault_update_memory`) rather than leaving a heap of near-duplicates.

--- a/tests/test_harvest_dedup.py
+++ b/tests/test_harvest_dedup.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for harvest cosine-similarity dedup with FTS fallback (issue #36)."""
+
+import pytest
+
+from neurostack import config as nsconfig
+
+np = pytest.importorskip("numpy")
+
+from neurostack.harvest import _is_duplicate  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db()
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _vec(*xs):
+    return np.array(xs, dtype=np.float32)
+
+
+def _save(conn, content, entity_type="learning"):
+    from neurostack.memories import save_memory
+
+    return save_memory(conn, content=content, entity_type=entity_type, embed_url="x")
+
+
+class TestCosineDedup:
+    def test_cosine_catches_paraphrase(self, db, monkeypatch):
+        # Different wording, overlapping keywords, identical embedding → duplicate.
+        # This is the class FTS5's strict all-terms match lets through.
+        from neurostack import embedder
+
+        monkeypatch.setattr(embedder, "get_embedding", lambda *a, **k: _vec(1, 0, 0))
+        _save(db, "Harrods supply chain integration is complex")
+        assert _is_duplicate(
+            db, "Harrods supply chain rollout is complicated", "learning", embed_url="x"
+        ) is True
+
+    def test_semantically_distinct_not_duplicate(self, db, monkeypatch):
+        # Shares keywords but orthogonal embedding → cosine rejects, and the FTS
+        # floor's all-terms match also misses (different exact words).
+        from neurostack import embedder
+
+        def embed(content, *a, **k):
+            return _vec(1, 0, 0) if "integration" in content else _vec(0, 0, 1)
+
+        monkeypatch.setattr(embedder, "get_embedding", embed)
+        _save(db, "Harrods supply chain integration is complex")
+        assert _is_duplicate(
+            db, "Harrods supply chain rollout differs entirely", "learning", embed_url="x"
+        ) is False
+
+    def test_fts_fallback_when_embedder_down(self, db, monkeypatch):
+        from neurostack import embedder
+
+        monkeypatch.setattr(embedder, "get_embedding", lambda *a, **k: _vec(1, 0, 0))
+        _save(db, "The AKS cluster upgrade must leave version 1.33")
+
+        def boom(*a, **k):
+            raise RuntimeError("embedder down")
+
+        monkeypatch.setattr(embedder, "get_embedding", boom)
+        # No embeddings available, but identical content still dedups via FTS.
+        assert _is_duplicate(
+            db, "The AKS cluster upgrade must leave version 1.33", "learning", embed_url="x"
+        ) is True
+
+    def test_dedup_is_per_entity_type(self, db, monkeypatch):
+        from neurostack import embedder
+
+        monkeypatch.setattr(embedder, "get_embedding", lambda *a, **k: _vec(1, 0, 0))
+        _save(db, "Harrods supply chain integration is complex", entity_type="learning")
+        # Same content, different type → not a duplicate.
+        assert _is_duplicate(
+            db, "Harrods supply chain integration is complex", "observation", embed_url="x"
+        ) is False


### PR DESCRIPTION
Partial #36 — the safe, tractable parts. Scoped with Rapha: ship dedup + docs now, defer the synthesis pipeline (part 1) to its own PR, skip the destructive TTL default (part 4).

## Part 2 — cosine dedup (the real fix)

`harvest._is_duplicate` was FTS5-only, and FTS5's strict all-terms `MATCH` lets paraphrases with different wording through as distinct memories — the "three near-identical Harrods supply-chain learnings" class the issue calls out.

Now it prefers **cosine similarity** via `find_similar_memories(threshold=0.88)`, and keeps the FTS5 keyword match as a **floor** so dedup still works when embeddings are unavailable (lite mode / embedder down) rather than silently switching off. Net: strictly more dedup coverage than before, no regression on the embedder-down path.

Threshold validated end-to-end against the production model `embeddinggemma:300m`:

| pair | cosine sim | dedup @ 0.88 |
|---|---|---|
| real paraphrase (same fact reworded) | 0.93 | caught |
| same topic, different fact | 0.43 | kept |
| unrelated | 0.20 | kept |

## Part 5 — type guidance

Expanded the `memory-management` skill's type guide: it was terse and pushed users to default to `observation`. Now it explains each type by durability/intent, flags `context` as ephemeral-with-TTL (not for durable handoffs), and points at promoting piles of observations into a consolidated `learning`.

## Not in this PR (deliberate)

- **Part 3** (split the credential/endpoint prefilter): already handled — #30 routes those to `context` with a 168h TTL. Re-splitting them back to `observation` would undo that.
- **Part 4** (TTL-by-type at the tool layer): skipped. It would auto-expire `context` memories after 7 days, silently deleting durable handoff/continuation memories. Needs a harvest-only scoping if pursued.
- **Part 1** (the `neurostack synthesize` observation→learning pipeline): the headline LLM feature, a separate focused PR next.

## Tests

`tests/test_harvest_dedup.py`: cosine catches a paraphrase, rejects a semantically-distinct keyword-overlapping pair, falls back to FTS when the embedder is down, and stays per-entity-type. 674 pass, ruff clean.