### PR TITLE
feat(usage): primed vs used two-tier activation signal

### DIFF
--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -243,10 +243,11 @@ def _run_tune(args, queries, db_path, cache):
     freeze_hotness = getattr(args, "autolabel", False) and not getattr(
         args, "tune_usage_signals", False)
     if freeze_hotness:
-        grids = {k: v for k, v in tn.DEFAULT_GRIDS.items() if k != "hotness_weight"}
-        order = tuple(p for p in tn.DEFAULT_ORDER if p != "hotness_weight")
-        print("  (hotness frozen — synthetic labels can't judge usage; "
-              "pass --tune-usage-signals to include it)")
+        usage_params = ("hotness_weight", "primed_weight")
+        grids = {k: v for k, v in tn.DEFAULT_GRIDS.items() if k not in usage_params}
+        order = tuple(p for p in tn.DEFAULT_ORDER if p not in usage_params)
+        print("  (hotness + primed frozen — synthetic labels can't judge usage; "
+              "pass --tune-usage-signals to include them)")
 
     result = tn.coordinate_ascent(
         train,

--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -87,6 +87,14 @@ class Config:
     feedback_enabled: bool = False
     feedback_window_seconds: float = 1800.0  # a use counts as feedback if within this of the search
     feedback_log_retention: int = 5000       # cap on retained search_log rows
+    # Two-tier activation signal (issue #95): vault_context injections are logged
+    # as 'primed' (synaptic tag — sub-threshold), deliberate record_usage / reads
+    # stay 'used' (capture — consolidating). Primed events carry a small hotness
+    # weight, their total contribution is capped BELOW one real use, and they only
+    # count within a decay window — priming alone must never promote a note.
+    primed_weight: float = 0.1        # hotness weight of one primed event vs one use
+    primed_cap: float = 0.5           # ceiling on total primed contribution (< 1.0 use)
+    primed_decay_days: float = 14.0   # primed events older than this contribute nothing
     # Vault write-back (issue #20): opt-in persistence of qualifying memories as
     # markdown files under a quarantined directory (default ``.neurostack/``).
     # Off by default — the DB stays the source of truth; files are exports. Only
@@ -123,6 +131,7 @@ class RankingWeights:
     inhibition_threshold: float = 0.65
     inhibition_strength: float = 0.30
     cooccurrence_boost_weight: float = 0.1
+    primed_weight: float = 0.1
     link_section_penalty: float = 0.5
     link_density_threshold: float = 0.5
 
@@ -135,6 +144,7 @@ class RankingWeights:
             inhibition_threshold=cfg.inhibition_threshold,
             inhibition_strength=cfg.inhibition_strength,
             cooccurrence_boost_weight=cfg.cooccurrence_boost_weight,
+            primed_weight=cfg.primed_weight,
             link_section_penalty=cfg.link_section_penalty,
             link_density_threshold=cfg.link_density_threshold,
         )
@@ -169,7 +179,8 @@ def load_config() -> Config:
         if "link_density_threshold" in data:
             cfg.link_density_threshold = float(data["link_density_threshold"])
         for key in ("convergence_weight", "hotness_weight",
-                    "inhibition_threshold", "inhibition_strength"):
+                    "inhibition_threshold", "inhibition_strength",
+                    "primed_weight", "primed_cap", "primed_decay_days"):
             if key in data:
                 setattr(cfg, key, float(data[key]))
         if "feedback_enabled" in data:
@@ -218,6 +229,9 @@ def load_config() -> Config:
         "NEUROSTACK_HOTNESS_WEIGHT": ("hotness_weight", float),
         "NEUROSTACK_INHIBITION_THRESHOLD": ("inhibition_threshold", float),
         "NEUROSTACK_INHIBITION_STRENGTH": ("inhibition_strength", float),
+        "NEUROSTACK_PRIMED_WEIGHT": ("primed_weight", float),
+        "NEUROSTACK_PRIMED_CAP": ("primed_cap", float),
+        "NEUROSTACK_PRIMED_DECAY_DAYS": ("primed_decay_days", float),
         "NEUROSTACK_FEEDBACK_ENABLED": ("feedback_enabled", bool),
         "NEUROSTACK_FEEDBACK_WINDOW_SECONDS": ("feedback_window_seconds", float),
         "NEUROSTACK_FEEDBACK_LOG_RETENTION": ("feedback_log_retention", int),

