### PR TITLE
Promotion queue: surface memories whose knowledge should move into notes (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **#92 — promotion queue.** `neurostack promote` + MCP `vault_promotion_queue`: a deterministic worklist of memories whose knowledge should move into vault notes, in four buckets — `debt` (tagged `promotion-debt`), `drift` (unresolved memory-drift rows), `dead_handoffs` (stale context memories that read as handoffs; `open-thread` tag exempts), `uncovered` (durable memories whose nearest note chunk is below a similarity floor). Pure local compute, no LLM, no writes. `vault_session_end` now returns a soft `promotion_debt_warning` when a session wrote durable memories but no note changed while it ran.
+
 - **#90 — archive-on-forget.** Every memory delete path (`vault_forget`/`memories forget`, merge source, TTL expiry, prune) now moves the row to a `memories_archive` table instead of destroying it. Archived rows are outside search/FTS/drift by construction but stay greppable and restorable. New CLI: `neurostack memories archived [-w] [--limit N]` and `neurostack memories restore ID` (restored rows re-embed via `backfill memories`). `memories stats` gains `archived`; MCP `vault_forget` result carries `archived: true`.
 
 ### Schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 | `neurostack record-usage "path1" "path2"` | Record note usage for hotness scoring |
 | `neurostack decay` | Report note excitability and dormancy |
 | `neurostack prediction-errors` | Show notes flagged as poor retrieval fit |
+| `neurostack promote` | Promotion queue: memories that should become vault notes (#92). `--workspace`, `--sim-floor`, `--handoff-age-days` |
 | `neurostack feedback` | Show accumulated implicit-feedback stats — searches, uses, ranks (issue #66) |
 | `neurostack migrate write-back` | Export qualifying memories to markdown files (issue #20). `--dry-run` to preview |
 | `neurostack sync` | Reconcile write-back files against the DB (DB wins on conflict) |
@@ -150,6 +151,7 @@ Models: `neurostack-ask` (RAG), `neurostack-search` (hybrid), `neurostack-tiered
 - `vault_forget(memory_id)` - Delete memory (archived to `memories_archive`, restorable via CLI, issue #90)
 - `vault_memories(query, entity_type, workspace, limit)` - List/search memories
 - `vault_harvest(sessions, dry_run)` - Extract session insights
+- `vault_promotion_queue(workspace, handoff_age_days, uncovered_sim_floor, uncovered_limit)` - Deterministic worklist of memories to promote into notes (#92): debt / drift / dead_handoffs / uncovered
 
 ### Sessions
 - `vault_session_start(source_agent, workspace)` - Begin memory session

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -10,7 +10,7 @@ from .. import __version__
 from ..config import get_config
 from .api import cmd_api, cmd_bundle, cmd_serve
 from .index import cmd_backfill, cmd_export, cmd_index, cmd_reembed_chunks, cmd_watch
-from .memories import cmd_memories
+from .memories import cmd_memories, cmd_promote
 from .search import (
     cmd_ask,
     cmd_brief,
@@ -739,6 +739,24 @@ def main():
         "Also reads NEUROSTACK_WORKSPACE env var",
     )
     p.set_defaults(func=cmd_prediction_errors)
+
+    # promote
+    p = sub.add_parser(
+        "promote",
+        help="Promotion queue: memories whose knowledge should move"
+        " into vault notes (issue #92)",
+    )
+    p.add_argument("--handoff-age-days", type=int, default=14,
+                   help="Grace window before a handoff memory counts as dead")
+    p.add_argument("--sim-floor", type=float, default=0.55,
+                   help="Nearest-chunk similarity below this = uncovered")
+    p.add_argument("--limit", type=int, default=200,
+                   help="Max durable memories scanned for coverage")
+    p.add_argument(
+        "--workspace", "-w", default=None,
+        help="Restrict to vault subdirectory. Also reads NEUROSTACK_WORKSPACE",
+    )
+    p.set_defaults(func=cmd_promote)
 
     # stats
     p = sub.add_parser("stats", help="Show index stats")

--- a/src/neurostack/cli/memories.py
+++ b/src/neurostack/cli/memories.py
@@ -279,3 +279,49 @@ def cmd_memories(args):
     else:
         print("Usage: neurostack memories {add,search,list,forget,prune,stats,update,merge}")
         print("       neurostack memories --help")
+
+
+def cmd_promote(args):
+    """Promotion queue: memories whose knowledge should move into notes."""
+    from ..promotion import compute_promotion_queue
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    queue = compute_promotion_queue(
+        conn,
+        workspace=_get_workspace(args),
+        handoff_age_days=args.handoff_age_days,
+        uncovered_sim_floor=args.sim_floor,
+        uncovered_limit=args.limit,
+    )
+    if args.json:
+        print(json.dumps(queue, indent=2, default=str))
+        return
+
+    counts = queue["counts"]
+    total = sum(counts.values())
+    print(f"  Promotion queue: {total} candidates "
+          f"(debt {counts['debt']}, drift {counts['drift']}, "
+          f"dead handoffs {counts['dead_handoffs']}, "
+          f"uncovered {counts['uncovered']})")
+    for bucket, label in [
+        ("debt", "PROMOTION-DEBT"),
+        ("drift", "DRIFTED"),
+        ("dead_handoffs", "DEAD HANDOFFS"),
+        ("uncovered", "NO COVERING NOTE"),
+    ]:
+        if not queue[bucket]:
+            continue
+        print(f"\n  {label}:")
+        for e in queue[bucket]:
+            extra = ""
+            if bucket == "drift":
+                extra = f" [drifted from {e['drifted_from']}]"
+            elif bucket == "uncovered":
+                extra = (f" [nearest {e['nearest_note']}"
+                         f" sim {e['nearest_similarity']}]")
+            print(f"    #{e['memory_id']:<4} [{e['entity_type']}]"
+                  f" {e['created_at']}{extra}")
+            print(f"          {e['preview'][:100]}")
+    if total:
+        print(f"\n  {queue['hint']}")

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -1028,7 +1028,7 @@ def end_session(
         (session_id,),
     ).fetchone()
 
-    return {
+    result = {
         "session_id": session_id,
         "started_at": updated["started_at"],
         "ended_at": updated["ended_at"],
@@ -1036,6 +1036,36 @@ def end_session(
         "source_agent": updated["source_agent"],
         "workspace": updated["workspace"],
     }
+
+    # Promotion-debt warning (issue #92): the session wrote durable memories
+    # but no vault note changed while it ran — knowledge is about to strand in
+    # the volatile layer. Soft signal only; the caller decides what to do.
+    from .promotion import DURABLE_TYPES
+    durable = conn.execute(
+        "SELECT COUNT(*) AS c FROM memories WHERE session_id = ?"
+        f" AND entity_type IN ({','.join('?' * len(DURABLE_TYPES))})",
+        (session_id, *DURABLE_TYPES),
+    ).fetchone()["c"]
+    if durable:
+        # notes.updated_at is ISO-with-T (watcher), started_at is SQLite
+        # 'YYYY-MM-DD HH:MM:SS' — datetime() canonicalises both to UTC.
+        notes_touched = conn.execute(
+            "SELECT COUNT(*) AS c FROM notes"
+            " WHERE datetime(updated_at) >= datetime(?)",
+            (updated["started_at"],),
+        ).fetchone()["c"]
+        if notes_touched == 0:
+            result["promotion_debt_warning"] = {
+                "durable_memories": durable,
+                "notes_updated_during_session": 0,
+                "hint": (
+                    "Run your vault-save step, or tag one of this session's"
+                    " memories 'promotion-debt' so the promotion queue"
+                    " (vault_promotion_queue / neurostack promote) picks it up."
+                ),
+            }
+
+    return result
 
 
 def get_session(

--- a/src/neurostack/promotion.py
+++ b/src/neurostack/promotion.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Promotion queue (issue #92): memories whose knowledge should move into notes.
+
+Agents write rich memories but the note layer lags. Detection is mechanical;
+only the note-writing needs judgment. This module computes a deterministic
+worklist in four buckets — no LLM calls, no writes — for a downstream agent
+(a weekly cron, or an interactive session) to consume:
+
+- **debt**: memories explicitly tagged ``promotion-debt`` by a session that
+  ended without running its vault-save step.
+- **drift**: unresolved ``memory_drift`` prediction errors (issue #38) — the
+  memory no longer matches the notes it references.
+- **dead_handoffs**: ``context`` memories that read as handoff/continuation
+  state and are older than a grace window. Consumed handoffs stored as if
+  live are the single biggest volatile-layer polluter. Memories tagged
+  ``open-thread`` are deliberate keeps and excluded.
+- **uncovered**: durable memories (decision/learning/bug/convention) whose
+  nearest note chunk falls below a similarity floor — knowledge with no
+  covering note anywhere in the vault.
+"""
+
+import json
+import sqlite3
+
+DURABLE_TYPES = ("decision", "learning", "bug", "convention")
+HANDOFF_MARKERS = ("handoff", "continuation", "state anchor")
+DEFAULT_HANDOFF_AGE_DAYS = 14
+DEFAULT_UNCOVERED_SIM_FLOOR = 0.55
+DEFAULT_UNCOVERED_LIMIT = 200
+_PREVIEW_CHARS = 240
+
+
+def _entry(row: dict, **extra) -> dict:
+    tags_raw = row.get("tags")
+    if isinstance(tags_raw, str):
+        try:
+            tags = json.loads(tags_raw)
+        except (json.JSONDecodeError, TypeError):
+            tags = []
+    else:
+        tags = tags_raw or []
+    return {
+        "memory_id": row["memory_id"],
+        "entity_type": row["entity_type"],
+        "workspace": row.get("workspace"),
+        "tags": tags,
+        "created_at": row.get("created_at"),
+        "preview": (row.get("content") or "")[:_PREVIEW_CHARS],
+        **extra,
+    }
+
+
+def _debt_bucket(conn: sqlite3.Connection, workspace: str | None) -> list[dict]:
+    sql = (
+        "SELECT DISTINCT m.* FROM memories m, json_each(m.tags) t"
+        " WHERE t.value = 'promotion-debt'"
+    )
+    params: list = []
+    if workspace:
+        sql += " AND m.workspace = ?"
+        params.append(workspace)
+    sql += " ORDER BY m.created_at DESC"
+    return [_entry(dict(r)) for r in conn.execute(sql, params).fetchall()]
+
+
+def _drift_bucket(conn: sqlite3.Connection, workspace: str | None) -> list[dict]:
+    sql = (
+        "SELECT m.*, p.note_path, p.cosine_distance, p.detected_at"
+        " FROM prediction_errors p JOIN memories m ON m.memory_id = p.memory_id"
+        " WHERE p.memory_id IS NOT NULL AND p.resolved_at IS NULL"
+        " AND p.error_type = 'memory_drift'"
+    )
+    params: list = []
+    if workspace:
+        sql += " AND m.workspace = ?"
+        params.append(workspace)
+    sql += " ORDER BY p.cosine_distance DESC"
+    return [
+        _entry(
+            dict(r),
+            drifted_from=r["note_path"],
+            cosine_distance=r["cosine_distance"],
+            detected_at=r["detected_at"],
+        )
+        for r in conn.execute(sql, params).fetchall()
+    ]
+
+
+def _dead_handoff_bucket(
+    conn: sqlite3.Connection, workspace: str | None, age_days: int
+) -> list[dict]:
+    sql = (
+        "SELECT * FROM memories WHERE entity_type = 'context'"
+        " AND created_at < datetime('now', ?)"
+    )
+    params: list = [f"-{age_days} days"]
+    if workspace:
+        sql += " AND workspace = ?"
+        params.append(workspace)
+    sql += " ORDER BY created_at ASC"
+
+    out = []
+    for r in conn.execute(sql, params).fetchall():
+        row = dict(r)
+        head = (row.get("content") or "")[:120].lower()
+        if not any(m in head for m in HANDOFF_MARKERS):
+            continue
+        tags_raw = row.get("tags") or "[]"
+        if "open-thread" in tags_raw:
+            continue
+        out.append(_entry(row, age_days_over=age_days))
+    return out
+
+
+def _uncovered_bucket(
+    conn: sqlite3.Connection,
+    workspace: str | None,
+    sim_floor: float,
+    limit: int,
+    exclude_ids: set[int],
+) -> list[dict]:
+    import numpy as np
+
+    from .embedder import blob_to_embedding, cosine_similarity_batch
+
+    chunk_rows = conn.execute(
+        "SELECT note_path, embedding FROM chunks WHERE embedding IS NOT NULL"
+    ).fetchall()
+    if not chunk_rows:
+        return []
+    chunk_matrix = np.vstack([blob_to_embedding(r["embedding"]) for r in chunk_rows])
+    chunk_paths = [r["note_path"] for r in chunk_rows]
+
+    sql = (
+        "SELECT * FROM memories WHERE embedding IS NOT NULL"
+        f" AND entity_type IN ({','.join('?' * len(DURABLE_TYPES))})"
+    )
+    params: list = list(DURABLE_TYPES)
+    if workspace:
+        sql += " AND workspace = ?"
+        params.append(workspace)
+    sql += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+
+    out = []
+    for r in conn.execute(sql, params).fetchall():
+        row = dict(r)
+        if row["memory_id"] in exclude_ids:
+            continue
+        emb = blob_to_embedding(row["embedding"])
+        if emb is None:
+            continue
+        sims = cosine_similarity_batch(emb, chunk_matrix)
+        best = int(sims.argmax())
+        best_sim = float(sims[best])
+        if best_sim >= sim_floor:
+            continue
+        out.append(_entry(
+            row,
+            nearest_note=chunk_paths[best],
+            nearest_similarity=round(best_sim, 4),
+        ))
+    out.sort(key=lambda e: e["nearest_similarity"])
+    return out
+
+
+def compute_promotion_queue(
+    conn: sqlite3.Connection,
+    workspace: str | None = None,
+    handoff_age_days: int = DEFAULT_HANDOFF_AGE_DAYS,
+    uncovered_sim_floor: float = DEFAULT_UNCOVERED_SIM_FLOOR,
+    uncovered_limit: int = DEFAULT_UNCOVERED_LIMIT,
+) -> dict:
+    """Compute the promotion worklist. Pure read — no LLM, no writes."""
+    workspace = workspace.strip("/") if workspace else None
+
+    debt = _debt_bucket(conn, workspace)
+    drift = _drift_bucket(conn, workspace)
+    dead = _dead_handoff_bucket(conn, workspace, handoff_age_days)
+    claimed = {e["memory_id"] for b in (debt, drift, dead) for e in b}
+    uncovered = _uncovered_bucket(
+        conn, workspace, uncovered_sim_floor, uncovered_limit, claimed
+    )
+
+    return {
+        "counts": {
+            "debt": len(debt),
+            "drift": len(drift),
+            "dead_handoffs": len(dead),
+            "uncovered": len(uncovered),
+        },
+        "debt": debt,
+        "drift": drift,
+        "dead_handoffs": dead,
+        "uncovered": uncovered,
+        "hint": (
+            "Per entry: promote durable content into a note (folder pattern,"
+            " update index.md), then vault_update_memory to slim + wiki-link,"
+            " or vault_forget a consumed handoff (archived, restorable)."
+            " 'open-thread' tagged memories are deliberate keeps."
+        ),
+    }

--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -266,3 +266,38 @@ def vault_memories(
     return {"memories": output}
 
 
+
+
+@registry.tool(tags=["memory", "read"], annotations=_READ_ONLY)
+def vault_promotion_queue(
+    workspace: str = None,
+    handoff_age_days: int = 14,
+    uncovered_sim_floor: float = 0.55,
+    uncovered_limit: int = 200,
+) -> dict:
+    """Memories whose knowledge should be promoted into vault notes.
+
+    Deterministic worklist, four buckets (issue #92): 'debt' (tagged
+    promotion-debt), 'drift' (unresolved memory_drift rows), 'dead_handoffs'
+    (stale context memories that read as handoffs; 'open-thread' tag exempts),
+    'uncovered' (durable memories whose nearest note chunk is below the
+    similarity floor — no covering note exists). Read-only; a downstream agent
+    writes the notes and clears entries via vault_update_memory/vault_forget.
+
+    Args:
+        workspace: Optional vault subdirectory scope
+        handoff_age_days: Grace window before a handoff counts as dead (default 14)
+        uncovered_sim_floor: Nearest-chunk similarity below this = uncovered (default 0.55)
+        uncovered_limit: Max durable memories scanned for coverage (default 200, newest first)
+    """
+    from ..promotion import compute_promotion_queue
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    return compute_promotion_queue(
+        conn,
+        workspace=workspace,
+        handoff_age_days=handoff_age_days,
+        uncovered_sim_floor=uncovered_sim_floor,
+        uncovered_limit=uncovered_limit,
+    )

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for the promotion queue (issue #92)."""
+
+import json
+
+import pytest
+
+from neurostack import config as nsconfig
+
+np = pytest.importorskip("numpy")
+
+from neurostack.promotion import compute_promotion_queue  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db()
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _vec(*xs):
+    return np.array(xs, dtype=np.float32)
+
+
+def _add_note_chunk(conn, path, vec):
+    conn.execute(
+        "INSERT OR REPLACE INTO notes (path, title, content_hash, updated_at)"
+        " VALUES (?, ?, 'h', '2026-07-01T00:00:00+00:00')",
+        (path, path),
+    )
+    conn.execute(
+        "INSERT INTO chunks (note_path, heading_path, content, content_hash,"
+        " position, embedding) VALUES (?, '', 'chunk', 'h', 0, ?)",
+        (path, vec.tobytes()),
+    )
+    conn.commit()
+
+
+def _add_memory(conn, content, entity_type="decision", vec=None, tags=None,
+                workspace=None, created_at=None):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, embedding, tags, workspace)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (content, entity_type,
+         vec.tobytes() if vec is not None else None,
+         json.dumps(tags) if tags else None, workspace),
+    )
+    if created_at:
+        conn.execute(
+            "UPDATE memories SET created_at = ? WHERE memory_id = ?",
+            (created_at, cur.lastrowid),
+        )
+    conn.commit()
+    return cur.lastrowid
+
+
+class TestPromotionQueue:
+    def test_empty_db_empty_queue(self, db):
+        q = compute_promotion_queue(db)
+        assert q["counts"] == {
+            "debt": 0, "drift": 0, "dead_handoffs": 0, "uncovered": 0,
+        }
+
+    def test_debt_bucket_by_tag(self, db):
+        mid = _add_memory(db, "Skipped vault-save", tags=["promotion-debt"])
+        _add_memory(db, "Normal memory", tags=["other"])
+        q = compute_promotion_queue(db)
+        assert [e["memory_id"] for e in q["debt"]] == [mid]
+
+    def test_drift_bucket_from_prediction_errors(self, db):
+        mid = _add_memory(db, "Drifted memory")
+        db.execute(
+            "INSERT INTO prediction_errors (note_path, query, cosine_distance,"
+            " error_type, memory_id) VALUES ('a.md', '', 0.7, 'memory_drift', ?)",
+            (mid,),
+        )
+        db.commit()
+        q = compute_promotion_queue(db)
+        assert q["counts"]["drift"] == 1
+        assert q["drift"][0]["drifted_from"] == "a.md"
+
+    def test_resolved_drift_excluded(self, db):
+        mid = _add_memory(db, "Resolved drift")
+        db.execute(
+            "INSERT INTO prediction_errors (note_path, query, cosine_distance,"
+            " error_type, memory_id, resolved_at)"
+            " VALUES ('a.md', '', 0.7, 'memory_drift', ?, datetime('now'))",
+            (mid,),
+        )
+        db.commit()
+        assert compute_promotion_queue(db)["counts"]["drift"] == 0
+
+    def test_dead_handoff_needs_marker_age_and_type(self, db):
+        old = "2026-01-01 00:00:00"
+        dead = _add_memory(db, "HANDOFF (session 1): continue X",
+                           entity_type="context", created_at=old)
+        _add_memory(db, "HANDOFF but fresh", entity_type="context")
+        _add_memory(db, "Old context, no marker",
+                     entity_type="context", created_at=old)
+        _add_memory(db, "HANDOFF but a decision",
+                     entity_type="decision", created_at=old)
+        q = compute_promotion_queue(db)
+        assert [e["memory_id"] for e in q["dead_handoffs"]] == [dead]
+
+    def test_open_thread_tag_exempts_handoff(self, db):
+        _add_memory(db, "CONTINUATION: still live thread",
+                     entity_type="context", tags=["open-thread"],
+                     created_at="2026-01-01 00:00:00")
+        assert compute_promotion_queue(db)["counts"]["dead_handoffs"] == 0
+
+    def test_uncovered_below_floor_covered_above(self, db):
+        _add_note_chunk(db, "covered.md", _vec(1, 0, 0, 0))
+        covered = _add_memory(db, "Covered knowledge", vec=_vec(1, 0, 0, 0))
+        uncovered = _add_memory(db, "Orphan knowledge", vec=_vec(0, 1, 0, 0))
+        q = compute_promotion_queue(db)
+        ids = [e["memory_id"] for e in q["uncovered"]]
+        assert uncovered in ids
+        assert covered not in ids
+        entry = next(e for e in q["uncovered"] if e["memory_id"] == uncovered)
+        assert entry["nearest_note"] == "covered.md"
+        assert entry["nearest_similarity"] < 0.55
+
+    def test_uncovered_skips_non_durable_and_other_buckets(self, db):
+        _add_note_chunk(db, "n.md", _vec(1, 0, 0, 0))
+        _add_memory(db, "Ephemeral obs", entity_type="observation",
+                     vec=_vec(0, 1, 0, 0))
+        debt = _add_memory(db, "Tagged debt", vec=_vec(0, 1, 0, 0),
+                           tags=["promotion-debt"])
+        q = compute_promotion_queue(db)
+        ids = [e["memory_id"] for e in q["uncovered"]]
+        assert ids == []
+        assert [e["memory_id"] for e in q["debt"]] == [debt]
+
+    def test_workspace_scoping(self, db):
+        _add_memory(db, "In scope", tags=["promotion-debt"], workspace="work/x")
+        _add_memory(db, "Out of scope", tags=["promotion-debt"], workspace="home/y")
+        q = compute_promotion_queue(db, workspace="work/x")
+        assert q["counts"]["debt"] == 1
+        assert q["debt"][0]["workspace"] == "work/x"
+
+
+class TestSessionEndDebtWarning:
+    def test_warns_when_durable_memories_but_no_note_change(self, db):
+        from neurostack.memories import end_session, save_memory, start_session
+
+        sid = start_session(db)["session_id"]
+        save_memory(db, content="A durable decision", entity_type="decision",
+                    session_id=sid, dedup=False)
+        result = end_session(db, sid)
+        assert result["promotion_debt_warning"]["durable_memories"] == 1
+
+    def test_no_warning_when_note_updated_during_session(self, db):
+        from neurostack.memories import end_session, save_memory, start_session
+
+        sid = start_session(db)["session_id"]
+        save_memory(db, content="A durable decision", entity_type="decision",
+                    session_id=sid, dedup=False)
+        # Note indexed after session start (ISO-with-T format, as the watcher writes)
+        db.execute(
+            "INSERT INTO notes (path, title, content_hash, updated_at)"
+            " VALUES ('fresh.md', 'fresh', 'h',"
+            " strftime('%Y-%m-%dT%H:%M:%S+00:00', datetime('now', '+1 hour')))"
+        )
+        db.commit()
+        result = end_session(db, sid)
+        assert "promotion_debt_warning" not in result
+
+    def test_no_warning_for_observation_only_session(self, db):
+        from neurostack.memories import end_session, save_memory, start_session
+
+        sid = start_session(db)["session_id"]
+        save_memory(db, content="Just an observation", session_id=sid,
+                    dedup=False)
+        result = end_session(db, sid)
+        assert "promotion_debt_warning" not in result


### PR DESCRIPTION
Closes #92.

Deterministic, read-only worklist in four buckets (debt / drift / dead_handoffs / uncovered) via `neurostack promote` and MCP `vault_promotion_queue`; `vault_session_end` gains a soft `promotion_debt_warning`. Coverage check reuses stored embeddings (batched numpy, no sqlite-vec dependency). Gate: 698 tests passed (12 new), ruff clean.