### PR TITLE
fix(redact): mask credential values in harvest and synthesize saves

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from .redact import redact_secrets
+
 log = logging.getLogger("neurostack")
 
 
@@ -784,6 +786,10 @@ def harvest_sessions(
         # Save classified insights
         for item in classified:
             summary = item.get("summary", _make_summary(item["text"]))
+            # Transcripts carry live credentials; a summary must never store one
+            # (issue #113). Redact BEFORE the dedup check so the stored form and
+            # the deduped form are the same string.
+            summary, redacted = redact_secrets(summary)
             etype = item.get("entity_type", item.get("prefilter_type", "observation"))
 
             if len(summary) < _MIN_LEN:
@@ -797,6 +803,8 @@ def harvest_sessions(
             ttl = {"context": 168.0, "observation": 720.0}.get(etype)
             record = {"content": summary, "entity_type": etype, "tags": tags,
                       "ttl_hours": ttl, "provider": session.provider}
+            if redacted:
+                record["redacted"] = redacted
 
             if _is_duplicate(conn, summary, etype, embed_url=url):
                 record["status"] = "skipped (duplicate)"

--- a/src/neurostack/redact.py
+++ b/src/neurostack/redact.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Mask value-shaped credentials before they reach unattended memory writes.
+
+Used by the harvest and synthesize save paths (issue #113), never by
+``save_memory`` itself: agent-written memories are deliberate, and silently
+rewriting them would corrupt intentional content. Machine-generated text —
+a transcript summary or a synthesized learning — has no such claim.
+
+Patterns match the SHAPE OF A VALUE, not a mention. `"the api key is wrong"`
+and the AWS documentation example `AKIAIOSFODNN7EXAMPLE` must survive; a real
+`AIzaSy…` or `nsk-…` must not. False positives here silently damage stored
+knowledge, so precision beats recall.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger("neurostack")
+
+# Marker left in place of a masked value. Keeps the sentence readable and makes
+# a redaction greppable after the fact.
+REDACTION_MARKER = "***REDACTED***"
+
+# Documented example keys that appear in real transcripts and carry no secret.
+_ALLOWLIST = frozenset({
+    "AKIAIOSFODNN7EXAMPLE",
+})
+
+# A `password=` right-hand side that is a REFERENCE, not a value: an env-var
+# interpolation, an all-caps env name, or a documentation placeholder. These are
+# the shapes that made the live sweep's `password` hits false positives.
+_PLACEHOLDER = re.compile(
+    r"""^(?:
+          [$%{<]                      # ${VAR}, %VAR%, {var}, <redacted>
+        | [A-Z][A-Z0-9_]*$            # BARE_ENV_NAME
+        | (?:your|my|the|some)[-_]     # your-password-here
+        | (?:os\.environ|process\.env|import\.meta\.env)
+    )""",
+    re.VERBOSE,
+)
+
+# Each pattern keeps its human-readable prefix and masks only the secret tail,
+# so the redacted text still says WHICH kind of credential was removed.
+_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("google-api-key", re.compile(r"AIza[0-9A-Za-z_\-]{30,}")),
+    ("neurostack-api-key", re.compile(r"nsk-[0-9A-Za-z_\-]{16,}")),
+    # `pk_live_…` is Stripe's PUBLISHABLE key — public by design, not redacted.
+    ("stripe-secret-key", re.compile(r"(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{16,}")),
+    ("github-token", re.compile(r"gh[pousr]_[0-9A-Za-z]{32,}")),
+    ("slack-token", re.compile(r"xox[baprs]-[0-9A-Za-z\-]{16,}")),
+    ("aws-access-key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("openai-key", re.compile(r"(?<![0-9A-Za-z_\-])sk-(?:proj-)?[0-9A-Za-z_\-]{32,}")),
+    ("jwt", re.compile(r"eyJ[0-9A-Za-z_\-]{10,}\.[0-9A-Za-z_\-]{10,}\.[0-9A-Za-z_\-]{10,}")),
+    ("private-key", re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.DOTALL,
+    )),
+    ("bearer-token", re.compile(r"(?<=Bearer )[0-9A-Za-z_\-\.]{24,}")),
+    # `password = "…"` / `password: …` — the assignment shape only. A bare
+    # mention of the word ("the password survived") never matches.
+    ("password-assignment", re.compile(
+        r"""(?<=password)(?P<sep>["']?\s*[:=]\s*["']?)(?P<value>[^\s"',;]{8,})""",
+        re.IGNORECASE | re.VERBOSE,
+    )),
+)
+
+
+def redact_secrets(text: str) -> tuple[str, list[str]]:
+    """Mask credential values in ``text``.
+
+    Returns the redacted text and the list of pattern names that fired, in
+    match order. An already-masked value is left alone: the marker contains no
+    characters any pattern accepts, so re-running this is a no-op.
+    """
+    if not text:
+        return text, []
+
+    kinds: list[str] = []
+
+    for name, pattern in _PATTERNS:
+        def _mask(match: re.Match[str], _name: str = name) -> str:
+            found = match.group(0)
+            if found in _ALLOWLIST:
+                return found
+            if _name == "password-assignment":
+                if _PLACEHOLDER.match(match.group("value")):
+                    return found
+                kinds.append(_name)
+                return match.group("sep") + REDACTION_MARKER
+            kinds.append(_name)
+            for prefix in ("AIza", "nsk-", "AKIA"):
+                if found.startswith(prefix):
+                    return prefix + REDACTION_MARKER
+            return REDACTION_MARKER
+
+        text = pattern.sub(_mask, text)
+
+    if kinds:
+        log.warning("Redacted %d credential value(s) before save: %s",
+                    len(kinds), ", ".join(sorted(set(kinds))))
+    return text, kinds

--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -308,6 +308,7 @@ def synthesize_observations(
         return report
 
     from .memories import save_memory, update_memory
+    from .redact import redact_secrets
 
     for cluster in planned:
         plan = _plan(cluster)
@@ -318,6 +319,12 @@ def synthesize_observations(
             plan["error"] = f"synthesis failed: {exc}"
             report["skipped"].append(plan)
             continue
+
+        # A learning inherits its members' text, so a credential left in an old
+        # observation would propagate into the new memory (issue #113).
+        learning, redacted = redact_secrets(learning)
+        if redacted:
+            plan["redacted"] = redacted
 
         try:
             memory = save_memory(

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,129 @@
+"""Tests for credential redaction in unattended memory writes (issue #113).
+
+The sweep that motivated this found two real leaks (a Firebase web key, an
+`nsk-` key) and fifteen false positives from a bare `password` word match — so
+these tests weight precision as heavily as recall. Every "survives" case below
+is a string that actually appeared in the live store.
+
+No fixture here is a real credential. Values are assembled at import time from
+harmless parts: a literal secret in a public repo would trip GitHub push
+protection, and pasting the very keys this module exists to erase would be
+self-defeating.
+"""
+
+from neurostack.redact import REDACTION_MARKER, redact_secrets
+
+# Same shape as the two values found in the live DB, none of their characters.
+FIREBASE_KEY = "AIza" + "Sy" + "B" * 33
+NSK_KEY = "nsk-" + "Q" * 43
+
+
+class TestSecretsMasked:
+    def test_google_api_key_keeps_prefix_drops_value(self):
+        out, kinds = redact_secrets(f"apiKey: {FIREBASE_KEY},")
+        assert FIREBASE_KEY not in out
+        assert out == f"apiKey: AIza{REDACTION_MARKER},"
+        assert kinds == ["google-api-key"]
+
+    def test_neurostack_key(self):
+        out, kinds = redact_secrets(f"export NEUROSTACK_API_KEY={NSK_KEY}")
+        assert NSK_KEY not in out
+        assert out.endswith(f"nsk-{REDACTION_MARKER}")
+        assert kinds == ["neurostack-api-key"]
+
+    def test_stripe_secret_and_restricted_keys(self):
+        out, kinds = redact_secrets(
+            "sk_" + "live_" + "9" * 24 + " and rk_" + "live_" + "9" * 24
+        )
+        assert "9" * 24 not in out
+        assert kinds == ["stripe-secret-key", "stripe-secret-key"]
+
+    def test_github_slack_openai_jwt_tokens(self):
+        secrets = [
+            "ghp_" + "a" * 36,
+            "xox" + "b-" + "1" * 12 + "-" + "c" * 24,
+            "sk-" + "proj-" + "b" * 40,
+            "eyJ" + "hbGciOiJIUzI1NiJ9." + "e" * 24 + "." + "f" * 24,
+        ]
+        for secret in secrets:
+            out, kinds = redact_secrets(f"token is {secret}")
+            assert secret not in out, secret
+            assert kinds, secret
+
+    def test_private_key_block_removed_whole(self):
+        text = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIEowIBAAKCAQEA1234\nabcd\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        out, kinds = redact_secrets(f"key:\n{text}\ndone")
+        assert "MIIEowIBAAKCAQEA1234" not in out
+        assert out == f"key:\n{REDACTION_MARKER}\ndone"
+        assert kinds == ["private-key"]
+
+    def test_bearer_token_masked_but_word_kept(self):
+        out, _ = redact_secrets("Authorization: Bearer abcdefghij0123456789ABCDEFGH")
+        assert "abcdefghij0123456789ABCDEFGH" not in out
+        assert "Bearer " in out
+
+    def test_password_assignment_masked(self):
+        out, kinds = redact_secrets('password = "hunter2-correct-horse"')
+        assert "hunter2-correct-horse" not in out
+        assert kinds == ["password-assignment"]
+
+    def test_multiple_kinds_in_one_text(self):
+        out, kinds = redact_secrets(f"{FIREBASE_KEY} then {NSK_KEY}")
+        assert FIREBASE_KEY not in out and NSK_KEY not in out
+        assert set(kinds) == {"google-api-key", "neurostack-api-key"}
+
+
+class TestNonSecretsSurvive:
+    def test_bare_mentions_untouched(self):
+        # Every one of these is a real live-store string the sweep flagged.
+        for text in [
+            "No Firebase API key in the build at all.",
+            "Firebase `auth/invalid-api-key` — the frontend config has the wrong key.",
+            "The commit reverted to hardcoding a password, an unnecessary regression.",
+            "apiKey: import.meta.env.VITE_FIREBASE_API_KEY,",
+            "VITE_FIREBASE_API_KEY=your-firebase-api-key",
+            "It checks `_cc.cloud_api_key` at line 1048.",
+            "password blacklist enforced at signup",
+        ]:
+            out, kinds = redact_secrets(text)
+            assert out == text, text
+            assert kinds == [], text
+
+    def test_password_references_are_not_values(self):
+        # `PASSWORD=${OPERATIONS_APP_PASSWORD}` is a real live-store line.
+        for text in [
+            "DB_PASSWORD=${OPERATIONS_APP_PASSWORD}",
+            "password=%DEPLOY_PASSWORD%",
+            "password: {password}",
+            "password = <redacted-by-ci>",
+            "password=your-password-here",
+            "password = os.environ['DB_PW']",
+            "PASSWORD=OPERATIONS_APP_PASSWORD",
+        ]:
+            out, kinds = redact_secrets(text)
+            assert out == text, text
+            assert kinds == [], text
+
+    def test_aws_documentation_example_allowlisted(self):
+        text = "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
+        out, kinds = redact_secrets(text)
+        assert out == text
+        assert kinds == []
+
+    def test_real_aws_key_still_masked(self):
+        out, kinds = redact_secrets("AKIA1234567890ABCDEF")
+        assert out == f"AKIA{REDACTION_MARKER}"
+        assert kinds == ["aws-access-key"]
+
+    def test_already_masked_text_is_a_noop(self):
+        text = f"apiKey: AIza{REDACTION_MARKER},"
+        out, kinds = redact_secrets(text)
+        assert out == text
+        assert kinds == []
+
+    def test_empty_text(self):
+        assert redact_secrets("") == ("", [])


### PR DESCRIPTION
Closes #113.

## What

Credential values no longer reach the two unattended memory write paths.

- New `neurostack.redact.redact_secrets(text) -> (text, kinds)`. Masks Google/Firebase API keys, `nsk-` keys, Stripe secret and restricted keys, GitHub, Slack, OpenAI, JWTs, PEM private-key blocks, `Bearer` tokens, AWS access keys, and `password=` assignments. Prefixes are kept (`AIza***REDACTED***`) so the text still says which kind of credential was removed.
- `harvest_sessions` redacts the summary **before** the dedup check, so the stored form and the deduped form are the same string.
- `synthesize_observations` redacts the generated learning before `save_memory` — a learning inherits its members' text, which is exactly how the two live leaks propagated.
- Both report what fired (`record["redacted"]` / `plan["redacted"]`).

`save_memory` is deliberately NOT touched. Agent-written memories are intentional; silently rewriting them would corrupt real content. Mirrors the harvest-only TTL precedent from #36.

## Precision over recall

False positives here permanently damage stored knowledge, so every pattern matches the shape of a value, not a mention. Cases taken verbatim from the live store that MUST survive:

- `No Firebase API key in the build at all.`
- `apiKey: import.meta.env.VITE_FIREBASE_API_KEY,`
- `The commit reverted to hardcoding a password, an unnecessary regression.`
- `AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE` (AWS's documented example, allowlisted)
- `DB_PASSWORD=${OPERATIONS_APP_PASSWORD}` (env reference, not a value)

An already-masked string is a no-op: the marker contains no character any pattern accepts.

## Live data cleaned

Sweep of `/root/.local/share/neurostack/neurostack.db` on LXC 122 found two real secrets across five rows: a Firebase web key in memories 98, 163 and learning 1841, and a full `nsk-` key in memory 217 and learning 1830. All masked in place with a `***REDACTED***` marker, then `neurostack backfill memories` re-embedded all five from the masked content. Post-check: 0 hits in `memories`, `memories_archive`, and `memories_fts`.

## Gate

`ruff check src/ tests/` clean. `pytest -q`: 791 passed (778 + 13 new in `tests/test_redact.py`, plus one added for the env-reference guard found in self-review). LSP diagnostics clean on all three touched files.