--- a/src/neurostack/context.py
+++ b/src/neurostack/context.py
@@ -88,6 +88,7 @@ def build_vault_context(
             triples = search_triples(
                 task, top_k=15, mode="hybrid",
                 embed_url=url, workspace=workspace, context=context,
+                record=False,
             )
             triple_entries = []
             for t in triples:
@@ -117,6 +118,7 @@ def build_vault_context(
         results = hybrid_search(
             task, top_k=5, mode="hybrid",
             embed_url=url, workspace=workspace, context=context,
+            record=False,
         )
         summary_entries = []
         for r in results:
@@ -159,6 +161,25 @@ def build_vault_context(
                 tokens_used += entry_tokens
     except Exception as exc:
         log.debug("Could not fetch session history: %s", exc)
+
+    # Two-tier activation signal (issue #95): every note path this call RETURNS
+    # is a 'primed' event — the auto-RAG hooks inject it, the model may never
+    # act on it. Sub-retrievals above ran with record=False so nothing here was
+    # double-logged as a strong 'used' event; the deliberate tier stays
+    # vault_record_usage / reads. With feedback enabled, the surfacing is also
+    # search-logged so a later deliberate use attributes back to this task
+    # (tag-and-capture through the #66 loop).
+    primed_paths = [t["note"] for t in sections.get("triples", [])]
+    primed_paths += [s["path"] for s in sections.get("summaries", [])]
+    if primed_paths:
+        from .search import _record_note_usage
+
+        _record_note_usage(conn, primed_paths, tier="primed")
+        if cfg.feedback_enabled:
+            from .feedback import log_search
+
+            log_search(conn, task, list(dict.fromkeys(primed_paths)),
+                       cfg.feedback_log_retention)
 
     return {
         "task": task,

--- a/src/neurostack/feedback.py
+++ b/src/neurostack/feedback.py
@@ -173,7 +173,12 @@ def feedback_labels(conn, *, min_count: int = 1, max_age_days: float | None = No
 
 
 def feedback_stats(conn) -> dict:
-    """Summary of accumulated feedback — volume and rank distribution."""
+    """Summary of accumulated feedback — volume, rank distribution, and the
+    two activation tiers (issue #95): deliberate 'used' events vs auto-RAG
+    'primed' injections, with the in-window primed count that actually feeds
+    hotness."""
+    from .config import get_config
+
     searches = conn.execute("SELECT COUNT(*) FROM search_log").fetchone()[0]
     events = conn.execute("SELECT COUNT(*) FROM search_feedback").fetchone()[0]
     distinct_q = conn.execute(
@@ -189,6 +194,17 @@ def feedback_stats(conn) -> dict:
     below_top = conn.execute(
         "SELECT COUNT(*) FROM search_feedback WHERE rank IS NOT NULL AND rank > 1"
     ).fetchone()[0]
+    used_events = conn.execute(
+        "SELECT COUNT(*) FROM note_usage WHERE tier = 'used'"
+    ).fetchone()[0]
+    primed_events = conn.execute(
+        "SELECT COUNT(*) FROM note_usage WHERE tier = 'primed'"
+    ).fetchone()[0]
+    primed_in_window = conn.execute(
+        "SELECT COUNT(*) FROM note_usage WHERE tier = 'primed' "
+        "AND used_at >= datetime('now', ?)",
+        (f"-{float(get_config().primed_decay_days)} days",),
+    ).fetchone()[0]
     return {
         "searches_logged": searches,
         "feedback_events": events,
@@ -196,4 +212,7 @@ def feedback_stats(conn) -> dict:
         "distinct_chosen_notes": distinct_notes,
         "avg_chosen_rank": round(avg_rank, 2) if avg_rank is not None else None,
         "informative_events": below_top,  # chosen note was not already top-ranked
+        "used_events": used_events,
+        "primed_events": primed_events,
+        "primed_in_window": primed_in_window,  # primes still contributing to hotness
     }

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -195,11 +195,14 @@ CREATE TABLE IF NOT EXISTS folder_summaries (
     generated_at TEXT
 );
 
--- Usage tracking for hotness scoring
+-- Usage tracking for hotness scoring. tier distinguishes deliberate use
+-- ('used' — vault_record_usage, reads) from auto-RAG injection ('primed' —
+-- vault_context returns; issue #95): synaptic tag vs capture.
 CREATE TABLE IF NOT EXISTS note_usage (
     usage_id INTEGER PRIMARY KEY AUTOINCREMENT,
     note_path TEXT NOT NULL,
-    used_at TEXT NOT NULL DEFAULT (datetime('now'))
+    used_at TEXT NOT NULL DEFAULT (datetime('now')),
+    tier TEXT NOT NULL DEFAULT 'used'
 );
 
 CREATE INDEX IF NOT EXISTS idx_note_usage_path ON note_usage(note_path);
@@ -1092,6 +1095,33 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (22)")
         conn.commit()
         log.info("Migration to v22 complete.")
+
+    if current < 23:
+        log.info(
+            "Migrating schema v22 -> v23: note_usage.tier — "
+            "primed vs used two-tier activation signal (issue #95)..."
+        )
+        cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(note_usage)").fetchall()
+        }
+        if not cols:
+            # Partial DBs (older fixtures/tests) may lack the table entirely.
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS note_usage ("
+                " usage_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " note_path TEXT NOT NULL,"
+                " used_at TEXT NOT NULL DEFAULT (datetime('now')),"
+                " tier TEXT NOT NULL DEFAULT 'used')"
+            )
+        elif "tier" not in cols:
+            # Existing rows predate priming, so the 'used' default is correct.
+            conn.execute(
+                "ALTER TABLE note_usage ADD COLUMN"
+                " tier TEXT NOT NULL DEFAULT 'used'"
+            )
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (23)")
+        conn.commit()
+        log.info("Migration to v23 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -84,19 +84,28 @@ def log_prediction_error(
         pass  # Never let error logging disrupt search
 
 
-def _record_note_usage(conn: sqlite3.Connection, note_paths: list[str]) -> None:
+def _record_note_usage(
+    conn: sqlite3.Connection,
+    note_paths: list[str],
+    tier: str = "used",
+) -> None:
     """Record note access for hotness scoring. Non-blocking.
 
     Deduplicates paths so a single retrieval counts as one usage event per note,
     regardless of how many chunks/triples/edges from that note were returned.
+
+    ``tier`` is ``'used'`` (deliberate — record_usage, reads, search returns) or
+    ``'primed'`` (auto-RAG injection via vault_context; issue #95). Primed events
+    carry a small, capped, decaying weight in hotness — a synaptic tag, not a
+    consolidation.
     """
     if not note_paths:
         return
     unique_paths = list(dict.fromkeys(note_paths))
     try:
         conn.executemany(
-            "INSERT INTO note_usage (note_path) VALUES (?)",
-            [(p,) for p in unique_paths],
+            "INSERT INTO note_usage (note_path, tier) VALUES (?, ?)",
+            [(p, tier) for p in unique_paths],
         )
         conn.commit()
     except Exception:
@@ -385,72 +394,88 @@ def _get_context_notes(
     return direct, neighbors
 
 
-def hotness_score(conn: sqlite3.Connection, note_path: str, half_life_days: float = 30.0) -> float:
+def hotness_score(
+    conn: sqlite3.Connection,
+    note_path: str,
+    half_life_days: float = 30.0,
+    primed_weight: float = 0.1,
+    primed_cap: float = 0.5,
+    primed_decay_days: float = 14.0,
+) -> float:
     """Compute hotness score blending usage frequency and recency.
 
     Blends frequency and recency using sigmoid-compressed usage count
     with exponential half-life decay:
-        hotness = sigmoid(log1p(active_count)) * exp(-ln2/half_life * age_days)
+        hotness = sigmoid(log1p(weighted_count)) * exp(-ln2/half_life * age_days)
 
-    Returns a value in [0, 1]. Returns 0.0 if never used.
+    Returns a value in [0, 1]. Returns 0.0 if never used or primed.
     """
-    import math
-
-    rows = conn.execute(
-        "SELECT used_at FROM note_usage WHERE note_path = ? ORDER BY used_at DESC",
-        (note_path,),
-    ).fetchall()
-
-    if not rows:
-        return 0.0
-
-    active_count = len(rows)
-
-    # Age in days since most recent usage
-    most_recent = rows[0]["used_at"]
-    age_row = conn.execute(
-        "SELECT (julianday('now') - julianday(?)) as age_days", (most_recent,)
-    ).fetchone()
-    age_days = max(0.0, float(age_row["age_days"]))
-
-    decay = math.exp(-math.log(2) / half_life_days * age_days)
-    freq = 1.0 / (1.0 + math.exp(-math.log1p(active_count)))  # sigmoid(log1p(count))
-
-    return freq * decay
+    return batch_hotness_scores(
+        conn, [note_path], half_life_days=half_life_days,
+        primed_weight=primed_weight, primed_cap=primed_cap,
+        primed_decay_days=primed_decay_days,
+    ).get(note_path, 0.0)
 
 
 def batch_hotness_scores(
     conn: sqlite3.Connection,
     note_paths: list[str],
     half_life_days: float = 30.0,
+    primed_weight: float = 0.1,
+    primed_cap: float = 0.5,
+    primed_decay_days: float = 14.0,
 ) -> dict[str, float]:
     """Compute hotness scores for multiple notes in a single batch query.
 
+    Two-tier activation (issue #95, synaptic tagging-and-capture):
+
+    - ``'used'`` rows (deliberate record_usage / reads / search returns) each
+      count 1.0 toward the frequency term, as before.
+    - ``'primed'`` rows (auto-RAG vault_context injections) count
+      ``primed_weight`` each, the total capped at ``primed_cap`` — deliberately
+      BELOW one real use, so priming alone can never outrank a genuinely used
+      note — and only within ``primed_decay_days``; older primes contribute
+      nothing. Recency comes from the latest 'used' event, falling back to the
+      latest in-window prime for primed-only notes.
+
     Returns a dict mapping note_path -> hotness score (0-1).
-    Notes with no usage history are omitted from the result.
+    Notes with no live usage signal are omitted from the result.
     """
     import math
 
     if not note_paths:
         return {}
 
+    window = f"-{float(primed_decay_days)} days"
     placeholders = ",".join("?" for _ in note_paths)
     rows = conn.execute(
-        f"SELECT note_path, COUNT(*) as usage_count, "
-        f"julianday('now') - julianday(MAX(used_at)) as age_days "
+        f"SELECT note_path, "
+        f"SUM(CASE WHEN tier = 'primed' THEN 0 ELSE 1 END) as used_count, "
+        f"SUM(CASE WHEN tier = 'primed' AND used_at >= datetime('now', ?)"
+        f"    THEN 1 ELSE 0 END) as primed_count, "
+        f"julianday('now') - julianday("
+        f"    MAX(CASE WHEN tier != 'primed' THEN used_at END)) as used_age, "
+        f"julianday('now') - julianday("
+        f"    MAX(CASE WHEN tier = 'primed' AND used_at >= datetime('now', ?)"
+        f"        THEN used_at END)) as primed_age "
         f"FROM note_usage "
         f"WHERE note_path IN ({placeholders}) "
         f"GROUP BY note_path",
-        list(note_paths),
+        [window, window, *note_paths],
     ).fetchall()
 
     scores: dict[str, float] = {}
     ln2 = math.log(2)
     for row in rows:
-        age_days = max(0.0, float(row["age_days"]))
-        usage_count = int(row["usage_count"])
+        used_count = int(row["used_count"] or 0)
+        primed_count = int(row["primed_count"] or 0)
+        weighted = used_count + min(primed_weight * primed_count, primed_cap)
+        if weighted <= 0.0:
+            continue  # only stale primes — decayed to nothing
+        age_raw = row["used_age"] if used_count else row["primed_age"]
+        age_days = max(0.0, float(age_raw)) if age_raw is not None else 0.0
         decay = math.exp(-ln2 / half_life_days * age_days)
-        freq = 1.0 / (1.0 + math.exp(-math.log1p(usage_count)))
+        freq = 1.0 / (1.0 + math.exp(-math.log1p(weighted)))
         scores[row["note_path"]] = freq * decay
 
     return scores
@@ -878,7 +903,12 @@ def hybrid_search(
     # (default w=0.2 → 0.8 score + 0.2 hotness).
     if "hotness" not in ablate:
         hw = weights.hotness_weight
-        hotness_map = batch_hotness_scores(conn, [r["note_path"] for r in valid_results])
+        hotness_map = batch_hotness_scores(
+            conn, [r["note_path"] for r in valid_results],
+            primed_weight=weights.primed_weight,
+            primed_cap=cfg.primed_cap,
+            primed_decay_days=cfg.primed_decay_days,
+        )
         for r in valid_results:
             h = hotness_map.get(r["note_path"], 0.0)
             if h > 0.0:
@@ -1312,11 +1342,16 @@ def search_triples(
     db_path=None,
     workspace: str | None = None,
     context: str | None = None,
+    record: bool = True,
 ) -> list[TripleResult]:
     """Search triples using hybrid FTS5 + semantic similarity.
 
     ``context`` applies the same soft attention boost as hybrid_search on the
     scored (semantic/hybrid) paths; keyword-only paths have no score to boost.
+
+    ``record=False`` suppresses usage recording — vault_context retrieves
+    through here and logs its returns as 'primed' itself (issue #95), so its
+    sub-retrievals must not double-log strong 'used' events.
 
     Returns compact TripleResult objects (~10-20 tokens each).
     """
@@ -1329,7 +1364,8 @@ def search_triples(
     if mode == "keyword":
         fts_results = triple_fts_search(conn, query, limit=top_k, workspace=workspace)
         results = _to_triple_results(conn, fts_results[:top_k])
-        _record_note_usage(conn, [r.note_path for r in results])
+        if record:
+            _record_note_usage(conn, [r.note_path for r in results])
         return results
 
     try:
@@ -1342,7 +1378,8 @@ def search_triples(
         )
         fts_results = triple_fts_search(conn, query, limit=top_k, workspace=workspace)
         results = _to_triple_results(conn, fts_results[:top_k])
-        _record_note_usage(conn, [r.note_path for r in results])
+        if record:
+            _record_note_usage(conn, [r.note_path for r in results])
         return results
 
     if mode == "semantic":
@@ -1352,7 +1389,8 @@ def search_triples(
         )
         _boost_triples_by_context(conn, sem_results, context, embed_url=embed_url)
         results = _to_triple_results(conn, sem_results[:top_k])
-        _record_note_usage(conn, [r.note_path for r in results])
+        if record:
+            _record_note_usage(conn, [r.note_path for r in results])
         return results
 
     # Hybrid: FTS5 pre-filter + semantic rerank
@@ -1367,7 +1405,8 @@ def search_triples(
         )
         _boost_triples_by_context(conn, sem_results, context, embed_url=embed_url)
         results = _to_triple_results(conn, sem_results[:top_k])
-        _record_note_usage(conn, [r.note_path for r in results])
+        if record:
+            _record_note_usage(conn, [r.note_path for r in results])
         return results
 
     embeddings = []
@@ -1379,7 +1418,8 @@ def search_triples(
 
     if not valid_results:
         results = _to_triple_results(conn, fts_results[:top_k])
-        _record_note_usage(conn, [r.note_path for r in results])
+        if record:
+            _record_note_usage(conn, [r.note_path for r in results])
         return results
 
     matrix = np.stack(embeddings)
@@ -1394,7 +1434,8 @@ def search_triples(
     valid_results.sort(key=lambda x: x["score"], reverse=True)
 
     results = _to_triple_results(conn, valid_results[:top_k])
-    _record_note_usage(conn, [r.note_path for r in results])
+    if record:
+        _record_note_usage(conn, [r.note_path for r in results])
     return results
 
 

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -587,6 +587,10 @@ def vault_record_usage(note_paths: list[str]) -> dict:
     Call this after vault_search when you actually consumed the returned notes.
     Drives hotness scoring — frequently used notes score higher in future searches.
 
+    This is the strong 'used' tier of the two-tier activation signal (issue #95);
+    auto-RAG vault_context injections are logged server-side as weak 'primed'
+    events and never need this call.
+
     Args:
         note_paths: List of note paths that were used (e.g. ["research/foo.md", "work/bar.md"])
     """
@@ -594,7 +598,7 @@ def vault_record_usage(note_paths: list[str]) -> dict:
 
     conn = get_db(DB_PATH)
     conn.executemany(
-        "INSERT INTO note_usage (note_path) VALUES (?)",
+        "INSERT INTO note_usage (note_path, tier) VALUES (?, 'used')",
         [(p,) for p in note_paths],
     )
     conn.commit()

--- a/src/neurostack/tune.py
+++ b/src/neurostack/tune.py
@@ -40,6 +40,9 @@ DEFAULT_GRIDS: dict[str, list[float]] = {
     # optimum well past 0.6, so a grid capped there would silently under-move it.
     "convergence_weight": [0.0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9, 1.0],
     "hotness_weight": [0.0, 0.1, 0.2, 0.3, 0.4],
+    # Primed tier (issue #95): weight of one auto-RAG injection vs one real use.
+    # Usage-grounded labels only — frozen alongside hotness on synthetic labels.
+    "primed_weight": [0.0, 0.05, 0.1, 0.2, 0.3],
     "inhibition_threshold": [0.55, 0.65, 0.75, 0.85, 0.95],
     "inhibition_strength": [0.0, 0.15, 0.3, 0.45],
     "cooccurrence_boost_weight": [0.0, 0.05, 0.1, 0.2],
@@ -55,6 +58,7 @@ DEFAULT_ORDER: tuple[str, ...] = (
     "inhibition_strength",
     "inhibition_threshold",
     "hotness_weight",
+    "primed_weight",
     "cooccurrence_boost_weight",
     "link_section_penalty",
 )

--- a/tests/test_two_tier_usage.py
+++ b/tests/test_two_tier_usage.py
@@ -1,0 +1,274 @@
+"""Tests for the primed vs used two-tier activation signal (issue #95).
+
+Synaptic tagging-and-capture: auto-RAG vault_context injections are 'primed'
+(weak, capped below one real use, decaying), deliberate record_usage/reads stay
+'used' (strong). Acceptance: a repeatedly-primed-never-used note must NOT
+outrank a genuinely used one; stats expose both tiers.
+
+Style mirrors test_prediction_errors.py: real in-memory sqlite,
+monkeypatched get_db/get_embedding, never MagicMock.
+"""
+
+import sqlite3
+import struct
+
+import numpy as np
+import pytest
+
+from neurostack.context import build_vault_context
+from neurostack.feedback import feedback_stats
+from neurostack.search import (
+    _record_note_usage,
+    batch_hotness_scores,
+    hotness_score,
+    hybrid_search,
+    search_triples,
+)
+
+DIM = 768
+
+
+def _emb_blob() -> bytes:
+    v = [0.0] * DIM
+    v[0] = 1.0
+    return struct.pack(f"{DIM}f", *v)
+
+
+def _query_emb() -> np.ndarray:
+    q = np.zeros(DIM, dtype=np.float32)
+    q[0] = 1.0
+    return q
+
+
+def _add_note(conn, path, title="N", with_chunk=True):
+    conn.execute(
+        "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?, ?, ?, ?)",
+        (path, title, f"h_{path}", "2026-01-01"),
+    )
+    if with_chunk:
+        conn.execute(
+            "INSERT INTO chunks (note_path, heading_path, content, content_hash, "
+            "position, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            (path, "## H", "usetoken body text", f"hc_{path}", 0, _emb_blob()),
+        )
+    conn.commit()
+
+
+def _add_usage(conn, path, tier, count=1, days_ago=0.0):
+    conn.executemany(
+        "INSERT INTO note_usage (note_path, tier, used_at) "
+        "VALUES (?, ?, datetime('now', ?))",
+        [(path, tier, f"-{days_ago} days")] * count,
+    )
+    conn.commit()
+
+
+def _patch_search(monkeypatch, conn):
+    import neurostack.search as search_mod
+
+    monkeypatch.setattr(search_mod, "get_db", lambda path: conn)
+    monkeypatch.setattr(search_mod, "get_embedding", lambda q, base_url=None: _query_emb())
+
+
+class TestSchemaMigration:
+    def test_v22_gets_tier_column_and_old_rows_become_used(self, tmp_path):
+        from neurostack.schema import _run_migrations
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+            INSERT INTO schema_version VALUES (22);
+            CREATE TABLE note_usage (
+                usage_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                note_path TEXT NOT NULL,
+                used_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO note_usage (note_path) VALUES ('old.md');
+        """)
+        conn.commit()
+
+        _run_migrations(conn)
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(note_usage)").fetchall()}
+        assert "tier" in cols
+        row = conn.execute("SELECT tier FROM note_usage WHERE note_path = 'old.md'").fetchone()
+        assert row["tier"] == "used"
+        version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        assert version >= 23
+
+
+class TestRecordTier:
+    def test_default_tier_is_used(self, in_memory_db):
+        _record_note_usage(in_memory_db, ["a.md"])
+        row = in_memory_db.execute("SELECT tier FROM note_usage").fetchone()
+        assert row["tier"] == "used"
+
+    def test_primed_tier_recorded(self, in_memory_db):
+        _record_note_usage(in_memory_db, ["a.md"], tier="primed")
+        row = in_memory_db.execute("SELECT tier FROM note_usage").fetchone()
+        assert row["tier"] == "primed"
+
+
+class TestTierWeightedHotness:
+    def test_primed_never_outranks_used(self, in_memory_db):
+        """Acceptance: capped primed contribution stays below one real use,
+        regardless of prime volume."""
+        conn = in_memory_db
+        _add_usage(conn, "used-once.md", "used", count=1)
+        _add_usage(conn, "primed-heavy.md", "primed", count=50)
+
+        scores = batch_hotness_scores(conn, ["used-once.md", "primed-heavy.md"])
+
+        assert scores["primed-heavy.md"] > 0.0  # priming is a real, weak signal
+        assert scores["used-once.md"] > scores["primed-heavy.md"]
+
+    def test_primed_contribution_capped(self, in_memory_db):
+        conn = in_memory_db
+        _add_usage(conn, "five.md", "primed", count=5)     # 5 * 0.1 = cap 0.5
+        _add_usage(conn, "fifty.md", "primed", count=50)   # capped at 0.5 too
+
+        scores = batch_hotness_scores(conn, ["five.md", "fifty.md"])
+
+        assert scores["five.md"] == pytest.approx(scores["fifty.md"])
+
+    def test_stale_primes_decay_to_nothing(self, in_memory_db):
+        """Primed events older than the window contribute nothing — the note is
+        omitted entirely (hotness 0.0), while an equally old 'used' event survives."""
+        conn = in_memory_db
+        _add_usage(conn, "stale-primed.md", "primed", count=20, days_ago=30)
+        _add_usage(conn, "old-used.md", "used", count=1, days_ago=30)
+
+        scores = batch_hotness_scores(conn, ["stale-primed.md", "old-used.md"])
+
+        assert "stale-primed.md" not in scores
+        assert hotness_score(conn, "stale-primed.md") == 0.0
+        assert scores["old-used.md"] > 0.0
+
+    def test_primed_adds_on_top_of_used(self, in_memory_db):
+        conn = in_memory_db
+        _add_usage(conn, "plain.md", "used", count=2)
+        _add_usage(conn, "boosted.md", "used", count=2)
+        _add_usage(conn, "boosted.md", "primed", count=3)
+
+        scores = batch_hotness_scores(conn, ["plain.md", "boosted.md"])
+
+        assert scores["boosted.md"] > scores["plain.md"]
+
+    def test_ranking_through_hybrid_search(self, in_memory_db, monkeypatch):
+        """End-to-end acceptance: equal-content notes, one primed 50x, one used
+        once — the used note ranks first via the hotness blend."""
+        conn = in_memory_db
+        _add_note(conn, "primed-heavy.md")   # inserted first: wins ties without hotness
+        _add_note(conn, "used-once.md")
+        _add_usage(conn, "primed-heavy.md", "primed", count=50)
+        _add_usage(conn, "used-once.md", "used", count=1)
+        _patch_search(monkeypatch, conn)
+
+        results = hybrid_search("usetoken", top_k=5, embed_url="http://fake", record=False)
+
+        assert results[0].note_path == "used-once.md"
+        assert {r.note_path for r in results} == {"used-once.md", "primed-heavy.md"}
+
+
+class TestContextPrimes:
+    def _setup(self, conn):
+        _add_note(conn, "research/alpha.md", title="Alpha")
+        conn.execute(
+            "INSERT INTO triples (note_path, subject, predicate, object, "
+            "triple_text, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            ("research/alpha.md", "usetoken", "relates to", "thing",
+             "usetoken thing", _emb_blob()),
+        )
+        conn.commit()
+
+    def test_returned_paths_logged_primed_only(self, in_memory_db, monkeypatch):
+        """vault_context logs every returned note path as 'primed'; its
+        sub-retrievals must not write strong 'used' events."""
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_search(monkeypatch, conn)
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(
+            embedder_mod, "get_embedding", lambda q, base_url=None: _query_emb()
+        )
+
+        result = build_vault_context(conn, task="usetoken thing")
+
+        assert result["context"].get("summaries") or result["context"].get("triples")
+        rows = conn.execute("SELECT note_path, tier FROM note_usage").fetchall()
+        assert rows, "returned paths must be logged as primed events"
+        assert {r["tier"] for r in rows} == {"primed"}
+        assert "research/alpha.md" in {r["note_path"] for r in rows}
+
+    def test_feedback_enabled_logs_search(self, in_memory_db, monkeypatch):
+        """Tag-and-capture: with feedback on, the surfacing is search-logged so a
+        later deliberate use attributes back to the task."""
+        import dataclasses
+
+        import neurostack.config as config_mod
+        import neurostack.search as search_mod
+
+        conn = in_memory_db
+        self._setup(conn)
+        _patch_search(monkeypatch, conn)
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(
+            embedder_mod, "get_embedding", lambda q, base_url=None: _query_emb()
+        )
+        cfg = dataclasses.replace(config_mod.get_config(), feedback_enabled=True)
+        monkeypatch.setattr(config_mod, "get_config", lambda: cfg)
+        monkeypatch.setattr(search_mod, "get_config", lambda: cfg)
+
+        build_vault_context(conn, task="usetoken thing")
+
+        logged = conn.execute("SELECT query FROM search_log").fetchall()
+        assert any(r["query"] == "usetoken thing" for r in logged)
+
+
+class TestSearchTriplesRecordGate:
+    def test_record_false_writes_nothing(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        _add_note(conn, "a.md", with_chunk=False)
+        conn.execute(
+            "INSERT INTO triples (note_path, subject, predicate, object, "
+            "triple_text, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            ("a.md", "usetoken", "p", "o", "usetoken o", _emb_blob()),
+        )
+        conn.commit()
+        _patch_search(monkeypatch, conn)
+
+        results = search_triples("usetoken", top_k=5, embed_url="http://fake", record=False)
+
+        assert results
+        assert conn.execute("SELECT COUNT(*) FROM note_usage").fetchone()[0] == 0
+
+    def test_record_true_writes_used(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        _add_note(conn, "a.md", with_chunk=False)
+        conn.execute(
+            "INSERT INTO triples (note_path, subject, predicate, object, "
+            "triple_text, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            ("a.md", "usetoken", "p", "o", "usetoken o", _emb_blob()),
+        )
+        conn.commit()
+        _patch_search(monkeypatch, conn)
+
+        search_triples("usetoken", top_k=5, embed_url="http://fake")
+
+        rows = conn.execute("SELECT tier FROM note_usage").fetchall()
+        assert rows and all(r["tier"] == "used" for r in rows)
+
+
+class TestFeedbackStatsTiers:
+    def test_stats_expose_both_tiers(self, in_memory_db):
+        conn = in_memory_db
+        _add_usage(conn, "a.md", "used", count=2)
+        _add_usage(conn, "b.md", "primed", count=3)
+        _add_usage(conn, "c.md", "primed", count=4, days_ago=400)  # out of window
+
+        stats = feedback_stats(conn)
+
+        assert stats["used_events"] == 2
+        assert stats["primed_events"] == 7
+        assert stats["primed_in_window"] == 3


### PR DESCRIPTION
Part of #95

## What
Two-tier activation signal mirroring synaptic tagging-and-capture: auto-RAG `vault_context` injections become weak **primed** events; deliberate `vault_record_usage`/reads stay strong **used** events. Auto-RAG fires on every prompt, so logging injections as usage was poisoning hotness; discarding them wasted a real, weaker signal.

## How
- Schema v23: `note_usage.tier` (`'used'` default — existing rows predate priming, so the default is correct). Migration tolerates partial fixture DBs.
- Hotness (`batch_hotness_scores`/`hotness_score`): `weighted = used + min(primed_weight × primed_in_window, primed_cap)`. **Invariant: cap 0.5 < one use ⇒ primed-only can never outrank used-once** (sigmoid is monotone). Primes older than `primed_decay_days` (14d) contribute nothing — the decay the issue requires. Recency from last use, falling back to last in-window prime.
- `build_vault_context`: sub-retrievals run `record=False` (`search_triples` gains the gate `hybrid_search` already had — they were double-logging strong events on every prompt), then returned paths are logged `'primed'` once. With `feedback_enabled`, the surfacing is search-logged so a later deliberate use attributes back through the #66 loop.
- Config knobs `primed_weight`/`primed_cap`/`primed_decay_days` (toml + env); `primed_weight` joins `RankingWeights` + tuner grids, frozen alongside hotness on synthetic labels.
- `feedback_stats` exposes `used_events`/`primed_events`/`primed_in_window`.

## Gate
- ruff clean; full suite 722 passed (13 new in `tests/test_two_tier_usage.py`)
- Acceptance test: note primed 50× never used does NOT outrank note used once — unit (`batch_hotness_scores`) and end-to-end through `hybrid_search`'s hotness blend
- Stale-prime decay, cap saturation, migration (v22→v23 + old rows 'used'), record-gate, and tier stats all locked