### PR TITLE
feat(synthesize): observation -> learning synthesis CLI

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -10,7 +10,7 @@ from .. import __version__
 from ..config import get_config
 from .api import cmd_api, cmd_bundle, cmd_serve
 from .index import cmd_backfill, cmd_export, cmd_index, cmd_reembed_chunks, cmd_watch
-from .memories import cmd_consolidate, cmd_memories, cmd_promote
+from .memories import cmd_consolidate, cmd_memories, cmd_promote, cmd_synthesize
 from .search import (
     cmd_ask,
     cmd_brief,
@@ -776,6 +776,31 @@ def main():
         help="Restrict to vault subdirectory. Also reads NEUROSTACK_WORKSPACE",
     )
     p.set_defaults(func=cmd_consolidate)
+
+    # synthesize
+    p = sub.add_parser(
+        "synthesize",
+        help="Observation -> learning synthesis: consolidate aged observation"
+        " heaps into single learnings (issue #36)",
+    )
+    p.add_argument("--run", action="store_true",
+                   help="Actually synthesize learnings and tag originals"
+                   " (default: dry run)")
+    p.add_argument("--cap", type=int, default=5,
+                   help="Max clusters synthesized per run (default: 5)")
+    p.add_argument("--min-age-days", type=int, default=7,
+                   help="Only observations older than this (default: 7)")
+    p.add_argument("--min-siblings", type=int, default=3,
+                   help="Related siblings required beyond the anchor (default: 3)")
+    p.add_argument("--threshold", type=float, default=0.35,
+                   help="Cosine similarity floor for siblings (default: 0.35)")
+    p.add_argument("--llm-model", default=None,
+                   help="Override the synthesis model")
+    p.add_argument(
+        "--workspace", "-w", default=None,
+        help="Restrict to vault subdirectory. Also reads NEUROSTACK_WORKSPACE",
+    )
+    p.set_defaults(func=cmd_synthesize)
 
     # stats
     p = sub.add_parser("stats", help="Show index stats")

--- a/src/neurostack/cli/memories.py
+++ b/src/neurostack/cli/memories.py
@@ -363,3 +363,52 @@ def cmd_consolidate(args):
         print(f"\n    deferred (over cap): {len(c['memory_ids'])} memories -> {c['target']}")
     if report["dry_run"] and report["clusters_planned"]:
         print("\n  Dry run — pass --run to synthesize, write notes, and archive.")
