### PR TITLE
Archive-on-forget: delete paths archive memories instead of destroying them (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **#90 — archive-on-forget.** Every memory delete path (`vault_forget`/`memories forget`, merge source, TTL expiry, prune) now moves the row to a `memories_archive` table instead of destroying it. Archived rows are outside search/FTS/drift by construction but stay greppable and restorable. New CLI: `neurostack memories archived [-w] [--limit N]` and `neurostack memories restore ID` (restored rows re-embed via `backfill memories`). `memories stats` gains `archived`; MCP `vault_forget` result carries `archived: true`.
+
+### Schema
+
+- v21 → v22: `memories_archive` table (#90).
+
 ## v0.16.0 — Retrieval & extraction fixes (2026-06-11)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,12 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack memories search "query"` | Search memories. `--type`, `--workspace`, `--limit N` |
 | `neurostack memories list` | List recent memories |
 | `neurostack memories update ID` | Update memory. `--content`, `--tags`, `--add-tags`, `--remove-tags`, `--type` |
-| `neurostack memories forget ID` | Delete a memory |
+| `neurostack memories forget ID` | Archive a memory (leaves search, restorable) |
+| `neurostack memories archived` | List archived memories. `--workspace`, `--limit N` |
+| `neurostack memories restore ID` | Restore an archived memory (re-embeds via backfill) |
 | `neurostack memories merge TARGET SOURCE` | Merge two memories (unions tags, audit trail) |
-| `neurostack memories prune` | Clean up. `--expired` or `--older-than N` (days) |
-| `neurostack memories stats` | Memory statistics |
+| `neurostack memories prune` | Archive expired/old memories. `--expired` or `--older-than N` (days) |
+| `neurostack memories stats` | Memory statistics (incl. archived count) |
 
 ### Sessions
 | Command | Description |
@@ -145,7 +147,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_remember(content, tags, entity_type, source_agent, workspace, ttl_hours, session_id)` - Save memory
 - `vault_update_memory(memory_id, content, tags, add_tags, remove_tags, entity_type, workspace, ttl_hours)` - Update memory
 - `vault_merge(target_id, source_id)` - Merge two memories
-- `vault_forget(memory_id)` - Delete memory
+- `vault_forget(memory_id)` - Delete memory (archived to `memories_archive`, restorable via CLI, issue #90)
 - `vault_memories(query, entity_type, workspace, limit)` - List/search memories
 - `vault_harvest(sessions, dry_run)` - Extract session insights
 

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -162,8 +162,15 @@ def main():
     mp.add_argument("--workspace", "-w", help="Workspace scope")
     mp.add_argument("--limit", type=int, default=20)
 
-    mp = mem_sub.add_parser("forget", help="Delete a memory by ID")
+    mp = mem_sub.add_parser("forget", help="Archive a memory by ID (restorable)")
     mp.add_argument("id", type=int, help="Memory ID")
+
+    mp = mem_sub.add_parser("archived", help="List archived (deleted) memories")
+    mp.add_argument("--workspace", "-w", help="Workspace scope")
+    mp.add_argument("--limit", type=int, default=20)
+
+    mp = mem_sub.add_parser("restore", help="Restore an archived memory by ID")
+    mp.add_argument("id", type=int, help="Memory ID to restore")
 
     mp = mem_sub.add_parser("prune", help="Delete expired or old memories")
     mp.add_argument("--older-than", type=int, help="Delete memories older than N days")

--- a/src/neurostack/cli/memories.py
+++ b/src/neurostack/cli/memories.py
@@ -12,8 +12,10 @@ def cmd_memories(args):
     from ..memories import (
         forget_memory,
         get_memory_stats,
+        list_archived_memories,
         merge_memories,
         prune_memories,
+        restore_memory,
         save_memory,
         search_memories,
         update_memory,
@@ -141,12 +143,46 @@ def cmd_memories(args):
     elif subcmd == "forget":
         deleted = forget_memory(conn, args.id)
         if args.json:
-            print(json.dumps({"deleted": deleted, "memory_id": args.id}))
+            print(json.dumps(
+                {"deleted": deleted, "archived": deleted, "memory_id": args.id}
+            ))
         else:
             if deleted:
-                print(f"  \033[32m\u2713\033[0m Deleted memory #{args.id}")
+                print(f"  \033[32m\u2713\033[0m Archived memory #{args.id}"
+                      " (restore with: neurostack memories restore"
+                      f" {args.id})")
             else:
                 print(f"  \033[31m\u2717\033[0m Memory #{args.id} not found")
+
+    elif subcmd == "archived":
+        rows = list_archived_memories(
+            conn,
+            workspace=_get_workspace(args) if hasattr(args, "workspace") else None,
+            limit=args.limit,
+        )
+        if args.json:
+            print(json.dumps(rows, indent=2, default=str))
+        else:
+            if not rows:
+                print("  No archived memories.")
+                return
+            for r in rows:
+                print(f"  #{r['memory_id']:<4} [{r['entity_type']}]"
+                      f" archived {r['archived_at']} ({r['archive_reason']})")
+                print(f"        {r['content'][:120]}")
+
+    elif subcmd == "restore":
+        memory = restore_memory(conn, args.id)
+        if args.json:
+            print(json.dumps(
+                {"restored": memory is not None, "memory_id": args.id}
+            ))
+        else:
+            if memory:
+                print(f"  \033[32m\u2713\033[0m Restored memory #{args.id}"
+                      " (re-embeds on next backfill)")
+            else:
+                print(f"  \033[31m\u2717\033[0m Memory #{args.id} not in archive")
 
     elif subcmd == "prune":
         count = prune_memories(
@@ -167,6 +203,7 @@ def cmd_memories(args):
             print(f"  Total:    {stats['total']}")
             print(f"  Embedded: {stats['embedded']}")
             print(f"  Expired:  {stats['expired']}")
+            print(f"  Archived: {stats['archived']}")
             if stats["by_type"]:
                 print("  By type:")
                 for t, c in sorted(stats["by_type"].items()):

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -251,8 +251,38 @@ def save_memory(
     return memory
 
 
+# Columns copied verbatim when a memory moves to memories_archive. Excludes
+# embedding/embed_pending: archived rows are outside search by construction,
+# and a restore re-embeds via embed_pending=1 + `neurostack backfill memories`.
+_ARCHIVE_COLUMNS = (
+    "memory_id, content, tags, entity_type, source_agent, workspace, "
+    "session_id, updated_at, revision_count, merge_count, merged_from, "
+    "created_at, expires_at, uuid, file_path"
+)
+
+
+def _archive_memories(
+    conn: sqlite3.Connection, where_sql: str, params: tuple, reason: str
+) -> int:
+    """Move matching memories into memories_archive, then delete them.
+
+    Every delete path routes through here (issue #90): deletion removes a row
+    from the working set, never from the record. Returns rows archived.
+    """
+    cursor = conn.execute(
+        f"INSERT OR REPLACE INTO memories_archive ({_ARCHIVE_COLUMNS}, archive_reason)"
+        f" SELECT {_ARCHIVE_COLUMNS}, ? FROM memories WHERE {where_sql}",
+        (reason, *params),
+    )
+    conn.execute(f"DELETE FROM memories WHERE {where_sql}", params)
+    return cursor.rowcount
+
+
 def forget_memory(conn: sqlite3.Connection, memory_id: int) -> bool:
-    """Delete a specific memory. Returns True if deleted."""
+    """Archive a specific memory (removed from the working set, restorable).
+
+    Returns True if the memory existed and was archived.
+    """
     row = conn.execute(
         "SELECT file_path FROM memories WHERE memory_id = ?", (memory_id,)
     ).fetchone()
@@ -260,15 +290,72 @@ def forget_memory(conn: sqlite3.Connection, memory_id: int) -> bool:
     # on the FK also handles this; the explicit delete keeps it robust regardless
     # of the foreign_keys pragma state.
     conn.execute("DELETE FROM prediction_errors WHERE memory_id = ?", (memory_id,))
-    cursor = conn.execute(
-        "DELETE FROM memories WHERE memory_id = ?", (memory_id,)
-    )
+    archived = _archive_memories(conn, "memory_id = ?", (memory_id,), "forget")
     conn.commit()
-    deleted = cursor.rowcount > 0
+    deleted = archived > 0
     if deleted and row is not None:
         from .vault_writer import apply_writeback_delete
         apply_writeback_delete(row["file_path"])
     return deleted
+
+
+def restore_memory(conn: sqlite3.Connection, memory_id: int) -> Memory | None:
+    """Move an archived memory back into the working set.
+
+    The row returns with embed_pending=1 and no embedding — findable via FTS
+    at once, re-embedded by `neurostack backfill memories`. Returns the
+    restored Memory, or None if the id is not in the archive.
+    """
+    row = conn.execute(
+        "SELECT * FROM memories_archive WHERE memory_id = ?", (memory_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    conn.execute(
+        f"INSERT INTO memories ({_ARCHIVE_COLUMNS}, embed_pending)"
+        f" SELECT {_ARCHIVE_COLUMNS}, 1 FROM memories_archive WHERE memory_id = ?",
+        (memory_id,),
+    )
+    conn.execute(
+        "UPDATE memories SET file_path = NULL WHERE memory_id = ?", (memory_id,)
+    )
+    conn.execute(
+        "DELETE FROM memories_archive WHERE memory_id = ?", (memory_id,)
+    )
+    conn.commit()
+    restored = conn.execute(
+        "SELECT * FROM memories WHERE memory_id = ?", (memory_id,)
+    ).fetchone()
+    memory = _row_to_memory(restored)
+    # Recreate the write-back mirror file if write-back is enabled (the
+    # original file was removed when the memory was archived).
+    from .vault_writer import apply_writeback_create
+    apply_writeback_create(conn, memory)
+    return memory
+
+
+def list_archived_memories(
+    conn: sqlite3.Connection,
+    workspace: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """List archived memories, newest archive first."""
+    where = "WHERE workspace = ?" if workspace else ""
+    params: tuple = (workspace, limit) if workspace else (limit,)
+    rows = conn.execute(
+        f"SELECT * FROM memories_archive {where}"
+        " ORDER BY archived_at DESC, memory_id DESC LIMIT ?",
+        params,
+    ).fetchall()
+    out = []
+    for r in rows:
+        r = dict(r)
+        try:
+            r["tags"] = json.loads(r["tags"]) if isinstance(r["tags"], str) else (r["tags"] or [])
+        except (json.JSONDecodeError, TypeError):
+            r["tags"] = []
+        out.append(r)
+    return out
 
 
 def update_memory(
@@ -602,8 +689,9 @@ def merge_memories(
         ),
     )
 
-    # Delete source
-    conn.execute("DELETE FROM memories WHERE memory_id = ?", (source_id,))
+    # Archive the source (its content lives on merged into the target; the
+    # archived row keeps the pre-merge original for the record — issue #90)
+    _archive_memories(conn, "memory_id = ?", (source_id,), "merge")
     conn.commit()
 
     updated = conn.execute(
@@ -632,10 +720,13 @@ def search_memories(
 
     Uses FTS5 for keyword search, with optional semantic reranking.
     """
-    # Purge expired memories first
+    # Purge expired memories first (to the archive, not oblivion — issue #90)
     if not include_expired:
-        conn.execute(
-            "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at < datetime('now')"
+        _archive_memories(
+            conn,
+            "expires_at IS NOT NULL AND expires_at < datetime('now')",
+            (),
+            "expire",
         )
         conn.commit()
 
@@ -822,21 +913,26 @@ def prune_memories(
     older_than_days: int | None = None,
     expired_only: bool = False,
 ) -> int:
-    """Delete expired or old memories. Returns count deleted."""
+    """Archive expired or old memories. Returns count archived."""
     if expired_only:
-        cursor = conn.execute(
-            "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at < datetime('now')"
+        count = _archive_memories(
+            conn,
+            "expires_at IS NOT NULL AND expires_at < datetime('now')",
+            (),
+            "expire",
         )
     elif older_than_days is not None:
-        cursor = conn.execute(
-            "DELETE FROM memories WHERE created_at < datetime('now', ?)",
+        count = _archive_memories(
+            conn,
+            "created_at < datetime('now', ?)",
             (f"-{older_than_days} days",),
+            "prune",
         )
     else:
         return 0
 
     conn.commit()
-    return cursor.rowcount
+    return count
 
 
 def get_memory_stats(conn: sqlite3.Connection) -> dict:
@@ -857,10 +953,15 @@ def get_memory_stats(conn: sqlite3.Connection) -> dict:
     for r in rows:
         by_type[r["entity_type"]] = r["c"]
 
+    archived = conn.execute(
+        "SELECT COUNT(*) as c FROM memories_archive"
+    ).fetchone()["c"]
+
     return {
         "total": total,
         "expired": expired,
         "embedded": embedded,
+        "archived": archived,
         "by_type": by_type,
     }
 

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -308,6 +308,33 @@ CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
     INSERT INTO memories_fts(rowid, content)
         VALUES (new.memory_id, new.content);
 END;
+
+-- Archived memories (issue #90): every delete path (forget, merge-source,
+-- TTL expiry, prune) moves the row here instead of destroying it. Archived
+-- rows are invisible to search/FTS/drift by construction — this table has no
+-- FTS index and no embedding — but stay greppable and restorable forever.
+CREATE TABLE IF NOT EXISTS memories_archive (
+    memory_id INTEGER PRIMARY KEY,
+    content TEXT NOT NULL,
+    tags JSON,
+    entity_type TEXT NOT NULL DEFAULT 'observation',
+    source_agent TEXT,
+    workspace TEXT,
+    session_id INTEGER,
+    updated_at TEXT,
+    revision_count INTEGER NOT NULL DEFAULT 1,
+    merge_count INTEGER NOT NULL DEFAULT 0,
+    merged_from JSON,
+    created_at TEXT,
+    expires_at TEXT,
+    uuid TEXT,
+    file_path TEXT,
+    archived_at TEXT NOT NULL DEFAULT (datetime('now')),
+    archive_reason TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_archive_workspace
+    ON memories_archive(workspace);
 
 -- NeuroStack-managed note metadata (read-only vault guarantee)
 -- Source of truth for status/tags/type — vault .md files are never modified.
@@ -1033,6 +1060,38 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (21)")
         conn.commit()
         log.info("Migration to v21 complete.")
+
+    if current < 22:
+        log.info(
+            "Migrating schema v21 -> v22: memories_archive table — "
+            "delete paths archive instead of destroy (issue #90)..."
+        )
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS memories_archive (
+                memory_id INTEGER PRIMARY KEY,
+                content TEXT NOT NULL,
+                tags JSON,
+                entity_type TEXT NOT NULL DEFAULT 'observation',
+                source_agent TEXT,
+                workspace TEXT,
+                session_id INTEGER,
+                updated_at TEXT,
+                revision_count INTEGER NOT NULL DEFAULT 1,
+                merge_count INTEGER NOT NULL DEFAULT 0,
+                merged_from JSON,
+                created_at TEXT,
+                expires_at TEXT,
+                uuid TEXT,
+                file_path TEXT,
+                archived_at TEXT NOT NULL DEFAULT (datetime('now')),
+                archive_reason TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_memories_archive_workspace
+                ON memories_archive(workspace);
+        """)
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (22)")
+        conn.commit()
+        log.info("Migration to v22 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/skills/memory-management.md
+++ b/src/neurostack/skills/memory-management.md
@@ -31,6 +31,9 @@ Keeps the longer content, unions tags, picks the more specific entity_type.
 ```
 vault_forget(memory_id=42)
 ```
+Deletion archives, never destroys: the row leaves search/ranking but stays in
+`memories_archive`. Recover with `neurostack memories restore 42` (CLI); browse
+the archive with `neurostack memories archived`.
 
 ## Search memories
 ```

--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -79,6 +79,9 @@ def vault_remember(
 def vault_forget(memory_id: int) -> dict:
     """Delete a specific memory by ID.
 
+    The memory leaves the working set (search, drift, ranking) but is
+    archived, not destroyed — `neurostack memories restore ID` brings it back.
+
     Args:
         memory_id: The ID of the memory to delete (from vault_remember or vault_memories)
     """
@@ -87,7 +90,7 @@ def vault_forget(memory_id: int) -> dict:
 
     conn = get_db(DB_PATH)
     deleted = forget_memory(conn, memory_id)
-    return {"deleted": deleted, "memory_id": memory_id}
+    return {"deleted": deleted, "archived": deleted, "memory_id": memory_id}
 
 
 @registry.tool(tags=["memory", "write"], annotations=_WRITE_IDEMPOTENT)

--- a/tests/test_memories.py
+++ b/tests/test_memories.py
@@ -9,8 +9,10 @@ from neurostack.memories import (
     Memory,
     forget_memory,
     get_memory_stats,
+    list_archived_memories,
     merge_memories,
     prune_memories,
+    restore_memory,
     save_memory,
     search_memories,
     suggest_tags,
@@ -526,3 +528,128 @@ class TestMemoryEmbeddingBackfill:
         assert in_memory_db.execute(
             "SELECT embed_pending FROM memories WHERE memory_id=?", (m.memory_id,)
         ).fetchone()["embed_pending"] == 1
+
+
+class TestArchiveOnForget:
+    """Issue #90: delete paths archive instead of destroy."""
+
+    def test_forget_archives_row(self, in_memory_db):
+        m = save_memory(
+            in_memory_db, content="Archived not destroyed",
+            tags=["audit"], entity_type="decision", workspace="work/x",
+        )
+        assert forget_memory(in_memory_db, m.memory_id) is True
+
+        row = in_memory_db.execute(
+            "SELECT * FROM memories_archive WHERE memory_id = ?",
+            (m.memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["content"] == "Archived not destroyed"
+        assert row["archive_reason"] == "forget"
+        assert row["workspace"] == "work/x"
+        assert json.loads(row["tags"]) == ["audit"]
+        assert row["archived_at"] is not None
+
+    def test_forget_still_removes_from_working_set(self, in_memory_db):
+        m = save_memory(in_memory_db, content="working_set_gone_token")
+        forget_memory(in_memory_db, m.memory_id)
+
+        assert in_memory_db.execute(
+            "SELECT * FROM memories WHERE memory_id = ?", (m.memory_id,)
+        ).fetchone() is None
+        assert in_memory_db.execute(
+            "SELECT * FROM memories_fts WHERE memories_fts MATCH ?",
+            ("working_set_gone_token",),
+        ).fetchall() == []
+
+    def test_restore_round_trip(self, in_memory_db):
+        m = save_memory(
+            in_memory_db, content="restore_me_token", entity_type="learning",
+        )
+        forget_memory(in_memory_db, m.memory_id)
+
+        restored = restore_memory(in_memory_db, m.memory_id)
+        assert restored is not None
+        assert restored.memory_id == m.memory_id
+        assert restored.content == "restore_me_token"
+        assert restored.entity_type == "learning"
+
+        # Back in the working set: FTS matches, embed queued, archive row gone
+        assert in_memory_db.execute(
+            "SELECT * FROM memories_fts WHERE memories_fts MATCH ?",
+            ("restore_me_token",),
+        ).fetchall() != []
+        assert in_memory_db.execute(
+            "SELECT embed_pending FROM memories WHERE memory_id = ?",
+            (m.memory_id,),
+        ).fetchone()["embed_pending"] == 1
+        assert in_memory_db.execute(
+            "SELECT * FROM memories_archive WHERE memory_id = ?",
+            (m.memory_id,),
+        ).fetchone() is None
+
+    def test_restore_nonexistent_returns_none(self, in_memory_db):
+        assert restore_memory(in_memory_db, 99999) is None
+
+    def test_merge_archives_source_pre_merge(self, in_memory_db):
+        target = save_memory(in_memory_db, content="Target content")
+        source = save_memory(in_memory_db, content="Source original")
+        merge_memories(in_memory_db, target.memory_id, source.memory_id)
+
+        row = in_memory_db.execute(
+            "SELECT * FROM memories_archive WHERE memory_id = ?",
+            (source.memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["archive_reason"] == "merge"
+        assert row["content"] == "Source original"
+
+    def test_prune_archives(self, in_memory_db):
+        save_memory(in_memory_db, content="Recent")
+        old = save_memory(in_memory_db, content="Old prunable")
+        in_memory_db.execute(
+            "UPDATE memories SET created_at = datetime('now', '-60 days') "
+            "WHERE memory_id = ?", (old.memory_id,)
+        )
+        in_memory_db.commit()
+
+        assert prune_memories(in_memory_db, older_than_days=30) == 1
+        row = in_memory_db.execute(
+            "SELECT archive_reason FROM memories_archive WHERE memory_id = ?",
+            (old.memory_id,),
+        ).fetchone()
+        assert row["archive_reason"] == "prune"
+
+    def test_expired_purge_archives(self, in_memory_db):
+        m = save_memory(in_memory_db, content="Expiring soon", ttl_hours=1)
+        in_memory_db.execute(
+            "UPDATE memories SET expires_at = datetime('now', '-2 hours') "
+            "WHERE memory_id = ?", (m.memory_id,)
+        )
+        in_memory_db.commit()
+
+        search_memories(in_memory_db)  # triggers the expiry purge
+        row = in_memory_db.execute(
+            "SELECT archive_reason FROM memories_archive WHERE memory_id = ?",
+            (m.memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["archive_reason"] == "expire"
+
+    def test_list_archived(self, in_memory_db):
+        a = save_memory(in_memory_db, content="A", workspace="work/x")
+        b = save_memory(in_memory_db, content="B", workspace="home/y")
+        forget_memory(in_memory_db, a.memory_id)
+        forget_memory(in_memory_db, b.memory_id)
+
+        rows = list_archived_memories(in_memory_db)
+        assert {r["memory_id"] for r in rows} == {a.memory_id, b.memory_id}
+        scoped = list_archived_memories(in_memory_db, workspace="work/x")
+        assert [r["memory_id"] for r in scoped] == [a.memory_id]
+
+    def test_stats_archived_count(self, in_memory_db):
+        m = save_memory(in_memory_db, content="Counted")
+        forget_memory(in_memory_db, m.memory_id)
+        stats = get_memory_stats(in_memory_db)
+        assert stats["archived"] == 1

--- a/tests/test_memory_drift.py
+++ b/tests/test_memory_drift.py
@@ -223,9 +223,10 @@ def test_v20_to_v21_adds_memory_id_preserving_rows():
     assert row["note_path"] == "a.md"          # pre-existing row preserved
     assert row["memory_id"] is None
     assert row["error_type"] == "low_overlap"
+    from neurostack.schema import SCHEMA_VERSION
     assert conn.execute(
         "SELECT MAX(version) FROM schema_version"
-    ).fetchone()[0] == 21
+    ).fetchone()[0] == SCHEMA_VERSION
 
 
 def test_tool_surfaces_memory_drift(db):


### PR DESCRIPTION
Closes #90.

## What

Deletion removes a memory from the working set, never from the record. All four delete paths — `vault_forget`/`memories forget`, merge (source row, pre-merge content), TTL expiry purge, `memories prune` — route through a shared `_archive_memories` helper that moves rows into a new `memories_archive` table (schema v22) with an `archive_reason`.

## How

- `memories_archive` has no FTS index and no embedding column: invisible to search/drift/ranking by construction, no query-site filtering needed.
- `restore_memory` moves a row back with `embed_pending=1` (FTS immediately via trigger, semantic via `backfill memories`); SQLite AUTOINCREMENT means restored ids can never collide.
- CLI: `neurostack memories archived [-w] [--limit N]`, `neurostack memories restore ID`; `stats` gains `archived`. MCP `vault_forget` signature unchanged, result carries `archived: true`.

## Gate

`uv run pytest` 686 passed (9 new tests: archive/restore round-trip, per-path reasons, FTS exclusion, workspace-scoped listing, stats). `ruff check` clean. v22 migration is additive-only — safe on a live DB.