### PR TITLE
Do not record the re-post guard for a zero-yield transcript

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -1028,7 +1028,12 @@ def harvest_transcript(
             saved=saved, skipped=skipped, counts=counts,
         )
 
-    if not dry_run:
+    # Record the digest only if the run actually yielded something. LLM
+    # classification is not deterministic (issue #117), so a zero-yield run may
+    # simply have been unlucky — leaving it unrecorded lets a client re-post and
+    # pick up what the classifier dropped, instead of the guard making that loss
+    # permanent.
+    if not dry_run and (saved or skipped):
         harvest_state[state_key] = digest
         _save_harvest_state(harvest_state)
 

--- a/src/neurostack/tools/session_tools.py
+++ b/src/neurostack/tools/session_tools.py
@@ -146,7 +146,8 @@ def vault_harvest_transcript(
     A large transcript must be split on NEWLINE boundaries and posted as
     several calls; each chunk is harvested independently and near-duplicate
     insights across chunks are dropped. Re-posting an identical transcript for
-    the same session_id is a no-op.
+    the same session_id is a no-op once it has yielded insights; a post that
+    yielded none stays re-postable.
 
     Args:
         transcript: Raw session transcript in source_agent's native format

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -835,3 +835,27 @@ class TestHarvestTranscript:
         assert "error" not in report
         assert report["messages"] == 0
         assert report["counts"] == {} and report["saved"] == []
+
+    def test_zero_yield_is_not_guarded(self, in_memory_db, tmp_path, monkeypatch):
+        # LLM classification is not deterministic (issue #117), so recording the
+        # digest after a run that kept nothing would make that loss permanent.
+        # A zero-yield post stays re-postable.
+        self._setup(in_memory_db, tmp_path, monkeypatch)
+        transcript = _claude_line("assistant", _BUG_INSIGHT) + "\n"
+        # Stand in for the model returning all-SKIP on a keepable candidate.
+        # Restored by hand rather than monkeypatch.undo(), which would also
+        # revert _setup's db and state-path patches.
+        import neurostack.harvest as harvest_mod
+        real_classify = harvest_mod._llm_classify
+        harvest_mod._llm_classify = lambda *a, **k: []
+        try:
+            empty = harvest_transcript(transcript, session_id="sess-1",
+                                       source_agent="claude-code", use_llm=True)
+        finally:
+            harvest_mod._llm_classify = real_classify
+        assert empty["counts"] == {} and empty["saved"] == []
+
+        retry = harvest_transcript(transcript, session_id="sess-1",
+                                   source_agent="claude-code", use_llm=False)
+        assert "note" not in retry
+        assert len(retry["saved"]) == 1


### PR DESCRIPTION
Part of #115. Found by live-verifying #116 against the deployed server.

`_llm_classify` is not deterministic: three consecutive runs over one omp session's ten pre-filtered candidates kept 5, then 0, then 0 (issue #117). The re-post guard recorded the transcript digest unconditionally, so a post whose classifier run happened to keep nothing was marked harvested and every later retry became a no-op — the insights a luckier run would have kept were lost for good.

The digest is now recorded only when the run yielded something. A zero-yield post stays re-postable, which is the behaviour a flaky classifier needs. Cost is bounded: a re-run only happens when a client posts the same transcript again.

Also corrects the tool docstring, which promised an unconditional no-op.

Gate: `uv run ruff check src/ tests/` exit 0; `uv run pytest -q` exit 0, 805 passed.
