### PR TITLE
Let the operator drop unused tools from the MCP surface

### DIFF
--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -50,6 +50,11 @@ class Config:
     api_host: str = "127.0.0.1"
     api_port: int = 8000
     api_key: str = ""
+    # Tools to keep out of the MCP surface. Every registered tool's schema is
+    # injected into every client session, so a tool nobody calls costs tokens on
+    # each turn and lengthens the menu the model chooses from. Names are the tool
+    # names as registered, e.g. ["vault_communities", "vault_checkpoint"].
+    disabled_tools: list[str] = field(default_factory=list)
     cooccurrence_boost_weight: float = 0.1
     # Link-section down-weighting (issue #41): a chunk that is mostly wiki-link
     # markup — ## Related blocks, index / map-of-content notes — is navigational,
@@ -172,6 +177,11 @@ def load_config() -> Config:
             cfg.embed_dim = int(data["embed_dim"])
         if "api_port" in data:
             cfg.api_port = int(data["api_port"])
+        if "disabled_tools" in data:
+            raw = data["disabled_tools"]
+            if isinstance(raw, str):
+                raw = [p for p in raw.replace(",", " ").split() if p]
+            cfg.disabled_tools = [str(t).strip() for t in raw if str(t).strip()]
         if "cooccurrence_boost_weight" in data:
             cfg.cooccurrence_boost_weight = float(data["cooccurrence_boost_weight"])
         if "link_section_penalty" in data:
@@ -254,6 +264,13 @@ def load_config() -> Config:
                 setattr(cfg, attr, val.lower() in ("1", "true", "yes"))
             else:
                 setattr(cfg, attr, typ(val))
+
+    # Comma- or space-separated, e.g. NEUROSTACK_DISABLED_TOOLS="vault_merge,vault_diff"
+    disabled_env = os.environ.get("NEUROSTACK_DISABLED_TOOLS")
+    if disabled_env is not None:
+        cfg.disabled_tools = [
+            p for p in disabled_env.replace(",", " ").split() if p
+        ]
 
     return cfg
 

--- a/src/neurostack/tools/mcp_adapter.py
+++ b/src/neurostack/tools/mcp_adapter.py
@@ -26,14 +26,26 @@ log = logging.getLogger("neurostack.tools.mcp_adapter")
 def create_mcp_server(name: str = "neurostack", **server_kwargs) -> MCPServer:
     """Create an MCPServer with all registry tools auto-registered.
 
+    Tools named in ``disabled_tools`` are left off the surface. Every registered
+    tool's schema is injected into every client session, so one nobody calls
+    costs tokens on every turn and lengthens the menu the model picks from.
+
     Args:
         name: MCP server name
         **server_kwargs: Passed through to the MCPServer constructor
     """
+    from ..config import get_config
+
     mcp = MCPServer(name, **server_kwargs)
     registry = ensure_registered()
+    disabled = set(get_config().disabled_tools)
+    skipped: list[str] = []
 
     for tool_def in registry.list_tools():
+        if tool_def.name in disabled:
+            skipped.append(tool_def.name)
+            continue
+
         @functools.wraps(tool_def.fn)
         async def wrapper(_td=tool_def, **kwargs):
             return await asyncio.to_thread(_td.call, **kwargs)
@@ -54,5 +66,15 @@ def create_mcp_server(name: str = "neurostack", **server_kwargs) -> MCPServer:
 
         mcp.add_tool(wrapper, annotations=mcp_annotations)
 
-    log.debug("Registered %d tools on MCP server %r", len(registry), name)
+    log.debug(
+        "Registered %d of %d tools on MCP server %r",
+        len(registry) - len(skipped), len(registry), name,
+    )
+    if skipped:
+        log.info("Tools disabled by config: %s", ", ".join(sorted(skipped)))
+    unknown = disabled - {t.name for t in registry.list_tools()}
+    if unknown:
+        log.warning(
+            "disabled_tools names no such tool: %s", ", ".join(sorted(unknown))
+        )
     return mcp

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -152,3 +152,63 @@ class TestFeedbackConfig:
             cfg = load_config()
         assert cfg.feedback_enabled is True
         assert cfg.feedback_window_seconds == 600.0
