### PR TITLE
feat(consolidate): consolidation replay — promote queued memories into notes

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -10,7 +10,7 @@ from .. import __version__
 from ..config import get_config
 from .api import cmd_api, cmd_bundle, cmd_serve
 from .index import cmd_backfill, cmd_export, cmd_index, cmd_reembed_chunks, cmd_watch
-from .memories import cmd_memories, cmd_promote
+from .memories import cmd_consolidate, cmd_memories, cmd_promote
 from .search import (
     cmd_ask,
     cmd_brief,
@@ -757,6 +757,25 @@ def main():
         help="Restrict to vault subdirectory. Also reads NEUROSTACK_WORKSPACE",
     )
     p.set_defaults(func=cmd_promote)
+
+    # consolidate
+    p = sub.add_parser(
+        "consolidate",
+        help="Consolidation replay: promote queued memories into notes"
+        " via basin-clustered LLM synthesis (issue #96)",
+    )
+    p.add_argument("--run", action="store_true",
+                   help="Actually synthesize, write notes, and archive"
+                   " (default: dry run)")
+    p.add_argument("--cap", type=int, default=5,
+                   help="Max clusters consolidated per run (default: 5)")
+    p.add_argument("--llm-model", default=None,
+                   help="Override the synthesis model")
+    p.add_argument(
+        "--workspace", "-w", default=None,
+        help="Restrict to vault subdirectory. Also reads NEUROSTACK_WORKSPACE",
+    )
+    p.set_defaults(func=cmd_consolidate)
 
     # stats
     p = sub.add_parser("stats", help="Show index stats")

--- a/src/neurostack/cli/memories.py
+++ b/src/neurostack/cli/memories.py
@@ -325,3 +325,41 @@ def cmd_promote(args):
             print(f"          {e['preview'][:100]}")
     if total:
         print(f"\n  {queue['hint']}")
