### PR TITLE
synthesize: bump SIBLING_THRESHOLD default to 0.75

### DIFF
--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -38,10 +38,13 @@ DEFAULT_MIN_AGE_DAYS = 7
 DEFAULT_MIN_SIBLINGS = 3
 # Live-calibrated on the prod embedder (embeddinggemma:300m) against the real
 # memory store: 0.35-0.55 chains dense early-harvest noise into 100+ member
-# mega-clusters; 0.65 yields coherent 4-15 member topic groups. Paraphrases
+# mega-clusters; 0.65 still cross-linked unrelated topics (one cluster mixed
+# neurostack-cloud, KPI-dashboard, AFD, firewall and Citrix observations) and
+# pulled credential-bearing rows along; 0.75 yields tight same-topic groups
+# whose live learnings read well (issue #111, run of 2026-08-23). Paraphrases
 # (~0.93) are handled earlier by harvest dedup — synthesis clusters are the
 # same-topic tier.
-SIBLING_THRESHOLD = 0.65
+SIBLING_THRESHOLD = 0.75
 # Hard per-cluster member ceiling: one learning cannot faithfully preserve the
 # facts of an unbounded heap, and the prompt must stay bounded. Oversized
 # clusters keep the anchor plus its most similar members; the rest stay

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -152,7 +152,7 @@ class TestClustering:
         assert len(clusters) == 1
 
     def test_threshold_default_live_calibrated(self):
-        assert SIBLING_THRESHOLD == 0.65
+        assert SIBLING_THRESHOLD == 0.75
 
     def test_oversized_cluster_capped_keeps_anchor_and_most_similar(
             self, in_memory_db):


### PR DESCRIPTION
Part of #111.

Bumps `SIBLING_THRESHOLD` 0.65 -> 0.75 and rewrites the calibration comment with the live evidence: 0.65 cross-linked unrelated topics (one cluster mixed neurostack-cloud, KPI-dashboard, AFD, firewall and Citrix observations) and pulled a credential-bearing memory along; 0.75 produced 10 tight clusters whose 5 live learnings (#1834-#1838, 23 observations superseded, ratio 1.15 -> 1.04) read well. Pinned-default test updated.

Gate: ruff clean, 778 tests pass.
