### PR TITLE
feat(index): incremental --changed-since to skip whole-vault rebuild

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -382,6 +382,12 @@ def main():
         help="Keep notes whose files were deleted from disk "
              "(default: prune orphaned notes from the index)",
     )
+    p.add_argument(
+        "--changed-since", default=None, metavar="GIT_REF",
+        help="Incremental: index only .md files changed since this git ref (in the "
+             "vault repo), skipping the global graph/co-occurrence/vec rebuild. Much "
+             "cheaper for a small sync; falls back to a full index if the ref is invalid.",
+    )
     p.set_defaults(func=cmd_index)
 
     # export (issue #4)

--- a/src/neurostack/cli/index.py
+++ b/src/neurostack/cli/index.py
@@ -10,6 +10,42 @@ from pathlib import Path
 def cmd_index(args):
     from ..schema import DB_PATH, get_db
     from ..watcher import full_index
+    vault_root = Path(args.vault)
+
+    # Incremental: index only the notes git says changed since the given ref, and
+    # skip the whole-vault global rebuild. Falls back to a full index if git can't
+    # resolve the ref (e.g. a fresh clone with no matching history).
+    changed_since = getattr(args, "changed_since", None)
+    if changed_since:
+        import subprocess
+
+        from ..watcher import incremental_index
+
+        def _git_files(diff_filter):
+            return subprocess.run(
+                ["git", "-C", str(vault_root), "diff", "--name-only",
+                 f"--diff-filter={diff_filter}", changed_since, "HEAD", "--", "*.md"],
+                capture_output=True, text=True,
+            )
+
+        r_changed = _git_files("ACMR")
+        if r_changed.returncode != 0:
+            print(f"  changed-since: git diff failed ({r_changed.stderr.strip()}); "
+                  "falling back to a full index.")
+        else:
+            r_deleted = _git_files("D")
+            changed = [vault_root / p for p in r_changed.stdout.split("\n") if p.strip()]
+            deleted = [p for p in r_deleted.stdout.split("\n") if p.strip()]
+            n, d = incremental_index(
+                changed, deleted, vault_root=vault_root,
+                embed_url=args.embed_url, summarize_url=args.summarize_url,
+                skip_summary=args.skip_summary, skip_triples=args.skip_triples,
+            )
+            print(f"Incremental index (since {changed_since}): "
+                  f"{n} note(s) updated, {d} removed. "
+                  "Global graph/co-occurrence/vec rebuild deferred to the next full index.")
+            return
+
     pruned = full_index(
         vault_root=Path(args.vault),
         embed_url=args.embed_url,

--- a/src/neurostack/watcher.py
+++ b/src/neurostack/watcher.py
@@ -788,6 +788,70 @@ def full_index(
     return pruned
 
 
+def incremental_index(
+    changed: list[Path],
+    deleted: list[str] | None = None,
+    vault_root: Path | None = None,
+    embed_url: str = None,
+    summarize_url: str = None,
+    skip_summary: bool = False,
+    skip_triples: bool = False,
+    conn=None,
+):
+    """Index only the given changed notes and drop the deleted ones, skipping the
+    whole-vault global rebuild.
+
+    ``full_index`` re-embeds only changed notes, but then unconditionally rebuilds the
+    globals: the wiki-link graph + PageRank, co-occurrence (which can be millions of
+    entity pairs), and the sqlite-vec index (every chunk + triple). Those are O(vault)
+    and dominate cost and memory on a small change, which is what makes a routine
+    ``brain-sync`` pull of a few edited notes reindex the whole vault and, on a
+    memory-tight host, OOM.
+
+    This path runs ``index_single_note`` per changed note instead — itself incremental
+    (content-hash short-circuit, per-chunk vec upsert) — plus targeted deletes. It
+    deliberately does NOT touch co-occurrence, PageRank, the graph, or the vec rebuild;
+    a periodic full ``neurostack index`` refreshes those. FTS5 and per-note semantic
+    search stay correct for changed notes immediately; only graph/co-occurrence-derived
+    boosts lag until the next full index.
+
+    Returns ``(n_indexed, n_deleted)``.
+    """
+    vault_root = vault_root or _vault_root()
+    embed_url = embed_url or get_config().embed_url
+    summarize_url = summarize_url or get_config().llm_url
+    if conn is None:
+        conn = get_db(DB_PATH)
+    _has_vec = has_vec_index(conn)
+
+    n_deleted = 0
+    for rel in deleted or []:
+        # Clear vec entries before the row cascade drops the chunks they point at.
+        if _has_vec:
+            delete_chunk_vecs(conn, rel)
+        conn.execute("DELETE FROM notes WHERE path = ?", (rel,))
+        n_deleted += 1
+    if n_deleted:
+        conn.commit()
+
+    n_indexed = 0
+    for path in changed:
+        try:
+            index_single_note(
+                path, vault_root, conn,
+                embed_url, summarize_url, skip_summary, skip_triples,
+            )
+            n_indexed += 1
+        except Exception as e:
+            log.error(f"Error indexing {path}: {e}")
+
+    log.info(
+        f"Incremental index: {n_indexed} note(s) indexed, {n_deleted} removed "
+        "(global graph/co-occurrence/vec rebuild deferred to the next full index)."
+    )
+    return n_indexed, n_deleted
+
+
 def backfill_summaries(
     vault_root: Path | None = None,
     summarize_url: str = None,

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -252,3 +252,70 @@ class TestReindexPreservesNoteMetadata:
             "SELECT content FROM chunks WHERE note_path='n.md'"
         ).fetchall()
         assert any("EDITED" in c["content"] for c in chunks)
+
+
+class TestIncrementalIndex:
+    """incremental_index processes only the changed/deleted notes and skips the
+    whole-vault global rebuild (graph/co-occurrence/vec) — the cheap path brain-sync
+    uses so a small sync doesn't reindex the entire vault."""
+
+    def _write(self, path, body):
+        path.write_text(
+            "---\ndate: 2026-01-01\ntags: [x]\ntype: permanent\n---\n\n# N\n\n" + body + "\n"
+        )
+
+    def test_indexes_changed_deletes_removed_skips_globals(
+        self, in_memory_db, tmp_path, monkeypatch
+    ):
+        import neurostack.watcher as w
+
+        # No real embedder needed to prove routing/CRUD behaviour.
+        monkeypatch.setattr(w, "get_embeddings_batch", lambda texts, **k: [None] * len(texts))
+        conn = in_memory_db
+
+        # A note already in the index that the sync will delete.
+        gone = tmp_path / "gone.md"
+        self._write(gone, "obsolete body")
+        w.index_single_note(gone, tmp_path, conn, skip_summary=True, skip_triples=True)
+        assert conn.execute("SELECT 1 FROM notes WHERE path='gone.md'").fetchone()
+
+        # A new/changed note on disk that incremental_index should pick up.
+        changed = tmp_path / "changed.md"
+        self._write(changed, "fresh body content")
+
+        n_indexed, n_deleted = w.incremental_index(
+            [changed], deleted=["gone.md"], vault_root=tmp_path,
+            skip_summary=True, skip_triples=True, conn=conn,
+        )
+
+        assert (n_indexed, n_deleted) == (1, 1)
+        # changed note indexed, with chunks
+        assert conn.execute("SELECT 1 FROM notes WHERE path='changed.md'").fetchone()
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM chunks WHERE note_path='changed.md'"
+        ).fetchone()["c"] > 0
+        # deleted note removed, and the FK cascade dropped its chunks
+        assert conn.execute("SELECT 1 FROM notes WHERE path='gone.md'").fetchone() is None
+        assert conn.execute(
+            "SELECT COUNT(*) c FROM chunks WHERE note_path='gone.md'"
+        ).fetchone()["c"] == 0
+        # globals deliberately deferred: no wiki-link graph was rebuilt this run
+        assert conn.execute("SELECT COUNT(*) c FROM graph_edges").fetchone()["c"] == 0
+
+    def test_unchanged_note_is_a_noop(self, in_memory_db, tmp_path, monkeypatch):
+        import neurostack.watcher as w
+
+        monkeypatch.setattr(w, "get_embeddings_batch", lambda texts, **k: [None] * len(texts))
+        conn = in_memory_db
+        note = tmp_path / "n.md"
+        self._write(note, "stable body")
+        w.index_single_note(note, tmp_path, conn, skip_summary=True, skip_triples=True)
+        before = conn.execute("SELECT updated_at FROM notes WHERE path='n.md'").fetchone()[0]
+
+        # Re-run over the same unchanged file: content-hash short-circuit → no rewrite.
+        n_indexed, n_deleted = w.incremental_index(
+            [note], vault_root=tmp_path, skip_summary=True, skip_triples=True, conn=conn,
+        )
+        after = conn.execute("SELECT updated_at FROM notes WHERE path='n.md'").fetchone()[0]
+        assert n_indexed == 1 and n_deleted == 0
+        assert before == after, "unchanged note must not be rewritten"


### PR DESCRIPTION
## Problem
`brain-sync` on the runtime host runs a full `neurostack index` whenever the vault repo changes. `full_index` re-embeds only changed notes, but then **unconditionally rebuilds the globals** — wiki-link graph + PageRank, co-occurrence (millions of entity pairs), and the full sqlite-vec index. On a small sync that O(vault) work dominates, and on the memory-tight LXC it OOM'd: a routine pull of a few edited notes reindexed the entire ~634-note vault, exhausted 2 GB + swap, jammed for 40+ min, and starved the MCP server.

## Fix
- `incremental_index()` — loops `index_single_note` over the changed notes (content-hash short-circuit, per-chunk vec upsert) plus targeted deletes, **skipping the global rebuild**. FTS5 + per-note semantic search stay correct immediately; graph/co-occurrence-derived boosts refresh on the next full index.
- `neurostack index --changed-since <git-ref>` — diffs the vault repo for changed/deleted `.md`, falls back to a full index if the ref is unresolvable.

## Verify
- Unit: 2 new tests (changed indexed / deleted removed / globals untouched; unchanged = no-op). Full watcher suite 18/18, ruff clean.
- Live (LXC 122): `neurostack index --changed-since <ref>` selected the 4 changed notes and finished in <1 s with no global rebuild.

A periodic full `neurostack index` (nightly timer on the host) keeps the deferred globals fresh.