+
+
+def cmd_synthesize(args):
+    """Observation -> learning synthesis (issue #36)."""
+    from ..schema import DB_PATH, get_db
+    from ..synthesize import synthesize_observations
+
+    conn = get_db(DB_PATH)
+    report = synthesize_observations(
+        conn,
+        cap=args.cap,
+        dry_run=not args.run,
+        min_age_days=args.min_age_days,
+        min_siblings=args.min_siblings,
+        threshold=args.threshold,
+        workspace=_get_workspace(args),
+        llm_model=getattr(args, "llm_model", None),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    mode = "DRY RUN" if report["dry_run"] else "RUN"
+    before = report["ratio_before"]
+    print(f"  Synthesis ({mode}): {report['clusters_found']} cluster(s), "
+          f"{report['clusters_planned']} within cap {report['cap']}")
+    print(f"  Active observations: {before['observations']}, "
+          f"learnings: {before['learnings']}"
+          + (f" (ratio {before['ratio']}:1)" if before["ratio"] else ""))
+    if report["candidates_without_embedding"]:
+        print(f"  Skipped {report['candidates_without_embedding']} candidate(s) "
+          "without embeddings — run: neurostack backfill memories")
+    for c in report["synthesized"]:
+        ids = ", ".join(str(i) for i in c["memory_ids"])
+        print(f"\n    [{len(c['memory_ids'])} observations] anchor #{c['anchor_id']}")
+        print(f"      memories: {ids}")
+        if c.get("learning_id"):
+            print(f"      -> learning #{c['learning_id']}: {c['learning'][:120]}")
+    for c in report.get("skipped", []):
+        print(f"\n    SKIPPED anchor #{c['anchor_id']}: {c['error']}")
+    for c in report.get("deferred", []):
+        print(f"\n    deferred (over cap): {len(c['memory_ids'])} observations")
+    if not report["dry_run"]:
+        after = report["ratio_after"]
+        print(f"\n  After: {after['observations']} observations, "
+              f"{after['learnings']} learnings"
+              + (f" (ratio {after['ratio']}:1)" if after["ratio"] else ""))
+    if report["dry_run"] and report["clusters_planned"]:
+        print("\n  Dry run — pass --run to synthesize learnings and tag originals.")

--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -790,7 +790,11 @@ def harvest_sessions(
                 continue
 
             tags = _extract_tags(item["text"])
-            ttl = 168.0 if etype == "context" else None
+            # Harvest-created rows only: agent-written memories keep their
+            # caller-chosen TTL. Auto-captured context goes stale in a week;
+            # auto-captured observations get 30 days to be synthesized into a
+            # learning (issue #36) before they expire as noise.
+            ttl = {"context": 168.0, "observation": 720.0}.get(etype)
             record = {"content": summary, "entity_type": etype, "tags": tags,
                       "ttl_hours": ttl, "provider": session.provider}
 

--- a/src/neurostack/skills/memory-management.md
+++ b/src/neurostack/skills/memory-management.md
@@ -55,7 +55,16 @@ insight in noise, so reach for a more specific type whenever one fits.
   values, "X is currently at version N". Harvest gives these a 168h TTL by default. Not for
   durable handoffs or long-lived facts; those aren't ephemeral state.
 - **observation**: A durable fact that isn't yet a synthesised insight. Use sparingly — if you can
-  phrase it as a learning or decision, do that. Raw observations are the noisiest, least useful bucket.
+  phrase it as a learning or decision, do that. Raw observations are the noisiest, least useful
+  bucket; harvest-created observations expire after 30 days unless promoted.
 
-When several related observations pile up, promote them into one consolidated `learning`
-(via `vault_update_memory`) rather than leaving a heap of near-duplicates.
+## Promote observations into learnings
+
+When several related observations pile up, consolidate them into one `learning` instead of
+leaving a heap of near-duplicates. Manually via `vault_update_memory`, or in bulk:
+```
+neurostack synthesize            # dry run: show planned clusters
+neurostack synthesize --run      # consolidate; originals get superseded_by:<id> tags
+```
+Clusters are observations older than 7 days with at least 3 similar siblings. Originals are
+tagged, never deleted — filter them out with the `superseded_by:` tag prefix.

--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Observation -> learning synthesis (issue #36): consolidate aged observation
+heaps into single durable learnings.
+
+Memory capture skews raw — observations pile up ~3.5x faster than learnings,
+and near-duplicate observations about the same topic bury the insight they
+collectively contain. This module is the rework pass:
+
+1. Candidates: ``observation`` memories older than ``min_age_days`` that are
+   alive (not expired) and not already superseded by an earlier synthesis run.
+2. Cluster on stored embeddings: greedy anchor grouping, oldest anchor first,
+   pairwise cosine >= ``threshold``. A cluster needs the anchor plus at least
+   ``min_siblings`` related observations. Candidates without an embedding are
+   reported, never silently dropped (#29 backfill heals them).
+3. One LLM synthesis per cluster (same ``llm_url`` path as consolidation) — a
+   single consolidated ``learning`` memory that preserves every concrete fact.
+4. Save the learning through ``save_memory``, then tag each original with
+   ``superseded_by:<new_memory_id>``. Originals are tagged, NEVER deleted or
+   archived — the tag excludes them from future synthesis runs and keeps the
+   provenance chain walkable in both directions.
+
+``dry_run=True`` (the default everywhere) stops after step 2 and reports the
+plan — no LLM calls, no writes. A per-run ``cap`` bounds how many clusters one
+pass may synthesize so a backlog cannot flood the memory store.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+
+log = logging.getLogger("neurostack")
+
+DEFAULT_CAP = 5
+DEFAULT_MIN_AGE_DAYS = 7
+DEFAULT_MIN_SIBLINGS = 3
+# Same-topic-different-fact observations measure ~0.43 on the prod embedder
+# (embeddinggemma:300m) while unrelated content sits ~0.20; 0.35 splits the
+# gap with margin on the grouping side. Paraphrases (~0.93) are handled
+# earlier by harvest dedup — synthesis clusters are the same-topic tier.
+SIBLING_THRESHOLD = 0.35
+_MEMORY_CHARS = 1500          # per-observation content budget in the prompt
+_SUPERSEDED_PREFIX = "superseded_by:"
+
+_SYNTH_PROMPT = """You are consolidating an engineer's raw session observations into one \
+durable learning. Below are {n} related observations about the same topic.
+
+Write ONE consolidated learning — the insight the observations collectively \
+support — preserving every concrete fact: identifiers, versions, hosts, paths, \
+commands, numbers. Merge overlap, keep disagreements visible, and do not invent \
+or embellish anything. Respond with the learning text only: no preamble, no \
+headings, no quotes around it.
+
+Observations:
+{observations}
+"""
+
+
+def _strip_fences(raw: str) -> str:
+    raw = re.sub(r"<think>.*?(</think>|$)", "", raw, flags=re.DOTALL).strip()
+    raw = re.sub(r"^```[a-z]*\n?", "", raw)
+    raw = re.sub(r"\n?```$", "", raw)
+    return raw.strip()
+
+
+def _candidate_rows(
+    conn: sqlite3.Connection,
+    min_age_days: int,
+    workspace: str | None = None,
+) -> list[dict]:
+    """Alive, non-superseded observations older than min_age_days, oldest first."""
+    where = [
+        "entity_type = 'observation'",
+        "created_at <= datetime('now', ?)",
+        "(expires_at IS NULL OR expires_at > datetime('now'))",
+        "COALESCE(tags, '') NOT LIKE ?",
+    ]
+    params: list = [f"-{int(min_age_days)} days", f"%{_SUPERSEDED_PREFIX}%"]
+    if workspace:
+        ws = workspace.strip("/")
+        where.append("(workspace = ? OR workspace LIKE ? || '/%')")
+        params.extend([ws, ws])
+    rows = conn.execute(
+        f"SELECT * FROM memories WHERE {' AND '.join(where)} ORDER BY created_at",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def cluster_observations(
+    conn: sqlite3.Connection,
+    min_age_days: int = DEFAULT_MIN_AGE_DAYS,
+    min_siblings: int = DEFAULT_MIN_SIBLINGS,
+    threshold: float = SIBLING_THRESHOLD,
+    workspace: str | None = None,
+) -> tuple[list[dict], int]:
+    """Greedy anchor clustering over stored embeddings. Pure read.
+
+    Returns (clusters, no_embedding_count). Each cluster dict carries its
+    member rows, oldest-anchor first. Clusters below ``1 + min_siblings``
+    members are discarded — a heap that small is not yet worth consolidating.
+    """
+    from .embedder import HAS_NUMPY, blob_to_embedding, cosine_similarity_batch
+
+    if not HAS_NUMPY:
+        raise ImportError(
+            "Synthesis requires numpy. Install with: pip install neurostack[full]"
+        )
+    import numpy as np
+
+    rows = _candidate_rows(conn, min_age_days, workspace=workspace)
+    embedded: list[dict] = []
+    no_embedding = 0
+    vectors = []
+    for r in rows:
+        if not r.get("embedding"):
+            no_embedding += 1
+            continue
+        try:
+            vectors.append(blob_to_embedding(r["embedding"]))
+        except ValueError:
+            no_embedding += 1
+            continue
+        embedded.append(r)
+    if len(embedded) < 1 + min_siblings:
+        return [], no_embedding
+
+    matrix = np.stack(vectors)
+    assigned = [False] * len(embedded)
+    clusters: list[dict] = []
+    for i, anchor in enumerate(embedded):
+        if assigned[i]:
+            continue
+        sims = cosine_similarity_batch(matrix[i], matrix)
+        member_idx = [
+            j for j in range(len(embedded))
+            if not assigned[j] and (j == i or sims[j] >= threshold)
+        ]
+        if len(member_idx) < 1 + min_siblings:
+            continue
+        for j in member_idx:
+            assigned[j] = True
+        clusters.append({
+            "anchor_id": anchor["memory_id"],
+            "members": [embedded[j] for j in member_idx],
+        })
+
+    clusters.sort(key=lambda c: -len(c["members"]))
+    return clusters, no_embedding
+
+
+def _synthesize(
+    members: list[dict],
+    llm_url: str,
+    llm_model: str,
+    api_key: str = "",
+) -> str:
+    """One LLM synthesis for a cluster. Raises on failure — caller skips cluster."""
+    import httpx
+
+    from .config import _auth_headers
+
+    blocks = []
+    for m in members:
+        blocks.append(
+            f"[memory {m['memory_id']} · {m['created_at']}]\n"
+            f"{(m['content'] or '')[:_MEMORY_CHARS]}"
+        )
+    prompt = _SYNTH_PROMPT.format(n=len(members), observations="\n\n".join(blocks))
+
+    resp = httpx.post(
+        f"{llm_url}/v1/chat/completions",
+        headers=_auth_headers(api_key),
+        json={
+            "model": llm_model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "temperature": 0.2,
+            "max_tokens": 1000,
+        },
+        timeout=300.0,
+    )
+    resp.raise_for_status()
+    content = _strip_fences(resp.json()["choices"][0]["message"]["content"])
+    if not content:
+        raise ValueError("LLM returned an empty synthesis")
+    return content
+
+
+def _cluster_tags(members: list[dict], limit: int = 8) -> list[str]:
+    """Union of member tags by frequency, synthesis marker last."""
+    counts: dict[str, int] = {}
+    for m in members:
+        try:
+            for t in json.loads(m.get("tags") or "[]"):
+                if not t.startswith(_SUPERSEDED_PREFIX):
+                    counts[t] = counts.get(t, 0) + 1
+        except (TypeError, ValueError):
+            continue
+    ranked = sorted(counts, key=lambda t: (-counts[t], t))[:limit]
+    return [*ranked, "synthesized"]
+
+
+def _majority_workspace(members: list[dict]) -> str | None:
+    ws = [m.get("workspace") for m in members if m.get("workspace")]
+    return max(set(ws), key=ws.count) if ws else None
+
+
+def observation_learning_ratio(conn: sqlite3.Connection) -> dict:
+    """Active (non-superseded, non-expired) observation:learning counts."""
+    row = conn.execute(
+        """
+        SELECT
+          SUM(CASE WHEN entity_type = 'observation'
+              AND COALESCE(tags, '') NOT LIKE ? THEN 1
+              ELSE 0 END) AS observations,
+          SUM(CASE WHEN entity_type = 'learning' THEN 1 ELSE 0 END) AS learnings
+        FROM memories
+        WHERE expires_at IS NULL OR expires_at > datetime('now')
+        """,
+        (f"%{_SUPERSEDED_PREFIX}%",),
+    ).fetchone()
+    observations = row["observations"] or 0
+    learnings = row["learnings"] or 0
+    return {
+        "observations": observations,
+        "learnings": learnings,
+        "ratio": round(observations / learnings, 2) if learnings else None,
+    }
+
+
+def synthesize_observations(
+    conn: sqlite3.Connection,
+    cap: int = DEFAULT_CAP,
+    dry_run: bool = True,
+    min_age_days: int = DEFAULT_MIN_AGE_DAYS,
+    min_siblings: int = DEFAULT_MIN_SIBLINGS,
+    threshold: float = SIBLING_THRESHOLD,
+    workspace: str | None = None,
+    llm_url: str | None = None,
+    llm_model: str | None = None,
+    embed_url: str | None = None,
+) -> dict:
+    """Run one synthesis pass. Returns a report dict.
+
+    Dry run (default): cluster + plan only — no LLM, no writes. Real run: per
+    cluster synthesize -> save one ``learning`` -> tag each original with
+    ``superseded_by:<learning_id>``. Any per-cluster failure skips that
+    cluster and is reported, never aborting the rest of the pass.
+    """
+    from .config import get_config
+
+    cfg = get_config()
+    llm_url = llm_url or cfg.llm_url
+    llm_model = llm_model or cfg.llm_model
+
+    clusters, no_embedding = cluster_observations(
+        conn, min_age_days=min_age_days, min_siblings=min_siblings,
+        threshold=threshold, workspace=workspace,
+    )
+    planned = clusters[: max(0, cap)]
+    report: dict = {
+        "dry_run": dry_run,
+        "cap": cap,
+        "min_age_days": min_age_days,
+        "min_siblings": min_siblings,
+        "threshold": threshold,
+        "clusters_found": len(clusters),
+        "clusters_planned": len(planned),
+        "candidates_without_embedding": no_embedding,
+        "ratio_before": observation_learning_ratio(conn),
+        "synthesized": [],
+        "skipped": [],
+    }
+
+    def _plan(cluster: dict) -> dict:
+        return {
+            "anchor_id": cluster["anchor_id"],
+            "memory_ids": [m["memory_id"] for m in cluster["members"]],
+        }
+
+    if dry_run:
+        report["synthesized"] = [_plan(c) for c in planned]
+        report["deferred"] = [_plan(c) for c in clusters[cap:]]
+        report["ratio_after"] = report["ratio_before"]
+        return report
+
+    from .memories import save_memory, update_memory
+
+    for cluster in planned:
+        plan = _plan(cluster)
+        members = cluster["members"]
+        try:
+            learning = _synthesize(members, llm_url, llm_model, cfg.llm_api_key)
+        except Exception as exc:
+            plan["error"] = f"synthesis failed: {exc}"
+            report["skipped"].append(plan)
+            continue
+
+        try:
+            memory = save_memory(
+                conn, content=learning,
+                tags=_cluster_tags(members),
+                entity_type="learning",
+                source_agent="synthesize",
+                workspace=_majority_workspace(members),
+                embed_url=embed_url,
+                dedup=False,
+            )
+        except Exception as exc:
+            plan["error"] = f"save failed: {exc}"
+            report["skipped"].append(plan)
+            continue
+
+        for m in members:
+            update_memory(
+                conn, m["memory_id"],
+                add_tags=[f"{_SUPERSEDED_PREFIX}{memory.memory_id}"],
+            )
+        conn.commit()
+        plan["learning_id"] = memory.memory_id
+        plan["learning"] = learning
+        report["synthesized"].append(plan)
+        log.info("Synthesized %d observations into learning %d",
+                 len(members), memory.memory_id)
+
+    report["ratio_after"] = observation_learning_ratio(conn)
+    return report

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -539,3 +539,68 @@ class TestLlmClassify:
         }]
         out = _llm_classify(candidates, "http://llm.test", "model")
         assert out[0]["entity_type"] == "observation"
+
+
+# ---------------------------------------------------------------------------
+# harvest_sessions — per-type TTL on harvest-created memories (issue #36)
+# ---------------------------------------------------------------------------
+
+class TestHarvestTtl:
+    """Auto-captured context expires in 7 days, observations in 30; durable
+    types (learning, decision, ...) stay permanent. Agent-written memories are
+    unaffected — the TTL lives in the harvest save path only."""
+
+    def _run_harvest(self, in_memory_db, tmp_path, monkeypatch, classified):
+        import numpy as np
+
+        import neurostack.embedder as embedder_mod
+        import neurostack.harvest as harvest_mod
+        from neurostack.harvest import SessionFile
+
+        session = SessionFile(path=tmp_path / "s.jsonl", mtime=1.0,
+                              provider="claude-code")
+        monkeypatch.setattr(harvest_mod, "find_recent_sessions",
+                            lambda *a, **k: [session])
+        monkeypatch.setattr(harvest_mod, "extract_messages", lambda s: [
+            Message(role="assistant", text=c["text"]) for c in classified
+        ])
+        monkeypatch.setattr(harvest_mod, "_llm_classify",
+                            lambda cands, *a, **k: classified)
+        monkeypatch.setattr(harvest_mod, "_harvest_state_path",
+                            lambda: tmp_path / "state.json")
+        monkeypatch.setattr("neurostack.schema.get_db",
+                            lambda path: in_memory_db)
+        cfg = SimpleNamespace(embed_url="http://embed.test",
+                              llm_url="http://llm.test", llm_model="m",
+                              llm_api_key=None, writeback_enabled=False)
+        monkeypatch.setattr("neurostack.config.get_config", lambda: cfg)
+        monkeypatch.setattr(embedder_mod, "get_embedding",
+                            lambda *a, **k: np.ones(768, dtype=np.float32))
+        from neurostack.harvest import harvest_sessions
+        return harvest_sessions(n_sessions=1, dry_run=False)
+
+    def test_per_type_ttl(self, in_memory_db, tmp_path, monkeypatch):
+        classified = [
+            {"text": "The API key is stored at /etc/app/credentials for the deploy.",
+             "role": "assistant", "prefilter_type": "context",
+             "entity_type": "context",
+             "summary": "API key stored at /etc/app/credentials for deploys"},
+            {"text": "The dashboard pipeline currently runs on agent pool two.",
+             "role": "assistant", "prefilter_type": "decision",
+             "entity_type": "observation",
+             "summary": "Dashboard pipeline currently runs on agent pool two"},
+            {"text": "We decided to use merge commits over squash for this repo.",
+             "role": "assistant", "prefilter_type": "decision",
+             "entity_type": "decision",
+             "summary": "Use merge commits over squash for this repository"},
+        ]
+        report = self._run_harvest(in_memory_db, tmp_path, monkeypatch, classified)
+
+        assert [r["status"] for r in report["saved"]] == ["saved"] * 3
+        rows = {r["entity_type"]: r for r in in_memory_db.execute(
+            "SELECT entity_type, expires_at,"
+            " round((julianday(expires_at) - julianday('now')) * 24) AS ttl_h"
+            " FROM memories").fetchall()}
+        assert rows["context"]["ttl_h"] == 168
+        assert rows["observation"]["ttl_h"] == 720
+        assert rows["decision"]["expires_at"] is None

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -1,0 +1,274 @@
+"""Tests for observation -> learning synthesis (issue #36) — aged observation
+heaps -> embedding clusters -> LLM synthesis -> one learning, originals tagged.
+
+The LLM is a seam (monkeypatched); candidate selection, clustering, cap,
+supersede tagging, ratio accounting, and failure isolation are exercised for
+real against an in-memory DB.
+"""
+
+import json
+import struct
+
+import numpy as np
+import pytest
+
+import neurostack.synthesize as synth_mod
+from neurostack.synthesize import (
+    SIBLING_THRESHOLD,
+    _cluster_tags,
+    _strip_fences,
+    cluster_observations,
+    observation_learning_ratio,
+    synthesize_observations,
+)
+
+DIM = 768
+
+
+def _emb(*components) -> bytes:
+    v = [0.0] * DIM
+    for i, c in enumerate(components):
+        v[i] = c
+    return struct.pack(f"{DIM}f", *v)
+
+
+def _add_memory(conn, content, emb=None, *, entity_type="observation",
+                tags=None, workspace=None, age_days=30, expires_at=None):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, tags, workspace,"
+        " embedding, expires_at, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?))",
+        (content, entity_type, json.dumps(tags or []), workspace, emb,
+         expires_at, f"-{age_days} days"),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture
+def heap_db(in_memory_db):
+    """The acceptance scenario: 7 observations + 2 learnings (3.5:1).
+
+    Four observations share a topic axis (pairwise cosine 1.0), three are
+    mutually orthogonal singles — one cluster of 4, nothing else groups.
+    """
+    conn = in_memory_db
+    cluster = [
+        _add_memory(conn, f"AKS upgrade step {i} needs the node pool drained",
+                    _emb(1.0), tags=["aks", f"t{i}"], workspace="work")
+        for i in range(4)
+    ]
+    singles = [
+        _add_memory(conn, "LXC 127 pins num_thread=1", _emb(0.0, 1.0),
+                    workspace="homelab"),
+        _add_memory(conn, "haproxy cold start takes minutes", _emb(0.0, 0.0, 1.0)),
+        _add_memory(conn, "ruff needs the dev extra", _emb(0.0, 0.0, 0.0, 1.0)),
+    ]
+    for i in range(2):
+        _add_memory(conn, f"learning {i}", entity_type="learning")
+    return conn, cluster, singles
+
+
+def _fake_embed(*args, **kwargs):
+    return np.array([0.5] * DIM, dtype=np.float32)
+
+
+class TestHelpers:
+    def test_strip_fences(self):
+        raw = "<think>hmm</think>```markdown\nthe learning\n```"
+        assert _strip_fences(raw) == "the learning"
+
+    def test_cluster_tags_union_ranked_and_marked(self):
+        members = [
+            {"tags": json.dumps(["aks", "azure", "superseded_by:9"])},
+            {"tags": json.dumps(["aks"])},
+            {"tags": None},
+        ]
+        tags = _cluster_tags(members)
+        assert tags == ["aks", "azure", "synthesized"]
+
+    def test_ratio(self, heap_db):
+        conn, *_ = heap_db
+        ratio = observation_learning_ratio(conn)
+        assert ratio == {"observations": 7, "learnings": 2, "ratio": 3.5}
+
+    def test_ratio_no_learnings(self, in_memory_db):
+        assert observation_learning_ratio(in_memory_db)["ratio"] is None
+
+
+class TestCandidates:
+    def test_only_aged_alive_unsuperseded_observations(self, in_memory_db):
+        conn = in_memory_db
+        ok = _add_memory(conn, "aged observation", _emb(1.0))
+        _add_memory(conn, "too young", _emb(1.0), age_days=1)
+        _add_memory(conn, "a decision", _emb(1.0), entity_type="decision")
+        _add_memory(conn, "expired", _emb(1.0),
+                    expires_at="2020-01-01 00:00:00")
+        _add_memory(conn, "already superseded", _emb(1.0),
+                    tags=["superseded_by:42"])
+        rows = synth_mod._candidate_rows(conn, min_age_days=7)
+        assert [r["memory_id"] for r in rows] == [ok]
+
+    def test_null_tags_row_still_a_candidate(self, in_memory_db):
+        # tags is a nullable column; NULL NOT LIKE excludes silently
+        conn = in_memory_db
+        cur = conn.execute(
+            "INSERT INTO memories (content, entity_type, embedding, created_at)"
+            " VALUES ('null tags row', 'observation', ?,"
+            " datetime('now', '-30 days'))", (_emb(1.0),))
+        conn.commit()
+        rows = synth_mod._candidate_rows(conn, min_age_days=7)
+        assert [r["memory_id"] for r in rows] == [cur.lastrowid]
+
+    def test_workspace_scoping(self, in_memory_db):
+        conn = in_memory_db
+        w = _add_memory(conn, "in scope", _emb(1.0), workspace="work/acme")
+        _add_memory(conn, "out of scope", _emb(1.0), workspace="homelab")
+        rows = synth_mod._candidate_rows(conn, min_age_days=7, workspace="work")
+        assert [r["memory_id"] for r in rows] == [w]
+
+
+class TestClustering:
+    def test_groups_topic_heap_ignores_singles(self, heap_db):
+        conn, cluster_ids, _singles = heap_db
+        clusters, no_emb = cluster_observations(conn)
+        assert no_emb == 0
+        assert len(clusters) == 1
+        assert sorted(m["memory_id"] for m in clusters[0]["members"]) == cluster_ids
+        assert clusters[0]["anchor_id"] == cluster_ids[0]  # oldest-first anchor
+
+    def test_min_siblings_enforced(self, heap_db):
+        conn, *_ = heap_db
+        clusters, _ = cluster_observations(conn, min_siblings=4)
+        assert clusters == []
+
+    def test_missing_embeddings_counted_not_dropped(self, in_memory_db):
+        conn = in_memory_db
+        for i in range(4):
+            _add_memory(conn, f"embedded {i}", _emb(1.0))
+        _add_memory(conn, "no embedding")
+        clusters, no_emb = cluster_observations(conn)
+        assert no_emb == 1
+        assert len(clusters) == 1
+
+    def test_threshold_default(self):
+        assert SIBLING_THRESHOLD == 0.35
+
+
+class TestDryRun:
+    def test_dry_run_plans_without_llm_or_writes(self, heap_db, monkeypatch):
+        conn, cluster_ids, _ = heap_db
+
+        def boom(*args, **kwargs):
+            raise AssertionError("dry run must not call the LLM")
+        monkeypatch.setattr(synth_mod, "_synthesize", boom)
+
+        report = synthesize_observations(conn, dry_run=True)
+
+        assert report["dry_run"] is True
+        assert report["clusters_found"] == 1
+        assert report["synthesized"] == [
+            {"anchor_id": cluster_ids[0], "memory_ids": cluster_ids}]
+        assert report["ratio_after"] == report["ratio_before"]
+        assert conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE entity_type='learning'"
+        ).fetchone()[0] == 2
+
+    def test_cap_defers_extra_clusters(self, in_memory_db):
+        conn = in_memory_db
+        for axis in (1, 2):
+            emb = _emb(*([0.0] * (axis - 1) + [1.0]))
+            for i in range(4):
+                _add_memory(conn, f"axis {axis} fact {i}", emb)
+        report = synthesize_observations(conn, cap=1, dry_run=True)
+        assert report["clusters_found"] == 2
+        assert report["clusters_planned"] == 1
+        assert len(report["deferred"]) == 1
+
+
+class TestRealRun:
+    def _patch_seams(self, monkeypatch, learning="AKS upgrades need drained pools"):
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(embedder_mod, "get_embedding", _fake_embed)
+        monkeypatch.setattr(
+            synth_mod, "_synthesize", lambda members, *a, **kw: learning)
+
+    def test_run_saves_learning_and_tags_originals(self, heap_db, monkeypatch):
+        conn, cluster_ids, singles = heap_db
+        self._patch_seams(monkeypatch)
+
+        report = synthesize_observations(conn, dry_run=False)
+
+        assert len(report["synthesized"]) == 1
+        plan = report["synthesized"][0]
+        learning_id = plan["learning_id"]
+        row = conn.execute(
+            "SELECT * FROM memories WHERE memory_id = ?", (learning_id,)
+        ).fetchone()
+        assert row["entity_type"] == "learning"
+        assert row["content"] == "AKS upgrades need drained pools"
+        assert row["workspace"] == "work"
+        tags = json.loads(row["tags"])
+        assert "aks" in tags and "synthesized" in tags
+
+        # every original tagged, none deleted
+        for mid in cluster_ids:
+            orig = conn.execute(
+                "SELECT tags FROM memories WHERE memory_id = ?", (mid,)
+            ).fetchone()
+            assert f"superseded_by:{learning_id}" in json.loads(orig["tags"])
+        for mid in singles:
+            orig = conn.execute(
+                "SELECT tags FROM memories WHERE memory_id = ?", (mid,)
+            ).fetchone()
+            assert "superseded_by" not in (orig["tags"] or "")
+
+    def test_ratio_reaches_acceptance_target(self, heap_db, monkeypatch):
+        """Issue #36 acceptance: ~3.5:1 improves to <=2:1 after synthesis."""
+        conn, *_ = heap_db
+        self._patch_seams(monkeypatch)
+
+        report = synthesize_observations(conn, dry_run=False)
+
+        assert report["ratio_before"]["ratio"] == 3.5
+        assert report["ratio_after"]["ratio"] <= 2.0
+
+    def test_superseded_excluded_from_next_run(self, heap_db, monkeypatch):
+        conn, *_ = heap_db
+        self._patch_seams(monkeypatch)
+        synthesize_observations(conn, dry_run=False)
+
+        again = synthesize_observations(conn, dry_run=True)
+        assert again["clusters_found"] == 0
+
+    def test_synthesis_failure_isolated_per_cluster(self, in_memory_db,
+                                                    monkeypatch):
+        conn = in_memory_db
+        for axis in (1, 2):
+            emb = _emb(*([0.0] * (axis - 1) + [1.0]))
+            for i in range(4):
+                _add_memory(conn, f"axis {axis} fact {i}", emb)
+
+        import neurostack.embedder as embedder_mod
+        monkeypatch.setattr(embedder_mod, "get_embedding", _fake_embed)
+        calls = {"n": 0}
+
+        def flaky(members, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError("model gibberish")
+            return "the surviving learning"
+        monkeypatch.setattr(synth_mod, "_synthesize", flaky)
+
+        report = synthesize_observations(conn, dry_run=False)
+
+        assert len(report["skipped"]) == 1
+        assert "synthesis failed" in report["skipped"][0]["error"]
+        assert len(report["synthesized"]) == 1
+        # failed cluster's originals stay untagged
+        failed_ids = report["skipped"][0]["memory_ids"]
+        for mid in failed_ids:
+            tags = conn.execute(
+                "SELECT tags FROM memories WHERE memory_id = ?", (mid,)
+            ).fetchone()["tags"]
+            assert "superseded_by" not in tags


### PR DESCRIPTION
Part of #36 — the remaining part 1 (parts 2/3/5 shipped via #85; tool-layer TTL default stays deliberately skipped as a data-safety landmine, see the 2026-07-06 scoping).

## What
- `neurostack synthesize` (new `src/neurostack/synthesize.py`): consolidates aged observation heaps into single `learning` memories.
  - Candidates: alive, non-superseded observations older than `--min-age-days` (default 7).
  - Clustering: greedy anchor grouping on **stored embeddings** (pairwise cosine, `--threshold` 0.35, anchor + `--min-siblings` 3). The issue's FTS5-sibling wording predates #29's full embedding coverage; stored-embedding clustering is cheaper (no embedder round-trips) and stronger. Candidates without embeddings are counted and reported, never silently dropped.
  - One LLM synthesis per cluster (same `llm_url` path as #96 consolidation); originals tagged `superseded_by:<learning_id>` — tagged, never deleted or archived.
  - Safety: dry-run default, `--run` opt-in, `--cap` 5 clusters per pass, per-cluster failure isolation. NOT wired into session_end auto_harvest (deliberate — manual/timer-driven for now).
  - Report includes active observation:learning ratio before/after.
- Harvest: auto-captured observations now expire in 720h (30d) — harvest save path only, agent-written memories unaffected. The tool-layer TTL default from the issue would silently expire durable handoff `context` memories, so it stays skipped.
- `memory-management` skill: promote-observations guidance + the new command.

## Gate
ruff clean; 768 tests pass (18 new: candidate selection incl. NULL-tags regression, clustering/min-siblings/missing-embedding accounting, dry-run/cap, supersede tagging, per-cluster failure isolation, the #36 acceptance ratio scenario 3.5:1 -> <=2:1, harvest per-type TTL e2e).

## Live verify
Dry run against the local DB exercises the CLI end-to-end (0 clusters — live data is on LXC 122; a live dry run follows the deploy).