### PR TITLE
Migrate MCP adapter to mcp 2.0, lift the <2 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0",
     "watchdog>=4.0",
-    # mcp 2.0 removed mcp.server.fastmcp — pin until the adapter migrates (issue #98)
-    "mcp[cli]>=1.0,<2",
+    "mcp[cli]>=2,<3",
     "httpx>=0.27",
     "tomli_w>=1.0",
     "pathspec>=0.12",

--- a/src/neurostack/cli/api.py
+++ b/src/neurostack/cli/api.py
@@ -10,17 +10,16 @@ def cmd_serve(args):
     from ..server import mcp
     transport = args.transport
     if transport == "http":
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
+        run_kwargs = {"host": args.host, "port": args.port}
         if args.host not in ("127.0.0.1", "localhost", "::1"):
             from mcp.server.transport_security import TransportSecuritySettings
-            mcp.settings.transport_security = TransportSecuritySettings(
+            run_kwargs["transport_security"] = TransportSecuritySettings(
                 enable_dns_rebinding_protection=False,
                 allowed_hosts=["*"],
                 allowed_origins=["*"],
             )
         print(f"Starting NeuroStack MCP (Streamable HTTP) on {args.host}:{args.port}")
-        mcp.run(transport="streamable-http")
+        mcp.run(transport="streamable-http", **run_kwargs)
     else:
         mcp.run(transport=transport)
 

--- a/src/neurostack/server.py
+++ b/src/neurostack/server.py
@@ -4,7 +4,7 @@
 """NeuroStack MCP server — thin adapter over the protocol-agnostic tool registry.
 
 All tool logic lives in neurostack.tools.*_tools modules. This file
-creates a FastMCP server with all tools auto-registered.
+creates an MCPServer with all tools auto-registered.
 """
 
 from .tools.mcp_adapter import create_mcp_server

--- a/src/neurostack/tools/mcp_adapter.py
+++ b/src/neurostack/tools/mcp_adapter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024-2026 Raphael Southall
-"""MCP adapter — wraps registry tools for FastMCP.
+"""MCP adapter — wraps registry tools for the mcp 2.x MCPServer.
 
 Usage:
     from neurostack.tools.mcp_adapter import create_mcp_server
@@ -15,7 +15,7 @@ import functools
 import inspect
 import logging
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
 from . import ensure_registered
@@ -23,14 +23,14 @@ from . import ensure_registered
 log = logging.getLogger("neurostack.tools.mcp_adapter")
 
 
-def create_mcp_server(name: str = "neurostack", **fastmcp_kwargs) -> FastMCP:
-    """Create a FastMCP server with all registry tools auto-registered.
+def create_mcp_server(name: str = "neurostack", **server_kwargs) -> MCPServer:
+    """Create an MCPServer with all registry tools auto-registered.
 
     Args:
         name: MCP server name
-        **fastmcp_kwargs: Passed through to FastMCP constructor
+        **server_kwargs: Passed through to the MCPServer constructor
     """
-    mcp = FastMCP(name, **fastmcp_kwargs)
+    mcp = MCPServer(name, **server_kwargs)
     registry = ensure_registered()
 
     for tool_def in registry.list_tools():
@@ -46,13 +46,13 @@ def create_mcp_server(name: str = "neurostack", **fastmcp_kwargs) -> FastMCP:
         if tool_def.annotations:
             hints = tool_def.annotations
             mcp_annotations = ToolAnnotations(
-                readOnlyHint=hints.read_only,
-                destructiveHint=hints.destructive,
-                idempotentHint=hints.idempotent,
-                openWorldHint=hints.open_world,
+                read_only_hint=hints.read_only,
+                destructive_hint=hints.destructive,
+                idempotent_hint=hints.idempotent,
+                open_world_hint=hints.open_world,
             )
 
-        mcp.tool(annotations=mcp_annotations)(wrapper)
+        mcp.add_tool(wrapper, annotations=mcp_annotations)
 
     log.debug("Registered %d tools on MCP server %r", len(registry), name)
     return mcp

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -3,7 +3,7 @@
 """Integration tests for the MCP server layer (issue #5).
 
 Exercises the registered MCP tools end-to-end against a fixture vault:
-registry registration, the FastMCP adapter, and the tool functions
+registry registration, the MCPServer adapter, and the tool functions
 themselves (vault_search, vault_stats, vault_prediction_errors), asserting
 response structure and JSON serialisability.
 


### PR DESCRIPTION
Part of #98.

**What**: mcp 2.0.0 removed `mcp.server.fastmcp`; #97 pinned `mcp[cli]>=1.0,<2` to unblock CI. This ports the adapter to the mcp 2.0 high-level server and lifts the pin to `mcp[cli]>=2,<3`.

**How**:
- `mcp_adapter.py`: `FastMCP` → `mcp.server.mcpserver.MCPServer`; dynamic registration via `add_tool(wrapper, annotations=...)` (drops the `tool()(wrapper)` decorator dance); `ToolAnnotations` fields now snake_case.
- `cli/api.py`: 2.0 removed host/port/transport_security from server settings — they are `run(transport="streamable-http", ...)` kwargs now.
- Schema derivation from `wrapper.__signature__` unchanged; `list_tools()` still async.

**Gate**: ruff clean, 750/750 on mcp 2.0.0 (fresh `uv sync`).

**Live-verify (local)**: booted `neurostack serve --transport http` on 0.0.0.0:18901 — initialize OK, tools/list = 28 tools with wire annotations (`readOnlyHint`/`openWorldHint`), `vault_stats` call returned real stats, `isError: false`.