### PR TITLE
feat(context): soft context boost on vault_context sub-retrievals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0",
     "watchdog>=4.0",
-    "mcp[cli]>=1.0",
+    # mcp 2.0 removed mcp.server.fastmcp — pin until the adapter migrates (issue #98)
+    "mcp[cli]>=1.0,<2",
     "httpx>=0.27",
     "tomli_w>=1.0",
     "pathspec>=0.12",

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -791,6 +791,10 @@ def main():
     p.add_argument("--budget", type=int, default=2000,
                    help="Token budget (default: 2000)")
     p.add_argument("--workspace", "-w", help="Workspace scope")
+    p.add_argument(
+        "--context", "-c", default=None,
+        help="Project/domain context for result boosting",
+    )
     p.add_argument("--no-memories", action="store_true",
                    help="Exclude memories from context")
     p.add_argument("--no-triples", action="store_true",

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -997,6 +997,7 @@ def cmd_context(args):
         include_memories=not args.no_memories,
         include_triples=not args.no_triples,
         embed_url=args.embed_url,
+        context=getattr(args, "context", None),
     )
 
     if args.json:

--- a/src/neurostack/context.py
+++ b/src/neurostack/context.py
@@ -20,11 +20,16 @@ def build_vault_context(
     include_memories: bool = True,
     include_triples: bool = True,
     embed_url: str | None = None,
+    context: str | None = None,
 ) -> dict:
     """Assemble a context window for a specific task.
 
     Combines memories, triples, summaries, and session history
     relevant to the given task description. Respects token budget.
+
+    ``context`` applies the same soft attention boost as vault_search
+    (1.4x/1.2x convergence, re-ranking not filtering) to the memories,
+    triples, and summaries sub-retrievals (issue #94).
 
     Returns structured dict with sections and approximate token count.
     """