+
+
+class TestDisabledTools:
+    """Tools kept off the MCP surface (issue #122). Every registered tool's
+    schema is injected into every client session, so one nobody calls costs
+    tokens on each turn."""
+
+    def test_default_is_empty(self):
+        assert Config().disabled_tools == []
+
+    def test_toml_list(self, tmp_path):
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            'disabled_tools = ["vault_merge", "vault_diff"]\n'
+        )
+        with patch("neurostack.config.CONFIG_PATH", config_file):
+            cfg = load_config()
+        assert cfg.disabled_tools == ["vault_merge", "vault_diff"]
+
+    def test_toml_string_is_split(self, tmp_path):
+        # A hand-edited config is as likely to hold a string as a list.
+        config_file = tmp_path / "config.toml"
+        config_file.write_text('disabled_tools = "vault_merge, vault_diff"\n')
+        with patch("neurostack.config.CONFIG_PATH", config_file):
+            cfg = load_config()
+        assert cfg.disabled_tools == ["vault_merge", "vault_diff"]
+
+    def test_env_overrides_toml(self, tmp_path):
+        config_file = tmp_path / "config.toml"
+        config_file.write_text('disabled_tools = ["vault_merge"]\n')
+        env = {"NEUROSTACK_DISABLED_TOOLS": "vault_diff vault_checkpoint"}
+        with patch("neurostack.config.CONFIG_PATH", config_file), \
+                patch.dict(os.environ, env):
+            cfg = load_config()
+        assert cfg.disabled_tools == ["vault_diff", "vault_checkpoint"]
+
+    def test_adapter_omits_disabled_tool(self):
+        from neurostack.tools import ensure_registered
+        from neurostack.tools.mcp_adapter import create_mcp_server
+
+        registry = ensure_registered()
+        assert "vault_merge" in {t.name for t in registry.list_tools()}
+
+        cfg = Config()
+        cfg.disabled_tools = ["vault_merge"]
+        with patch("neurostack.config.get_config", lambda: cfg):
+            mcp = create_mcp_server(name="test-disabled")
+        names = {t.name for t in mcp._tool_manager.list_tools()}
+        assert "vault_merge" not in names
+        assert "vault_search" in names
+
+    def test_adapter_registers_everything_by_default(self):
+        from neurostack.tools import ensure_registered
+        from neurostack.tools.mcp_adapter import create_mcp_server
+
+        registry = ensure_registered()
+        cfg = Config()
+        with patch("neurostack.config.get_config", lambda: cfg):
+            mcp = create_mcp_server(name="test-all")
+        assert len(mcp._tool_manager.list_tools()) == len(registry.list_tools())


### PR DESCRIPTION
Closes #122.

## What

`disabled_tools` in `config.toml`, plus a `NEUROSTACK_DISABLED_TOOLS` env override, naming tools to leave off the MCP surface. `create_mcp_server` skips them when registering.

## Why

Every registered tool's schema is injected into every client session, so a tool nobody calls costs tokens on each turn and lengthens the menu the model picks from. Counting real calls across 48 local sessions, 12 of the 29 tools have never been called once — roughly 1.2k tokens of dead schema per session. Neither Claude Code nor omp exposes a per-tool MCP filter, so the choice has to live server-side.

## How

- `Config.disabled_tools: list[str]`, empty by default, so behaviour is unchanged for anyone who sets nothing.
- The TOML parser accepts a list or a string, since a hand-edited config is as likely to hold `"a, b"` as `["a", "b"]`.
- `NEUROSTACK_DISABLED_TOOLS` takes comma- or space-separated names and replaces the file value rather than merging, matching how every other env override in `load_config` behaves.
- The adapter logs which tools it skipped, and **warns on a name matching no tool** so a typo shows up in the log instead of silently disabling nothing.

## Gate

`uv run ruff check src/ tests/` exit 0. `uv run pytest -q` exit 0, **834 passed** (+6).

New tests cover the default staying empty, the TOML list, the TOML string being split, env beating TOML, the adapter omitting a disabled tool while keeping the rest, and the adapter registering everything when the list is empty.
