### PR TITLE
fix(synthesize): live-calibrated threshold 0.65 + per-cluster member cap

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -792,8 +792,10 @@ def main():
                    help="Only observations older than this (default: 7)")
     p.add_argument("--min-siblings", type=int, default=3,
                    help="Related siblings required beyond the anchor (default: 3)")
-    p.add_argument("--threshold", type=float, default=0.35,
-                   help="Cosine similarity floor for siblings (default: 0.35)")
+    p.add_argument("--threshold", type=float, default=0.65,
+                   help="Cosine similarity floor for siblings (default: 0.65)")
+    p.add_argument("--max-cluster", type=int, default=20,
+                   help="Max observations consolidated per cluster (default: 20)")
     p.add_argument("--llm-model", default=None,
                    help="Override the synthesis model")
     p.add_argument(

--- a/src/neurostack/cli/memories.py
+++ b/src/neurostack/cli/memories.py
@@ -378,6 +378,7 @@ def cmd_synthesize(args):
         min_age_days=args.min_age_days,
         min_siblings=args.min_siblings,
         threshold=args.threshold,
+        max_cluster=args.max_cluster,
         workspace=_get_workspace(args),
         llm_model=getattr(args, "llm_model", None),
     )

--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -36,11 +36,17 @@ log = logging.getLogger("neurostack")
 DEFAULT_CAP = 5
 DEFAULT_MIN_AGE_DAYS = 7
 DEFAULT_MIN_SIBLINGS = 3
-# Same-topic-different-fact observations measure ~0.43 on the prod embedder
-# (embeddinggemma:300m) while unrelated content sits ~0.20; 0.35 splits the
-# gap with margin on the grouping side. Paraphrases (~0.93) are handled
-# earlier by harvest dedup — synthesis clusters are the same-topic tier.
-SIBLING_THRESHOLD = 0.35
+# Live-calibrated on the prod embedder (embeddinggemma:300m) against the real
+# memory store: 0.35-0.55 chains dense early-harvest noise into 100+ member
+# mega-clusters; 0.65 yields coherent 4-15 member topic groups. Paraphrases
+# (~0.93) are handled earlier by harvest dedup — synthesis clusters are the
+# same-topic tier.
+SIBLING_THRESHOLD = 0.65
+# Hard per-cluster member ceiling: one learning cannot faithfully preserve the
+# facts of an unbounded heap, and the prompt must stay bounded. Oversized
+# clusters keep the anchor plus its most similar members; the rest stay
+# unsuperseded and regroup on a later pass.
+MAX_CLUSTER = 20
 _MEMORY_CHARS = 1500          # per-observation content budget in the prompt
 _SUPERSEDED_PREFIX = "superseded_by:"
 
@@ -94,6 +100,7 @@ def cluster_observations(
     min_age_days: int = DEFAULT_MIN_AGE_DAYS,
     min_siblings: int = DEFAULT_MIN_SIBLINGS,
     threshold: float = SIBLING_THRESHOLD,
+    max_cluster: int = MAX_CLUSTER,
     workspace: str | None = None,
 ) -> tuple[list[dict], int]:
     """Greedy anchor clustering over stored embeddings. Pure read.
@@ -101,6 +108,8 @@ def cluster_observations(
     Returns (clusters, no_embedding_count). Each cluster dict carries its
     member rows, oldest-anchor first. Clusters below ``1 + min_siblings``
     members are discarded — a heap that small is not yet worth consolidating.
+    Clusters above ``max_cluster`` keep the anchor plus its most similar
+    members; the overflow stays available for a later pass.
     """
     from .embedder import HAS_NUMPY, blob_to_embedding, cosine_similarity_batch
 
@@ -140,6 +149,11 @@ def cluster_observations(
         ]
         if len(member_idx) < 1 + min_siblings:
             continue
+        if len(member_idx) > max_cluster:
+            member_idx = sorted(
+                member_idx, key=lambda j: (j != i, -sims[j])
+            )[:max_cluster]
+            member_idx.sort()
         for j in member_idx:
             assigned[j] = True
         clusters.append({
@@ -238,6 +252,7 @@ def synthesize_observations(
     min_age_days: int = DEFAULT_MIN_AGE_DAYS,
     min_siblings: int = DEFAULT_MIN_SIBLINGS,
     threshold: float = SIBLING_THRESHOLD,
+    max_cluster: int = MAX_CLUSTER,
     workspace: str | None = None,
     llm_url: str | None = None,
     llm_model: str | None = None,
@@ -258,7 +273,7 @@ def synthesize_observations(
 
     clusters, no_embedding = cluster_observations(
         conn, min_age_days=min_age_days, min_siblings=min_siblings,
-        threshold=threshold, workspace=workspace,
+        threshold=threshold, max_cluster=max_cluster, workspace=workspace,
     )
     planned = clusters[: max(0, cap)]
     report: dict = {
@@ -267,6 +282,7 @@ def synthesize_observations(
         "min_age_days": min_age_days,
         "min_siblings": min_siblings,
         "threshold": threshold,
+        "max_cluster": max_cluster,
         "clusters_found": len(clusters),
         "clusters_planned": len(planned),
         "candidates_without_embedding": no_embedding,

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -151,8 +151,27 @@ class TestClustering:
         assert no_emb == 1
         assert len(clusters) == 1
 
-    def test_threshold_default(self):
-        assert SIBLING_THRESHOLD == 0.35
+    def test_threshold_default_live_calibrated(self):
+        assert SIBLING_THRESHOLD == 0.65
+
+    def test_oversized_cluster_capped_keeps_anchor_and_most_similar(
+            self, in_memory_db):
+        conn = in_memory_db
+        anchor = _add_memory(conn, "anchor", _emb(1.0))
+        near = [_add_memory(conn, f"near {i}", _emb(1.0, 0.1))
+                for i in range(2)]
+        far = [_add_memory(conn, f"far {i}", _emb(1.0, 0.5))
+               for i in range(3)]
+        clusters, _ = cluster_observations(
+            conn, threshold=0.6, max_cluster=3)
+        assert len(clusters) == 1
+        ids = [m["memory_id"] for m in clusters[0]["members"]]
+        # anchor survives the cap; the closest members win the remaining slots
+        assert ids == [anchor, *near]
+        # overflow stays unassigned and regroups into its own cluster if it
+        # can — here the three far rows form one (anchor + 2 siblings fails
+        # min_siblings=3), so they were simply left for a later pass
+        assert all(f not in ids for f in far)
 
 
 class TestDryRun:


### PR DESCRIPTION
Part of #36. Follow-up to #106 caught during live verification on LXC 122: the 0.35 sibling threshold (tuned on synthetic pair measurements) chained dense early-harvest noise into a 209-member mega-cluster. Live dry runs at 0.45/0.55/0.65 show 0.65 produces coherent 4-15 member topic groups.

- `SIBLING_THRESHOLD` 0.35 -> 0.65 (rationale comment updated with the live calibration).
- New `--max-cluster` (default 20): hard per-cluster ceiling, keeps the anchor plus its most similar members; overflow stays unsuperseded and regroups on a later pass.

Gate: ruff clean, 769 tests pass (cap-behaviour test added). Live verify after merge: dry run on LXC 122 must show bounded clusters.