+
+
+def cmd_consolidate(args):
+    """Consolidation replay: promote queued memories into notes (issue #96)."""
+    from ..consolidate import consolidate_replay
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    report = consolidate_replay(
+        conn,
+        cap=args.cap,
+        dry_run=not args.run,
+        workspace=_get_workspace(args),
+        llm_url=getattr(args, "summarize_url", None) or None,
+        llm_model=getattr(args, "llm_model", None),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    mode = "DRY RUN" if report["dry_run"] else "RUN"
+    print(f"  Consolidation replay ({mode}): "
+          f"{report['clusters_found']} cluster(s), "
+          f"{report['clusters_planned']} within cap {report['cap']}")
+    for c in report["consolidated"]:
+        ids = ", ".join(str(i) for i in c["memory_ids"])
+        print(f"\n    [{c['action']}] {c['target']}")
+        if c.get("title"):
+            print(f"      title: {c['title']}")
+        print(f"      memories: {ids}")
+        if c.get("commit_sha"):
+            print(f"      commit: {c['commit_sha'][:10]}  archived: {c['archived']}")
+    for c in report.get("skipped", []):
+        print(f"\n    SKIPPED [{c['action']}] {c['target']}: {c['error']}")
+    for c in report.get("deferred", []):
+        print(f"\n    deferred (over cap): {len(c['memory_ids'])} memories -> {c['target']}")
+    if report["dry_run"] and report["clusters_planned"]:
+        print("\n  Dry run — pass --run to synthesize, write notes, and archive.")

--- a/src/neurostack/consolidate.py
+++ b/src/neurostack/consolidate.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Consolidation replay (issue #96): promote episodic memories into semantic notes.
+
+Sleep-phase systems consolidation — hippocampal replay to neocortex. The
+promotion queue (#92) computes WHICH memories should become notes; this module
+is the nightly job that RUNS it:
+
+1. Take the queue's ``debt`` + ``uncovered`` buckets (durable knowledge with no
+   covering note). ``drift`` needs conflict judgment and ``dead_handoffs`` want
+   forgetting, not promotion — both stay interactive work.
+2. Cluster candidates by attractor basin: each memory maps to its nearest note
+   (embedding argmax over chunks), the note to its coarse (level 0) Hopfield
+   community. Memories with no resolvable basin group by workspace.
+3. One LLM synthesis per cluster (existing ``llm_url`` failover path) — a
+   consolidated section, not a raw dump.
+4. Write/extend the target vault note through the existing write path
+   (``vault_write_file``: validation, flock, commit + push with
+   rebase-on-conflict), then archive the promoted memories with a
+   ``promoted:<note_path>`` pointer (#90 archive, restorable).
+
+``dry_run=True`` (the default everywhere) stops after step 2 and reports the
+plan — no LLM calls, no writes, no archiving. A per-run ``cap`` bounds how many
+clusters one night may consolidate so a backlog cannot flood the vault.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import re
+import sqlite3
+
+log = logging.getLogger("neurostack")
+
+DEFAULT_CAP = 5
+# At or above this similarity the cluster extends its nearest note; below it
+# the knowledge has no home and a new note is created. Matches the promotion
+# queue's uncovered floor so the two mechanisms agree on what "covered" means.
+EXTEND_SIM_FLOOR = 0.55
+_MEMORY_CHARS = 1500          # per-memory content budget in the synthesis prompt
+_COARSE_LEVEL = 0             # attractor level 0 = broad basins
+
+_SYNTH_PROMPT = """You are consolidating an engineer's session memories into their permanent \
+notes vault. Below are {n} related memories from the same knowledge area.
+
+Write ONE consolidated markdown section that preserves every concrete fact — \
+identifiers, versions, hosts, paths, commands, numbers, decisions and their \
+reasons. Merge overlap, keep disagreements visible, and do not invent or embellish \
+anything. No preamble, no headings above ###.
+
+Also give the section a short specific title (3-8 words).
+
+Respond with JSON only: {{"title": "...", "synthesis": "markdown body"}}
+
+Memories:
+{memories}
+"""
+
+
+def _strip_fences(raw: str) -> str:
+    raw = re.sub(r"<think>.*?(</think>|$)", "", raw, flags=re.DOTALL).strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```\w*\n?", "", raw)
+        raw = re.sub(r"\n?```$", "", raw).strip()
+    return raw
+
+
+def _slugify(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:60] or "consolidated"
+
+
+def _memory_rows(conn: sqlite3.Connection, memory_ids: list[int]) -> list[dict]:
+    if not memory_ids:
+        return []
+    placeholders = ",".join("?" * len(memory_ids))
+    rows = conn.execute(
+        f"SELECT memory_id, content, entity_type, workspace, tags, created_at,"
+        f" uuid, embedding FROM memories WHERE memory_id IN ({placeholders})",
+        memory_ids,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _chunk_matrix(conn: sqlite3.Connection):
+    """All chunk embeddings + their note paths, or (None, []) without any."""
+    import numpy as np
+
+    from .embedder import blob_to_embedding
+
+    rows = conn.execute(
+        "SELECT note_path, embedding FROM chunks WHERE embedding IS NOT NULL"
+    ).fetchall()
+    if not rows:
+        return None, []
+    matrix = np.vstack([blob_to_embedding(r["embedding"]) for r in rows])
+    return matrix, [r["note_path"] for r in rows]
+
+
+def _nearest_note(row: dict, chunk_matrix, chunk_paths) -> tuple[str | None, float]:
+    from .embedder import blob_to_embedding, cosine_similarity_batch
+
+    if chunk_matrix is None or not row.get("embedding"):
+        return None, 0.0
+    emb = blob_to_embedding(row["embedding"])
+    if emb is None:
+        return None, 0.0
+    sims = cosine_similarity_batch(emb, chunk_matrix)
+    best = int(sims.argmax())
+    return chunk_paths[best], float(sims[best])
+
+
+def _note_community(conn: sqlite3.Connection, note_path: str) -> int | None:
+    row = conn.execute(
+        "SELECT cm.community_id FROM community_members cm"
+        " JOIN communities c ON c.community_id = cm.community_id"
+        " WHERE cm.entity = ? AND c.level = ?",
+        (note_path, _COARSE_LEVEL),
+    ).fetchone()
+    return row["community_id"] if row else None
+
+
+def cluster_candidates(
+    conn: sqlite3.Connection,
+    workspace: str | None = None,
+) -> list[dict]:
+    """Compute the night's clusters from the promotion queue. Pure read.
+
+    Returns a list of cluster dicts sorted largest-first (biggest debt relief),
+    each carrying its members (full memory rows + nearest-note info), the
+    planned action ('extend' or 'create'), and the planned target path.
+    """
+    from .promotion import compute_promotion_queue
+
+    queue = compute_promotion_queue(conn, workspace=workspace)
+    seen: set[int] = set()
+    candidate_ids: list[int] = []
+    for bucket in ("debt", "uncovered"):
+        for entry in queue[bucket]:
+            if entry["memory_id"] not in seen:
+                seen.add(entry["memory_id"])
+                candidate_ids.append(entry["memory_id"])
+    if not candidate_ids:
+        return []
+
+    chunk_matrix, chunk_paths = _chunk_matrix(conn)
+    clusters: dict[object, dict] = {}
+    for row in _memory_rows(conn, candidate_ids):
+        note, sim = _nearest_note(row, chunk_matrix, chunk_paths)
+        community = _note_community(conn, note) if note else None
+        key = community if community is not None else f"ws:{row.get('workspace') or ''}"
+        cluster = clusters.setdefault(key, {
+            "basin": key, "members": [],
+        })
+        row["nearest_note"] = note
+        row["nearest_similarity"] = round(sim, 4)
+        cluster["members"].append(row)
+
+    out = []
+    for cluster in clusters.values():
+        members = cluster["members"]
+        best = max(members, key=lambda m: m["nearest_similarity"])
+        if best["nearest_note"] and best["nearest_similarity"] >= EXTEND_SIM_FLOOR:
+            cluster["action"] = "extend"
+            cluster["target"] = best["nearest_note"]
+        else:
+            cluster["action"] = "create"
+            cluster["target"] = None  # named after synthesis; folder decided now
+            ws = [m.get("workspace") for m in members if m.get("workspace")]
+            cluster["target_folder"] = max(set(ws), key=ws.count) if ws else "inbox"
+        out.append(cluster)
+
+    out.sort(key=lambda c: (-len(c["members"]), str(c["basin"])))
+    return out
+
+
+def _synthesize(
+    members: list[dict],
+    llm_url: str,
+    llm_model: str,
+    api_key: str = "",
+) -> dict:
+    """One LLM synthesis for a cluster. Raises on failure — caller skips cluster."""
+    import httpx
+
+    from .config import _auth_headers
+
+    blocks = []
+    for m in members:
+        blocks.append(
+            f"[memory {m['memory_id']} · {m['entity_type']} · {m['created_at']}]\n"
+            f"{(m['content'] or '')[:_MEMORY_CHARS]}"
+        )
+    prompt = _SYNTH_PROMPT.format(n=len(members), memories="\n\n".join(blocks))
+
+    resp = httpx.post(
+        f"{llm_url}/v1/chat/completions",
+        headers=_auth_headers(api_key),
+        json={
+            "model": llm_model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "temperature": 0.2,
+            "max_tokens": 1500,
+        },
+        timeout=300.0,
+    )
+    resp.raise_for_status()
+    raw = _strip_fences(resp.json()["choices"][0]["message"]["content"])
+    parsed = json.loads(raw)
+    title = (parsed.get("title") or "Consolidated session knowledge").strip()
+    synthesis = (parsed.get("synthesis") or "").strip()
+    if not synthesis:
+        raise ValueError("LLM returned an empty synthesis")
+    return {"title": title, "synthesis": synthesis}
+
+
+def _sources_block(members: list[dict]) -> str:
+    lines = [
+        f"- memory {m['memory_id']} ({m['entity_type']}, {m['created_at']})"
+        for m in members
+    ]
+    return "Sources (archived memories):\n" + "\n".join(lines)
+
+
+def _new_note_content(title: str, synthesis: str, members: list[dict]) -> str:
+    today = datetime.date.today().isoformat()
+    return (
+        f"---\ndate: {today}\ntags: [consolidated]\ntype: note\n---\n\n"
+        f"# {title}\n\n{synthesis}\n\n{_sources_block(members)}\n"
+    )
+
+
+def _extended_content(existing: str, title: str, synthesis: str,
+                      members: list[dict]) -> str:
+    today = datetime.date.today().isoformat()
+    return (
+        existing.rstrip("\n")
+        + f"\n\n## {title} (consolidated {today})\n\n"
+        + synthesis
+        + "\n\n"
+        + _sources_block(members)
+        + "\n"
+    )
+
+
+def consolidate_replay(
+    conn: sqlite3.Connection,
+    cap: int = DEFAULT_CAP,
+    dry_run: bool = True,
+    workspace: str | None = None,
+    llm_url: str | None = None,
+    llm_model: str | None = None,
+) -> dict:
+    """Run one consolidation replay pass. Returns a report dict.
+
+    Dry run (default): cluster + plan only — no LLM, no writes, no archiving.
+    Real run: per cluster synthesize -> write/extend note -> archive members
+    with a ``promoted:<note_path>`` reason. A cluster is archived ONLY after
+    its note write committed AND pushed; any per-cluster failure skips that
+    cluster and is reported, never aborting the rest of the night.
+    """
+    from .config import get_config
+
+    cfg = get_config()
+    llm_url = llm_url or cfg.llm_url
+    llm_model = llm_model or cfg.llm_model
+
+    clusters = cluster_candidates(conn, workspace=workspace)
+    planned = clusters[: max(0, cap)]
+    report: dict = {
+        "dry_run": dry_run,
+        "cap": cap,
+        "clusters_found": len(clusters),
+        "clusters_planned": len(planned),
+        "consolidated": [],
+        "skipped": [],
+    }
+
+    def _plan(cluster: dict) -> dict:
+        return {
+            "basin": str(cluster["basin"]),
+            "action": cluster["action"],
+            "target": cluster["target"] or f"{cluster.get('target_folder')}/<slug>.md",
+            "memory_ids": [m["memory_id"] for m in cluster["members"]],
+        }
+
+    if dry_run:
+        report["consolidated"] = [_plan(c) for c in planned]
+        report["deferred"] = [_plan(c) for c in clusters[cap:]]
+        return report
+
+    from .memories import _archive_memories
+    from .tools import file_tools
+
+    for cluster in planned:
+        plan = _plan(cluster)
+        members = cluster["members"]
+        try:
+            synth = _synthesize(members, llm_url, llm_model, cfg.llm_api_key)
+        except Exception as exc:
+            plan["error"] = f"synthesis failed: {exc}"
+            report["skipped"].append(plan)
+            continue
+
+        if cluster["action"] == "extend":
+            target = cluster["target"]
+            abs_path = file_tools._vault_root() / target
+            try:
+                existing = abs_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                plan["error"] = f"target note unreadable: {exc}"
+                report["skipped"].append(plan)
+                continue
+            content = _extended_content(existing, synth["title"],
+                                        synth["synthesis"], members)
+        else:
+            target = f"{cluster['target_folder']}/{_slugify(synth['title'])}.md"
+            content = _new_note_content(synth["title"], synth["synthesis"], members)
+
+        result = file_tools.vault_write_file(
+            target, content,
+            commit_message=f"consolidate: {target} (nightly replay, issue #96)",
+        )
+        if not result.get("pushed"):
+            reason = result.get("git_error") or result.get("error") or "unknown"
+            plan["error"] = f"write not pushed: {reason}"
+            report["skipped"].append(plan)
+            continue
+
+        ids = [m["memory_id"] for m in members]
+        archived = _archive_memories(
+            conn,
+            f"memory_id IN ({','.join('?' * len(ids))})",
+            tuple(ids),
+            f"promoted:{target}",
+        )
+        conn.commit()
+        plan["target"] = target
+        plan["title"] = synth["title"]
+        plan["archived"] = archived
+        plan["commit_sha"] = result.get("commit_sha")
+        report["consolidated"].append(plan)
+        log.info("Consolidated %d memories into %s", archived, target)
+
+    return report

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -1,0 +1,252 @@
+"""Tests for consolidation replay (issue #96) — promotion queue -> basin
+clusters -> synthesis -> note write -> archive.
+
+The LLM and the git-backed write path are seams (monkeypatched); clustering,
+planning, cap, archive bookkeeping, and failure isolation are exercised for
+real against an in-memory DB.
+"""
+
+import json
+import struct
+
+import pytest
+
+import neurostack.consolidate as consolidate_mod
+from neurostack.consolidate import (
+    EXTEND_SIM_FLOOR,
+    _extended_content,
+    _new_note_content,
+    _slugify,
+    _strip_fences,
+    cluster_candidates,
+    consolidate_replay,
+)
+
+DIM = 768
+
+
+def _emb(*components) -> bytes:
+    v = [0.0] * DIM
+    for i, c in enumerate(components):
+        v[i] = c
+    return struct.pack(f"{DIM}f", *v)
+
+
+def _add_note(conn, path, emb=None):
+    conn.execute(
+        "INSERT INTO notes (path, title, content_hash, updated_at) VALUES (?, ?, ?, ?)",
+        (path, path, f"h_{path}", "2026-01-01"),
+    )
+    if emb is not None:
+        conn.execute(
+            "INSERT INTO chunks (note_path, heading_path, content, content_hash, "
+            "position, embedding) VALUES (?, ?, ?, ?, ?, ?)",
+            (path, "## H", "body", f"hc_{path}", 0, emb),
+        )
+
+
+def _add_memory(conn, content, emb, *, entity_type="decision", tags=None,
+                workspace=None):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, tags, workspace, embedding)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (content, entity_type, json.dumps(tags or []), workspace, emb),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _add_community(conn, note_paths, level=0):
+    cur = conn.execute(
+        "INSERT INTO communities (level, entity_count, member_notes, updated_at)"
+        " VALUES (?, ?, ?, datetime('now'))",
+        (level, len(note_paths), len(note_paths)),
+    )
+    cid = cur.lastrowid
+    conn.executemany(
+        "INSERT INTO community_members (community_id, entity) VALUES (?, ?)",
+        [(cid, p) for p in note_paths],
+    )
+    conn.commit()
+    return cid
+
+
+@pytest.fixture
+def vault_db(in_memory_db):
+    """Two notes: covered.md (basin c1), lonely.md (no community).
+
+    Memory A: promotion-debt, embedding identical to covered.md's chunk
+    (sim 1.0 -> extend). Memory B: durable, cosine 0.5 to lonely.md and 0 to
+    covered.md -> uncovered, no basin -> workspace-keyed create cluster.
+    """
+    conn = in_memory_db
+    _add_note(conn, "covered.md", emb=_emb(1.0))
+    _add_note(conn, "lonely.md", emb=_emb(0.0, 1.0))
+    cid = _add_community(conn, ["covered.md"])
+    a = _add_memory(conn, "Debt fact: pipeline 231 deploys the dashboard",
+                    _emb(1.0), tags=["promotion-debt"], workspace="work")
+    b = _add_memory(conn, "Uncovered fact: LXC 127 pins num_thread=1",
+                    _emb(0.0, 0.5, 0.86603), workspace="homelab")
+    conn.commit()
+    return conn, cid, a, b
+
+
+class TestHelpers:
+    def test_slugify(self):
+        assert _slugify("Ollama CPU fallback: num_thread=1!") == \
+            "ollama-cpu-fallback-num-thread-1"
+        assert _slugify("???") == "consolidated"
+
+    def test_strip_fences_and_think(self):
+        raw = "<think>hmm</think>```json\n{\"a\": 1}\n```"
+        assert _strip_fences(raw) == '{"a": 1}'
+
+    def test_new_note_has_frontmatter_and_sources(self):
+        members = [{"memory_id": 7, "entity_type": "decision",
+                    "created_at": "2026-01-01"}]
+        content = _new_note_content("T", "body", members)
+        assert content.startswith("---\ndate:")
+        assert "# T" in content and "- memory 7 (decision, 2026-01-01)" in content
+
+    def test_extended_content_appends_section(self):
+        members = [{"memory_id": 7, "entity_type": "bug", "created_at": "x"}]
+        out = _extended_content("---\n---\n\n# Old\n\nbody\n", "New facts",
+                                "synth", members)
+        assert out.startswith("---\n---\n\n# Old")
+        assert "## New facts (consolidated" in out
+        assert "- memory 7 (bug, x)" in out
+
+
+class TestClustering:
+    def test_clusters_split_by_basin_and_action(self, vault_db):
+        conn, cid, a, b = vault_db
+        clusters = cluster_candidates(conn)
+
+        assert len(clusters) == 2
+        by_basin = {str(c["basin"]): c for c in clusters}
+        extend = by_basin[str(cid)]
+        create = by_basin["ws:homelab"]
+        assert extend["action"] == "extend"
+        assert extend["target"] == "covered.md"
+        assert [m["memory_id"] for m in extend["members"]] == [a]
+        assert create["action"] == "create"
+        assert create["target"] is None
+        assert create["target_folder"] == "homelab"
+        assert [m["memory_id"] for m in create["members"]] == [b]
+
+    def test_no_candidates_no_clusters(self, in_memory_db):
+        assert cluster_candidates(in_memory_db) == []
+
+    def test_extend_floor_matches_promotion_floor(self):
+        assert EXTEND_SIM_FLOOR == 0.55
+
+
+class TestDryRun:
+    def test_dry_run_plans_without_llm_or_writes(self, vault_db, monkeypatch):
+        conn, cid, a, b = vault_db
+
+        def boom(*args, **kwargs):
+            raise AssertionError("dry run must not call the LLM")
+        monkeypatch.setattr(consolidate_mod, "_synthesize", boom)
+
+        report = consolidate_replay(conn, dry_run=True)
+
+        assert report["dry_run"] is True
+        assert report["clusters_found"] == 2
+        assert len(report["consolidated"]) == 2
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 2
+        assert conn.execute(
+            "SELECT COUNT(*) FROM memories_archive").fetchone()[0] == 0
+
+    def test_cap_defers_extra_clusters(self, vault_db):
+        conn, *_ = vault_db
+        report = consolidate_replay(conn, cap=1, dry_run=True)
+        assert report["clusters_planned"] == 1
+        assert len(report["deferred"]) == 1
+
+
+class TestRealRun:
+    def _patch_write(self, monkeypatch, tmp_path, pushed=True):
+        from neurostack.tools import file_tools
+
+        (tmp_path / "covered.md").write_text(
+            "---\ndate: 2026-01-01\n---\n\n# Covered\n\nold body\n")
+        writes = []
+
+        def fake_write(path, content, commit_message=None):
+            writes.append({"path": path, "content": content,
+                           "commit_message": commit_message})
+            return {"pushed": pushed, "commit_sha": "abc123def",
+                    "git_error": None if pushed else "push failed"}
+
+        monkeypatch.setattr(file_tools, "_vault_root", lambda: tmp_path)
+        monkeypatch.setattr(file_tools, "vault_write_file", fake_write)
+        return writes
+
+    def _patch_llm(self, monkeypatch):
+        monkeypatch.setattr(
+            consolidate_mod, "_synthesize",
+            lambda members, *a, **kw: {"title": "Synth Title",
+                                       "synthesis": "the consolidated facts"},
+        )
+
+    def test_run_writes_and_archives_with_pointer(self, vault_db, tmp_path,
+                                                  monkeypatch):
+        conn, cid, a, b = vault_db
+        writes = self._patch_write(monkeypatch, tmp_path)
+        self._patch_llm(monkeypatch)
+
+        report = consolidate_replay(conn, dry_run=False)
+
+        assert len(report["consolidated"]) == 2
+        assert report["skipped"] == []
+        paths = {w["path"] for w in writes}
+        assert "covered.md" in paths
+        assert "homelab/synth-title.md" in paths
+        extended = next(w for w in writes if w["path"] == "covered.md")
+        assert "old body" in extended["content"]  # extend keeps the note
+        assert "## Synth Title (consolidated" in extended["content"]
+        created = next(w for w in writes if w["path"] != "covered.md")
+        assert created["content"].startswith("---\ndate:")
+
+        # both memories archived with a pointer to the absorbing note
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+        rows = conn.execute(
+            "SELECT memory_id, archive_reason FROM memories_archive").fetchall()
+        reasons = {r["memory_id"]: r["archive_reason"] for r in rows}
+        assert reasons[a] == "promoted:covered.md"
+        assert reasons[b] == "promoted:homelab/synth-title.md"
+
+    def test_failed_push_skips_and_keeps_memories(self, vault_db, tmp_path,
+                                                  monkeypatch):
+        conn, cid, a, b = vault_db
+        self._patch_write(monkeypatch, tmp_path, pushed=False)
+        self._patch_llm(monkeypatch)
+
+        report = consolidate_replay(conn, dry_run=False)
+
+        assert report["consolidated"] == []
+        assert len(report["skipped"]) == 2
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 2
+        assert conn.execute(
+            "SELECT COUNT(*) FROM memories_archive").fetchone()[0] == 0
+
+    def test_synthesis_failure_isolated_per_cluster(self, vault_db, tmp_path,
+                                                    monkeypatch):
+        conn, cid, a, b = vault_db
+        self._patch_write(monkeypatch, tmp_path)
+        calls = {"n": 0}
+
+        def flaky(members, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError("model gibberish")
+            return {"title": "OK", "synthesis": "facts"}
+        monkeypatch.setattr(consolidate_mod, "_synthesize", flaky)
+
+        report = consolidate_replay(conn, dry_run=False)
+
+        assert len(report["skipped"]) == 1
+        assert "synthesis failed" in report["skipped"][0]["error"]
+        assert len(report["consolidated"]) == 1  # the other cluster proceeded
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 1


### PR DESCRIPTION
Part of #96. **Narrows #36, does not close it**: this ships the scheduled promotion/consolidation job (#36's timer + synthesis-of-memories half), but #36's observation→learning pipeline, harvest cosine dedup, prefilter tightening, and TTL defaults remain open.

## What
`neurostack consolidate` — the nightly job that RUNS the promotion queue (#92): cluster candidates by attractor basin, one LLM synthesis per cluster, write/extend the target vault note, archive the promoted memories with a `promoted:<note_path>` pointer.

## How
- **Candidates**: queue's `debt` + `uncovered` buckets. `drift` needs conflict judgment, `dead_handoffs` want forgetting — both deliberately stay interactive.
- **Clustering**: memory → nearest note (embedding argmax over chunks) → coarse (level 0) Hopfield community; no resolvable basin → workspace-keyed cluster. Largest clusters first.
- **Target**: extend the nearest note when best member similarity ≥ 0.55 (same floor the queue calls 'covered'), else create `<workspace>/<slug>.md` with full frontmatter.
- **Write path**: existing `vault_write_file` (path safety, frontmatter validation, flock, commit+push with rebase-on-conflict). Archive fires ONLY after committed+pushed; push/validation failure skips the cluster and keeps the memories.
- **Caps + safety**: `--cap` (default 5) bounds clusters per night; per-cluster synthesis failures are isolated; dry run (default) does clustering + planning only — zero LLM calls, writes, or archives.

## Gate
- ruff clean; full suite 734 passed (12 new in `tests/test_consolidate.py`)
- Locked: basin/action clustering, cap + deferral, dry-run purity, extend-keeps-note + create-frontmatter, archive pointers, failed-push keeps memories, per-cluster failure isolation

## Rollout (after merge)
Supervised dry run on LXC 122 → supervised `--run` → only then the nightly systemd timer on pop-os.