### PR TITLE
fix(synthesize): drop blank member tags from the consolidated learning

### DIFF
--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -209,7 +209,8 @@ def _cluster_tags(members: list[dict], limit: int = 8) -> list[str]:
     for m in members:
         try:
             for t in json.loads(m.get("tags") or "[]"):
-                if not t.startswith(_SUPERSEDED_PREFIX):
+                t = t.strip() if isinstance(t, str) else ""
+                if t and not t.startswith(_SUPERSEDED_PREFIX):
                     counts[t] = counts.get(t, 0) + 1
         except (TypeError, ValueError):
             continue

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -80,8 +80,8 @@ class TestHelpers:
 
     def test_cluster_tags_union_ranked_and_marked(self):
         members = [
-            {"tags": json.dumps(["aks", "azure", "superseded_by:9"])},
-            {"tags": json.dumps(["aks"])},
+            {"tags": json.dumps(["aks", "azure", "superseded_by:9", ""])},
+            {"tags": json.dumps(["aks", "  "])},
             {"tags": None},
         ]
         tags = _cluster_tags(members)


### PR DESCRIPTION
Part of #36. Caught on the first live `--run` (learning #1830 on LXC 122 inherited a "" tag from an old harvest row). `_cluster_tags` now strips and skips blank/non-string tags. Gate: ruff clean, suite green.