### PR TITLE
docs(skills): teach graph analysis, change feed, and memory drift

### DIFF
--- a/src/neurostack/skills/vault-audit.md
+++ b/src/neurostack/skills/vault-audit.md
@@ -11,11 +11,29 @@ vault_stats()
 ```
 Shows note count, chunk count, memory count, embedding coverage.
 
-## Find retrieval issues
+## Find retrieval issues + drifted memories
 ```
 vault_prediction_errors()
+vault_prediction_errors(error_type="memory_drift")
 ```
-Notes that were retrieved but had low semantic relevance - may need updating or re-indexing.
+Note-centric rows: notes retrieved with low semantic relevance — may need updating or re-indexing.
+Memory drift (issue #38): agent-written memories that no longer match the notes they reference
+(e.g. a memory says "X is a blocker" but the note now records X as done). Reconcile by
+`vault_update_memory` (edit the content) or `vault_forget`.
+
+## Find structural gaps + fragile hubs
+```
+vault_graph_analysis(top_k=10)
+```
+Gaps: note pairs that share many neighbours but aren't linked — candidate links to add.
+Bridges: hub notes whose removal fragments the graph (articulation points) — the load-bearing
+connectors worth protecting or reinforcing.
+
+## See what changed since last audit
+```
+vault_checkpoint(baseline="audit")   # once, to set a marker
+vault_diff(baseline="audit")          # later, to see added/modified/deleted notes since
+```
 
 ## Check what's stale
 ```

--- a/src/neurostack/skills/vault-search.md
+++ b/src/neurostack/skills/vault-search.md
@@ -21,6 +21,8 @@ NeuroStack has multiple retrieval tools. Pick the right one:
 | vault_memories | Search agent-written memories | Cheap |
 | vault_search(reference_only=True) | Broad scan — {path, score, snippet} only, no bodies | Very cheap |
 | vault_read_file(path, offset, limit) | Read a bounded slice of one note | Sized to `limit` |
+| vault_graph_analysis(top_k) | Structural gaps (unlinked but related) + bridge notes | Moderate |
+| vault_diff(since, baseline) / vault_checkpoint | What changed since a baseline or date | Cheap |
 
 ## Decision tree
 
@@ -33,6 +35,8 @@ NeuroStack has multiple retrieval tools. Pick the right one:
 7. Want similar notes? -> vault_related
 8. Many likely hits but you'll open only 1-2? -> vault_search(reference_only=True), then read the winner
 9. Context budget tight? -> add max_tokens=N to vault_search
+10. Curating the graph (what should be linked, what's a fragile hub)? -> vault_graph_analysis
+11. Orienting at session start / resuming a loop (what changed)? -> vault_diff since your last vault_checkpoint
 
 ## Lean retrieval (cut context footprint)
 


### PR DESCRIPTION
Follow-up to #12/#11/#38 (and the earlier #62 skill update in #81). The bundled skills didn't mention the tools those PRs shipped, so they were undiscoverable to anyone relying on the skills. This adds them.

**`vault-search` skill:**
- Table + decision tree gain `vault_graph_analysis` (structural gaps / bridge notes — curation) and `vault_diff` / `vault_checkpoint` (change feed — session orientation, loop resume).

**`vault-audit` skill:**
- "Find retrieval issues" now also covers **memory drift** (`vault_prediction_errors(error_type="memory_drift")`) — memories that no longer match the notes they reference, reconciled via `vault_update_memory` / `vault_forget`.
- New "structural gaps + fragile hubs" section (`vault_graph_analysis`).
- New "what changed since last audit" step (`vault_checkpoint` marker → `vault_diff`).

Every tool referenced ships in the current release and was verified live on the deployed server. Docs only — no code, no tests touched.