@@ -46,7 +51,7 @@ def build_vault_context(
 
             memories = search_memories(
                 conn, query=task, workspace=workspace,
-                limit=10, embed_url=url,
+                limit=10, embed_url=url, context=context,
             )
             # Memory drift detection (issue #38), non-blocking.
             from .memory_drift import check_memory_drift
@@ -82,7 +87,7 @@ def build_vault_context(
 
             triples = search_triples(
                 task, top_k=15, mode="hybrid",
-                embed_url=url, workspace=workspace,
+                embed_url=url, workspace=workspace, context=context,
             )
             triple_entries = []
             for t in triples:
@@ -111,7 +116,7 @@ def build_vault_context(
 
         results = hybrid_search(
             task, top_k=5, mode="hybrid",
-            embed_url=url, workspace=workspace,
+            embed_url=url, workspace=workspace, context=context,
         )
         summary_entries = []
         for r in results:

--- a/src/neurostack/memories.py
+++ b/src/neurostack/memories.py
@@ -707,6 +707,26 @@ def merge_memories(
     return merged
 
 
+def _boost_memories_by_context(results: list[dict], context: str | None) -> None:
+    """Soft context boost for scored memory rows (issue #94).
+
+    Mirrors vault_search's convergence boost: a memory whose workspace or tags
+    match the active context gets 1.4x. Re-ranking, not filtering — out-of-context
+    memories still surface. Callers re-sort.
+    """
+    if not context:
+        return
+    ctx = context.lower()
+    for r in results:
+        ws = (r.get("workspace") or "").lower()
+        try:
+            tags = json.loads(r.get("tags") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            tags = []
+        if ctx in ws or any(ctx in str(t).lower() for t in tags):
+            r["score"] *= 1.4
+
+
 def search_memories(
     conn: sqlite3.Connection,
     query: str | None = None,
@@ -715,10 +735,13 @@ def search_memories(
     limit: int = 20,
     embed_url: str | None = None,
     include_expired: bool = False,
+    context: str | None = None,
 ) -> list[Memory]:
     """Search memories by text, type, and/or workspace.
 
     Uses FTS5 for keyword search, with optional semantic reranking.
+    ``context`` applies a soft 1.4x boost (workspace/tag match) on the scored
+    semantic paths; the no-query listing path has no score to boost.
     """
     # Purge expired memories first (to the archive, not oblivion — issue #90)
     if not include_expired:
@@ -733,7 +756,7 @@ def search_memories(
     if query:
         return _hybrid_memory_search(
             conn, query, entity_type=entity_type, workspace=workspace,
-            limit=limit, embed_url=embed_url,
+            limit=limit, embed_url=embed_url, context=context,
         )
 
     # No query — list memories with filters
@@ -779,6 +802,7 @@ def _hybrid_memory_search(
     workspace: str | None = None,
     limit: int = 20,
     embed_url: str | None = None,
+    context: str | None = None,
 ) -> list[Memory]:
     """FTS5 + semantic search over memories."""
     # FTS5 search
@@ -852,6 +876,7 @@ def _hybrid_memory_search(
                 for i, r in enumerate(valid):
                     fts_score = 1.0 / (1.0 + abs(r.get("rank", 0)))
                     r["score"] = 0.3 * fts_score + 0.7 * float(scores[i])
+                _boost_memories_by_context(valid, context)
                 valid.sort(key=lambda x: x["score"], reverse=True)
                 return [_row_to_memory(r, score=r["score"]) for r in valid[:limit]]
 
@@ -894,11 +919,17 @@ def _hybrid_memory_search(
 
                 matrix = np.stack(embeddings)
                 scores = cosine_similarity_batch(query_emb, matrix)
-                top_indices = np.argsort(scores)[::-1][:limit]
+                scored = []
+                for idx in np.argsort(scores)[::-1][: limit * 3 if context else limit]:
+                    d = data[idx]
+                    d["score"] = float(scores[idx])
+                    scored.append(d)
+                _boost_memories_by_context(scored, context)
+                scored.sort(key=lambda x: x["score"], reverse=True)
 
                 return [
-                    _row_to_memory(data[idx], score=float(scores[idx]))
-                    for idx in top_indices
+                    _row_to_memory(d, score=d["score"])
+                    for d in scored[:limit]
                 ]
 
     except Exception as exc:

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -1280,6 +1280,30 @@ def triple_semantic_search(
     return results
 
 
+def _boost_triples_by_context(
+    conn: sqlite3.Connection,
+    results: list[dict],
+    context: str | None,
+    embed_url: str = None,
+) -> None:
+    """Apply the vault_search context boost to scored triple dicts (issue #94).
+
+    Same convergence path as hybrid_search: 1.4x for triples from notes that
+    directly match the context, 1.2x for their 1-hop link neighbors. Re-ranking,
+    not filtering — out-of-context triples still surface. Callers re-sort.
+    """
+    if not context or not results:
+        return
+    direct_ctx, neighbor_ctx = _get_context_notes(conn, context, embed_url=embed_url)
+    for r in results:
+        if r["note_path"] in direct_ctx:
+            r["score"] = r.get("score", 0.0) * 1.4
+        elif r["note_path"] in neighbor_ctx:
+            r["score"] = r.get("score", 0.0) * 1.2
+    results.sort(key=lambda x: x.get("score", 0.0), reverse=True)
+
+
+
 def search_triples(
     query: str,
     top_k: int = 10,
@@ -1287,8 +1311,12 @@ def search_triples(
     embed_url: str = None,
     db_path=None,
     workspace: str | None = None,
+    context: str | None = None,
 ) -> list[TripleResult]:
     """Search triples using hybrid FTS5 + semantic similarity.
+
+    ``context`` applies the same soft attention boost as hybrid_search on the
+    scored (semantic/hybrid) paths; keyword-only paths have no score to boost.
 
     Returns compact TripleResult objects (~10-20 tokens each).
     """
@@ -1319,8 +1347,10 @@ def search_triples(
 
     if mode == "semantic":
         sem_results = triple_semantic_search(
-            conn, query_embedding, limit=top_k, workspace=workspace,
+            conn, query_embedding, limit=top_k * 3 if context else top_k,
+            workspace=workspace,
         )
+        _boost_triples_by_context(conn, sem_results, context, embed_url=embed_url)
         results = _to_triple_results(conn, sem_results[:top_k])
         _record_note_usage(conn, [r.note_path for r in results])
         return results
@@ -1332,8 +1362,10 @@ def search_triples(
 
     if not fts_results:
         sem_results = triple_semantic_search(
-            conn, query_embedding, limit=top_k, workspace=workspace,
+            conn, query_embedding, limit=top_k * 3 if context else top_k,
+            workspace=workspace,
         )
+        _boost_triples_by_context(conn, sem_results, context, embed_url=embed_url)
         results = _to_triple_results(conn, sem_results[:top_k])
         _record_note_usage(conn, [r.note_path for r in results])
         return results
@@ -1356,6 +1388,8 @@ def search_triples(
     for i, r in enumerate(valid_results):
         fts_score = 1.0 / (1.0 + abs(r.get("rank", 0)))
         r["score"] = 0.3 * fts_score + 0.7 * float(scores[i])
+
+    _boost_triples_by_context(conn, valid_results, context, embed_url=embed_url)
 
     valid_results.sort(key=lambda x: x["score"], reverse=True)
 
@@ -1446,6 +1480,7 @@ def tiered_search(
             query, top_k=top_k * 2, mode=mode,
             embed_url=embed_url, db_path=db_path,
             workspace=workspace,
+            context=context,
         )
         result["triples"] = [
             {"note": t.note_path, "title": t.title,
@@ -1492,6 +1527,7 @@ def tiered_search(
         query, top_k=top_k * 3, mode=mode,
         embed_url=embed_url, db_path=db_path,
         workspace=workspace,
+        context=context,
     )
     result["triples"] = [
         {"note": t.note_path, "title": t.title,

--- a/src/neurostack/tools/insight_tools.py
+++ b/src/neurostack/tools/insight_tools.py
@@ -47,6 +47,7 @@ def vault_context(
     workspace: str = None,
     include_memories: bool = True,
     include_triples: bool = True,
+    context: str = None,
 ) -> dict:
     """Assemble task-scoped context for session recovery after /clear or new conversation.
 
@@ -57,9 +58,12 @@ def vault_context(
     Args:
         task: Description of the current task or goal
         token_budget: Maximum approximate tokens in response (default 2000)
-        workspace: Optional vault subdirectory to scope
+        workspace: Optional vault subdirectory to scope (hard filter)
         include_memories: Include relevant memories (default True)
         include_triples: Include relevant triples (default True)
+        context: Optional project/domain context (e.g. "strake") — soft
+            attention boost that re-ranks toward matching notes without
+            filtering out the rest of the vault
     """
     from ..context import build_vault_context
     from ..schema import DB_PATH, get_db
@@ -70,4 +74,5 @@ def vault_context(
         conn, task=task, token_budget=token_budget,
         workspace=workspace, include_memories=include_memories,
         include_triples=include_triples, embed_url=embed_url,
+        context=context,
     )

--- a/tests/test_context_boost.py
+++ b/tests/test_context_boost.py
@@ -1,0 +1,206 @@
+"""Tests for the context= soft attention boost on vault_context's sub-retrievals (issue #94).
+
+vault_search already had the 1.4x/1.2x convergence boost; this covers its extension to
+the three vault_context sub-retrievals: triples (via _get_context_notes note sets),
+memories (workspace/tag match), and the build_vault_context passthrough. Style mirrors
+test_prediction_errors.py: real in-memory sqlite, monkeypatched get_db/get_embedding,
+never MagicMock.
+"""
+
+import json
+import struct
+
+import numpy as np
+
+from neurostack.context import build_vault_context
+from neurostack.memories import _boost_memories_by_context, search_memories
+from neurostack.search import search_triples
+
+DIM = 768
+
+
+def _emb_blob() -> bytes:
+    """Unit embedding e0 — identical for every row so base scores tie exactly."""
+    v = [0.0] * DIM
+    v[0] = 1.0
+    return struct.pack(f"{DIM}f", *v)
+
+
+def _query_emb() -> np.ndarray:
+    q = np.zeros(DIM, dtype=np.float32)
+    q[0] = 1.0
+    return q
+
+
+def _add_note(conn, path, title="N"):
+    conn.execute(
+        "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?, ?, ?, ?)",
+        (path, title, f"h_{path}", "2026-01-01"),
+    )
+
+
+def _add_triple(conn, note_path, subject):
+    conn.execute(
+        "INSERT INTO triples (note_path, subject, predicate, object, triple_text, embedding)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (note_path, subject, "relates to", "thing", f"tripletoken {subject}", _emb_blob()),
+    )
+
+
+def _add_memory(conn, content, workspace=None, tags=None):
+    conn.execute(
+        "INSERT INTO memories (content, workspace, tags, embedding) VALUES (?, ?, ?, ?)",
+        (content, workspace, json.dumps(tags or []), _emb_blob()),
+    )
+
+
+def _patch_search(monkeypatch, conn):
+    import neurostack.search as search_mod
+
+    monkeypatch.setattr(search_mod, "get_db", lambda path: conn)
+    monkeypatch.setattr(search_mod, "get_embedding", lambda q, base_url=None: _query_emb())
+
+
+def _patch_memories(monkeypatch):
+    import neurostack.embedder as embedder_mod
+
+    monkeypatch.setattr(embedder_mod, "get_embedding", lambda q, base_url=None: _query_emb())
+
+
+class TestBoostMemoriesByContext:
+    def test_workspace_match_boosted(self):
+        rows = [{"workspace": "home/projects/strake", "tags": "[]", "score": 0.5}]
+        _boost_memories_by_context(rows, "strake")
+        assert rows[0]["score"] == 0.7
+
+    def test_tag_match_boosted(self):
+        rows = [{"workspace": None, "tags": json.dumps(["strake", "adr"]), "score": 0.5}]
+        _boost_memories_by_context(rows, "strake")
+        assert rows[0]["score"] == 0.7
+
+    def test_no_match_untouched(self):
+        rows = [{"workspace": "work/nyk", "tags": "[]", "score": 0.5}]
+        _boost_memories_by_context(rows, "strake")
+        assert rows[0]["score"] == 0.5
+
+    def test_no_context_noop(self):
+        rows = [{"workspace": "home/projects/strake", "tags": "[]", "score": 0.5}]
+        _boost_memories_by_context(rows, None)
+        assert rows[0]["score"] == 0.5
+
+    def test_malformed_tags_tolerated(self):
+        rows = [{"workspace": "strake", "tags": "not json", "score": 0.5}]
+        _boost_memories_by_context(rows, "strake")
+        assert rows[0]["score"] == 0.7
+
+
+class TestTripleContextBoost:
+    """Acceptance: in-context triples outrank equal-scored out-of-context ones;
+    out-of-context triples still surface (re-ranking, not filtering)."""
+
+    def _setup(self, conn):
+        _add_note(conn, "other/note-b.md", title="B")
+        _add_note(conn, "strake/note-a.md", title="A")
+        # out-of-context triple inserted FIRST so, on a tie, it wins without boost
+        _add_triple(conn, "other/note-b.md", "beta")
+        _add_triple(conn, "strake/note-a.md", "alpha")
+        conn.commit()
+
+    def test_in_context_ranks_first(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_search(monkeypatch, conn)
+
+        results = search_triples(
+            "tripletoken", top_k=5, embed_url="http://fake", context="strake",
+        )
+
+        assert results[0].note_path == "strake/note-a.md"
+        # not filtered: the out-of-context triple still surfaces
+        assert {r.note_path for r in results} == {"strake/note-a.md", "other/note-b.md"}
+
+    def test_without_context_tie_stands(self, in_memory_db, monkeypatch):
+        """Guard: the ordering above comes from the boost, not from luck."""
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_search(monkeypatch, conn)
+
+        results = search_triples("tripletoken", top_k=5, embed_url="http://fake")
+
+        assert results[0].note_path == "other/note-b.md"
+
+
+class TestMemoryContextBoost:
+    def _setup(self, conn):
+        # out-of-context memory inserted FIRST so, on a tie, it wins without boost
+        _add_memory(conn, "memtoken beta", workspace="work/nyk")
+        _add_memory(conn, "memtoken alpha", workspace="home/projects/strake")
+        conn.commit()
+
+    def test_in_context_ranks_first(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_memories(monkeypatch)
+
+        results = search_memories(
+            conn, query="memtoken", embed_url="http://fake", context="strake",
+        )
+
+        assert results[0].workspace == "home/projects/strake"
+        assert {m.workspace for m in results} == {"home/projects/strake", "work/nyk"}
+
+    def test_without_context_tie_stands(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_memories(monkeypatch)
+
+        results = search_memories(conn, query="memtoken", embed_url="http://fake")
+
+        assert results[0].workspace == "work/nyk"
+
+    def test_workspace_filter_unchanged(self, in_memory_db, monkeypatch):
+        """workspace stays a hard filter; context does not resurrect filtered rows."""
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_memories(monkeypatch)
+
+        results = search_memories(
+            conn, query="memtoken", embed_url="http://fake",
+            workspace="work/nyk", context="strake",
+        )
+
+        assert {m.workspace for m in results} == {"work/nyk"}
+
+
+class TestBuildVaultContextPassthrough:
+    def test_context_reaches_all_three_subretrievals(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        seen: dict[str, str | None] = {}
+
+        import neurostack.memories as memories_mod
+        import neurostack.search as search_mod
+
+        def fake_search_memories(conn, query=None, workspace=None, limit=10,
+                                 embed_url=None, context=None, **kw):
+            seen["memories"] = context
+            return []
+
+        def fake_search_triples(task, top_k=15, mode="hybrid", embed_url=None,
+                                workspace=None, context=None, **kw):
+            seen["triples"] = context
+            return []
+
+        def fake_hybrid_search(task, top_k=5, mode="hybrid", embed_url=None,
+                               workspace=None, context=None, **kw):
+            seen["summaries"] = context
+            return []
+
+        monkeypatch.setattr(memories_mod, "search_memories", fake_search_memories)
+        monkeypatch.setattr(search_mod, "search_triples", fake_search_triples)
+        monkeypatch.setattr(search_mod, "hybrid_search", fake_hybrid_search)
+
+        result = build_vault_context(conn, task="t", context="strake")
+
+        assert seen == {"memories": "strake", "triples": "strake", "summaries": "strake"}
+        # return shape unchanged: no new top-level keys
+        assert set(result) == {"task", "tokens_used", "workspace", "context"}


### PR DESCRIPTION
Part of #94

## What
Adds `context: str | None` to `vault_context` — the same acetylcholine-style attention gating `vault_search` already has (1.4x direct / 1.2x 1-hop convergence boost). Re-ranking, not filtering.

## How
- `search_triples` gains `context=`; boost applied on scored semantic/hybrid paths via `_get_context_notes`; `tiered_search` threads it to its triple calls (closes the gap where `vault_search context=` boosted chunks/summaries but not triples)
- `search_memories` gains `context=`; 1.4x when workspace or tags match the context (memories have no note path, so no 1-hop tier)
- `build_vault_context` passes `context` to all three sub-retrievals; MCP tool + CLI (`neurostack context --context/-c`) expose it

## Gate
- ruff clean; full suite 709 passed (11 new in `tests/test_context_boost.py`)
- Acceptance: in-context outranks equal-scored out-of-context, out-of-context still surfaces, workspace hard filter unchanged, 40/20/30 budget split unchanged (return shape locked in test)