### PR TITLE
feat(init): auto-install automation hooks during neurostack init

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -85,6 +85,10 @@ def main():
         "--no-index", action="store_false", dest="index",
         help="Skip indexing after init",
     )
+    p.add_argument(
+        "--no-hooks", action="store_false", dest="hooks", default=True,
+        help="Skip automation hook setup (harvest timer + session hooks)",
+    )
     p.add_argument("--pull-models", action="store_true", default=False,
                    help="Pull Ollama models (full mode)")
     p.add_argument("--embed-model", help="Embedding model override")
@@ -822,12 +826,12 @@ def main():
     hooks_sub = p.add_subparsers(dest="hooks_command")
     hp = hooks_sub.add_parser("install", help="Install automation hooks")
     hp.add_argument("--type", default="harvest-timer",
-                    choices=["harvest-timer", "decay-timer"],
+                    choices=["harvest-timer", "decay-timer", "claude-hook"],
                     help="Hook type (default: harvest-timer)")
     hooks_sub.add_parser("status", help="Show hook status")
     rp = hooks_sub.add_parser("remove", help="Remove automation hooks")
     rp.add_argument("--type", default="harvest-timer",
-                    choices=["harvest-timer", "decay-timer"],
+                    choices=["harvest-timer", "decay-timer", "claude-hook"],
                     help="Hook type to remove (default: harvest-timer)")
     p.set_defaults(func=cmd_hooks)
 

--- a/src/neurostack/cli/sessions.py
+++ b/src/neurostack/cli/sessions.py
@@ -218,6 +218,14 @@ _DECAY_TIMER = {
     "on_calendar": "*-*-* 03:00:00",
 }
 
+_HARVEST_TIMER = {
+    "unit": "neurostack-harvest",
+    "service_desc": "NeuroStack harvest - extract session insights",
+    "exec": "%h/.local/bin/neurostack harvest --sessions 3",
+    "timer_desc": "Run neurostack harvest every hour",
+    "on_calendar": "hourly",
+}
+
 
 def _install_user_timer(spec):
     """Write and enable a systemd --user timer/service pair; return the timer path."""
@@ -282,50 +290,15 @@ def cmd_hooks(args):
     subcmd = getattr(args, "hooks_command", None)
 
     if subcmd == "install":
-        import subprocess
-
         hook_type = args.type or "harvest-timer"
 
         if hook_type == "harvest-timer":
-            # Create a systemd user timer for periodic harvest
-            timer_dir = Path.home() / ".config" / "systemd" / "user"
-            timer_dir.mkdir(parents=True, exist_ok=True)
-
-            service_content = (
-                "[Unit]\n"
-                "Description=NeuroStack harvest - extract session insights\n\n"
-                "[Service]\n"
-                "Type=oneshot\n"
-                "ExecStart=%h/.local/bin/neurostack harvest --sessions 3\n"
-                "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin\n"
-            )
-            timer_content = (
-                "[Unit]\n"
-                "Description=Run neurostack harvest every hour\n\n"
-                "[Timer]\n"
-                "OnCalendar=hourly\n"
-                "Persistent=true\n\n"
-                "[Install]\n"
-                "WantedBy=timers.target\n"
-            )
-
-            (timer_dir / "neurostack-harvest.service").write_text(service_content)
-            (timer_dir / "neurostack-harvest.timer").write_text(timer_content)
-
-            subprocess.run(
-                ["systemctl", "--user", "daemon-reload"],
-                check=False, capture_output=True,
-            )
-            subprocess.run(
-                ["systemctl", "--user", "enable", "--now", "neurostack-harvest.timer"],
-                check=False, capture_output=True,
-            )
-
+            timer_path = _install_user_timer(_HARVEST_TIMER)
             if args.json:
                 print(json.dumps({"installed": True, "type": hook_type}))
             else:
                 print(f"  \033[32m\u2713\033[0m Installed {hook_type}")
-                print(f"    Timer: {timer_dir / 'neurostack-harvest.timer'}")
+                print(f"    Timer: {timer_path}")
                 print("    Check: systemctl --user status neurostack-harvest.timer")
         elif hook_type == "decay-timer":
             timer_path = _install_user_timer(_DECAY_TIMER)
@@ -335,11 +308,30 @@ def cmd_hooks(args):
                 print(f"  \033[32m✓\033[0m Installed {hook_type}")
                 print(f"    Timer: {timer_path}")
                 print("    Check: systemctl --user status neurostack-decay.timer")
+        elif hook_type == "claude-hook":
+            from ..setup import _claude_settings_path, install_claude_session_hook
+
+            result = install_claude_session_hook()
+            if args.json:
+                print(json.dumps({"installed": result == "installed", "type": hook_type,
+                                  "result": result}))
+            elif result == "installed":
+                print(f"  \033[32m✓\033[0m Installed {hook_type}")
+                print(f"    Hook: SessionEnd in {_claude_settings_path()}")
+            elif result == "already":
+                print("  Claude Code SessionEnd hook already installed")
+            elif result == "not-detected":
+                print("  Claude Code not detected (~/.claude missing) — skipped")
+            else:
+                print("  \033[31m✗\033[0m neurostack binary not found on PATH"
+                      " or in ~/.local/bin — hook not installed")
         else:
             print(f"  Unknown hook type: {hook_type}")
 
     elif subcmd == "status":
         import subprocess
+
+        from ..setup import claude_session_hook_installed
 
         result = subprocess.run(
             ["systemctl", "--user", "is-active", "neurostack-harvest.timer"],
@@ -351,46 +343,43 @@ def cmd_hooks(args):
             capture_output=True, text=True,
         )
         decay_active = decay.stdout.strip() == "active"
+        claude_hook = claude_session_hook_installed()
         if args.json:
             print(json.dumps({
                 "harvest_timer": "active" if active else "inactive",
                 "decay_timer": "active" if decay_active else "inactive",
+                "claude_session_hook": "installed" if claude_hook else "absent",
             }))
         else:
             status = "\033[32mactive\033[0m" if active else "\033[31minactive\033[0m"
             d_status = "\033[32mactive\033[0m" if decay_active else "\033[31minactive\033[0m"
+            c_status = ("\033[32minstalled\033[0m" if claude_hook
+                        else "\033[31mabsent\033[0m")
             print(f"  harvest-timer: {status}")
             print(f"  decay-timer: {d_status}")
+            print(f"  claude-session-hook: {c_status}")
 
     elif subcmd == "remove":
-        import subprocess
-
         hook_type = getattr(args, "type", None) or "harvest-timer"
         if hook_type == "decay-timer":
             _remove_user_timer("neurostack-decay")
-            if args.json:
-                print(json.dumps({"removed": True, "type": hook_type}))
-            else:
-                print(f"  \033[32m✓\033[0m Removed {hook_type}")
-            return
+        elif hook_type == "claude-hook":
+            from ..setup import remove_claude_session_hook
 
-        subprocess.run(
-            ["systemctl", "--user", "disable", "--now", "neurostack-harvest.timer"],
-            check=False, capture_output=True,
-        )
-        timer_dir = Path.home() / ".config" / "systemd" / "user"
-        for f in ("neurostack-harvest.service", "neurostack-harvest.timer"):
-            p = timer_dir / f
-            if p.exists():
-                p.unlink()
-        subprocess.run(
-            ["systemctl", "--user", "daemon-reload"],
-            check=False, capture_output=True,
-        )
-        if args.json:
-            print(json.dumps({"removed": True}))
+            removed = remove_claude_session_hook()
+            if args.json:
+                print(json.dumps({"removed": removed, "type": hook_type}))
+            elif removed:
+                print(f"  \033[32m✓\033[0m Removed {hook_type}")
+            else:
+                print("  No Claude Code SessionEnd hook found")
+            return
         else:
-            print("  \033[32m\u2713\033[0m Removed harvest timer")
+            _remove_user_timer("neurostack-harvest")
+        if args.json:
+            print(json.dumps({"removed": True, "type": hook_type}))
+        else:
+            print(f"  \033[32m\u2713\033[0m Removed {hook_type}")
 
     else:
         print("Usage: neurostack hooks {install,status,remove}")

--- a/src/neurostack/cli/setup.py
+++ b/src/neurostack/cli/setup.py
@@ -391,6 +391,32 @@ def _full_index_pipeline(vault_root, cfg):
         print(f"  \033[33m!\033[0m Communities failed: {e}")
 
 
+def _install_automation_hooks():
+    """Install harvest timer + Claude Code session hook; print a summary."""
+    import shutil
+
+    from ..setup import install_claude_session_hook
+    from .sessions import _HARVEST_TIMER, _install_user_timer
+
+    print("\n  \033[1mAutomation hooks\033[0m")
+
+    if shutil.which("systemctl"):
+        timer_path = _install_user_timer(_HARVEST_TIMER)
+        print(f"  \033[32m✓\033[0m Harvest timer (hourly): {timer_path}")
+    else:
+        print("  - Harvest timer skipped (no systemd on this system)")
+
+    result = install_claude_session_hook()
+    if result == "installed":
+        print("  \033[32m✓\033[0m Claude Code SessionEnd hook installed")
+    elif result == "already":
+        print("  \033[32m✓\033[0m Claude Code SessionEnd hook already present")
+    elif result == "not-detected":
+        print("  - Claude Code not detected — session hook skipped")
+    else:
+        print("  \033[33m!\033[0m neurostack binary not found — session hook skipped")
+
+
 def cmd_init(args):
     """Initialize a new NeuroStack vault — one command to set up everything."""
     import platform
@@ -417,6 +443,9 @@ def cmd_init(args):
 
         if mode == "full" and args.index:
             _full_index_pipeline(vault_root, cfg)
+
+        if getattr(args, "hooks", True):
+            _install_automation_hooks()
 
         print("\n  \033[32m✓\033[0m Setup complete.")
         print("    neurostack search 'query' # Search")
@@ -540,6 +569,13 @@ def cmd_init(args):
             else:
                 embed_api_key = llm_api_key
 
+    # ── Step 6: Automation hooks ──
+    print()
+    install_hooks = getattr(args, "hooks", True) and _confirm(
+        "Install automation hooks? (harvest timer + session hooks)",
+        default=True,
+    )
+
     # ── Summary ──
     print("\n  \033[1m━━━ Plan ━━━\033[0m\n")
     print(f"  Mode:       {mode}")
@@ -556,6 +592,7 @@ def cmd_init(args):
         print("  Index:      full (summaries + triples + communities)")
     else:
         print("  Index:      lite (FTS5 only)")
+    print(f"  Hooks:      {'yes' if install_hooks else 'no'}")
 
     if not _confirm("\n  Proceed?", default=True):
         print("\n  Cancelled.")
@@ -591,6 +628,9 @@ def cmd_init(args):
     else:
         # Lite: create vault with FTS5-only index
         _do_init(vault_root, cfg, profession_name=profession, run_index=True)
+
+    if install_hooks:
+        _install_automation_hooks()
 
     # 4. PATH check
     local_bin = str(Path.home() / ".local" / "bin")

--- a/src/neurostack/setup.py
+++ b/src/neurostack/setup.py
@@ -139,6 +139,101 @@ def _merge_mcp_entry(config: dict, key: str, server_name: str, entry: dict) -> t
 
 
 # ---------------------------------------------------------------------------
+# Claude Code SessionEnd harvest hook
+# ---------------------------------------------------------------------------
+
+def _claude_settings_path() -> Path:
+    """Claude Code user settings file (hooks live here, not in .mcp.json)."""
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _resolve_neurostack_binary() -> str | None:
+    """Absolute path to the neurostack CLI, or None when not installed.
+
+    Hooks must never rely on PATH: the previous SessionEnd hook ran a bare
+    'neurostack' that was not on PATH and failed silently for weeks.
+    """
+    which = shutil.which("neurostack")
+    if which:
+        return which
+    local = Path.home() / ".local" / "bin" / "neurostack"
+    if local.exists():
+        return str(local)
+    return None
+
+
+def _session_hook_command(binary: str) -> str:
+    """Backgrounded harvest command that logs instead of vanishing."""
+    log = Path.home() / ".local" / "state" / "neurostack-hook.log"
+    return f"nohup {binary} harvest --sessions 1 >>{log} 2>&1 &"
+
+
+def claude_code_detected() -> bool:
+    """True when a Claude Code installation is present for this user."""
+    return (Path.home() / ".claude").is_dir()
+
+
+def claude_session_hook_installed() -> bool:
+    """True when a neurostack harvest SessionEnd hook is already configured."""
+    settings = _read_json(_claude_settings_path())
+    for matcher in settings.get("hooks", {}).get("SessionEnd", []):
+        for hook in matcher.get("hooks", []):
+            if "neurostack" in hook.get("command", "") and "harvest" in hook.get("command", ""):
+                return True
+    return False
+
+
+def install_claude_session_hook() -> str:
+    """Add a SessionEnd harvest hook to Claude Code settings.
+
+    Returns one of: 'installed', 'already', 'not-detected', 'no-binary'.
+    Idempotent: an existing neurostack harvest hook is left untouched.
+    """
+    if not claude_code_detected():
+        return "not-detected"
+    if claude_session_hook_installed():
+        return "already"
+    binary = _resolve_neurostack_binary()
+    if binary is None:
+        return "no-binary"
+
+    path = _claude_settings_path()
+    settings = _read_json(path)
+    session_end = settings.setdefault("hooks", {}).setdefault("SessionEnd", [])
+    session_end.append({
+        "hooks": [{"type": "command", "command": _session_hook_command(binary)}],
+    })
+    (Path.home() / ".local" / "state").mkdir(parents=True, exist_ok=True)
+    _write_json(path, settings)
+    return "installed"
+
+
+def remove_claude_session_hook() -> bool:
+    """Strip neurostack harvest SessionEnd hooks. Returns True if any removed."""
+    path = _claude_settings_path()
+    settings = _read_json(path)
+    session_end = settings.get("hooks", {}).get("SessionEnd")
+    if not session_end:
+        return False
+    removed = False
+    kept = []
+    for matcher in session_end:
+        hooks = [
+            h for h in matcher.get("hooks", [])
+            if not ("neurostack" in h.get("command", "") and "harvest" in h.get("command", ""))
+        ]
+        if len(hooks) != len(matcher.get("hooks", [])):
+            removed = True
+        if hooks or not matcher.get("hooks"):
+            matcher["hooks"] = hooks
+            kept.append(matcher)
+    if removed:
+        settings["hooks"]["SessionEnd"] = kept
+        _write_json(path, settings)
+    return removed
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -243,3 +243,100 @@ class TestSetupClient:
 
         captured = capsys.readouterr()
         assert "[dry-run]" in captured.out
+
+
+class TestClaudeSessionHook:
+    """install/remove/status for the Claude Code SessionEnd harvest hook."""
+
+    def _patched(self, tmp_path, binary="/opt/bin/neurostack"):
+        settings = tmp_path / ".claude" / "settings.json"
+        return (
+            patch("neurostack.setup._claude_settings_path", return_value=settings),
+            patch("neurostack.setup.claude_code_detected", return_value=True),
+            patch("neurostack.setup._resolve_neurostack_binary", return_value=binary),
+            patch("neurostack.setup.Path.home", return_value=tmp_path),
+            settings,
+        )
+
+    def test_install_creates_hook(self, tmp_path):
+        from neurostack.setup import install_claude_session_hook
+
+        p1, p2, p3, p4, settings = self._patched(tmp_path)
+        with p1, p2, p3, p4:
+            assert install_claude_session_hook() == "installed"
+        data = json.loads(settings.read_text())
+        cmd = data["hooks"]["SessionEnd"][0]["hooks"][0]["command"]
+        assert "/opt/bin/neurostack harvest --sessions 1" in cmd
+        assert cmd.startswith("nohup ")
+
+    def test_install_is_idempotent(self, tmp_path):
+        from neurostack.setup import install_claude_session_hook
+
+        p1, p2, p3, p4, settings = self._patched(tmp_path)
+        with p1, p2, p3, p4:
+            assert install_claude_session_hook() == "installed"
+            assert install_claude_session_hook() == "already"
+        data = json.loads(settings.read_text())
+        assert len(data["hooks"]["SessionEnd"]) == 1
+
+    def test_install_preserves_existing_hooks(self, tmp_path):
+        from neurostack.setup import install_claude_session_hook
+
+        p1, p2, p3, p4, settings = self._patched(tmp_path)
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({
+            "model": "opus",
+            "hooks": {"SessionEnd": [
+                {"hooks": [{"type": "command", "command": "echo bye"}]},
+            ]},
+        }))
+        with p1, p2, p3, p4:
+            assert install_claude_session_hook() == "installed"
+        data = json.loads(settings.read_text())
+        assert data["model"] == "opus"
+        assert len(data["hooks"]["SessionEnd"]) == 2
+        assert data["hooks"]["SessionEnd"][0]["hooks"][0]["command"] == "echo bye"
+
+    def test_install_without_claude_code(self, tmp_path):
+        from neurostack.setup import install_claude_session_hook
+
+        with patch("neurostack.setup.claude_code_detected", return_value=False):
+            assert install_claude_session_hook() == "not-detected"
+
+    def test_install_without_binary(self, tmp_path):
+        from neurostack.setup import install_claude_session_hook
+
+        p1, p2, p3, p4, settings = self._patched(tmp_path, binary=None)
+        with p1, p2, p3, p4:
+            assert install_claude_session_hook() == "no-binary"
+        assert not settings.exists()
+
+    def test_remove_strips_only_neurostack_hook(self, tmp_path):
+        from neurostack.setup import (
+            claude_session_hook_installed,
+            install_claude_session_hook,
+            remove_claude_session_hook,
+        )
+
+        p1, p2, p3, p4, settings = self._patched(tmp_path)
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({
+            "hooks": {"SessionEnd": [
+                {"hooks": [{"type": "command", "command": "echo bye"}]},
+            ]},
+        }))
+        with p1, p2, p3, p4:
+            install_claude_session_hook()
+            assert claude_session_hook_installed()
+            assert remove_claude_session_hook() is True
+            assert not claude_session_hook_installed()
+        data = json.loads(settings.read_text())
+        assert data["hooks"]["SessionEnd"][0]["hooks"][0]["command"] == "echo bye"
+        assert len(data["hooks"]["SessionEnd"]) == 1
+
+    def test_remove_when_absent(self, tmp_path):
+        from neurostack.setup import remove_claude_session_hook
+
+        p1, p2, p3, p4, _ = self._patched(tmp_path)
+        with p1, p2, p3, p4:
+            assert remove_claude_session_hook() is False


### PR DESCRIPTION
## What

`neurostack init` now sets up automation hooks by default: the hourly harvest timer and, when Claude Code is detected, a `SessionEnd` harvest hook in `~/.claude/settings.json`. `--no-hooks` skips both in non-interactive mode; the interactive wizard asks "Install automation hooks?" and shows the choice in the plan summary.

## How

- New helpers in `neurostack/setup.py` (`install_claude_session_hook`, `remove_claude_session_hook`, `claude_session_hook_installed`) reuse the existing `_read_json`/`_write_json` merge machinery and preserve unrelated settings and hooks.
- The hook command uses the resolved absolute binary path and appends to `~/.local/state/neurostack-hook.log` — a bare `neurostack` off PATH plus `>/dev/null` is exactly the silent failure mode the old hook had for weeks.
- `hooks install/remove --type claude-hook` added for parity; `hooks status` now reports the session hook. The inline harvest-timer install was refactored onto the existing `_install_user_timer` spec.
- Idempotent: re-running init detects an existing neurostack harvest hook and leaves `settings.json` with one entry.
- Codex and Gemini have no shell-command session-hook surface, so only Claude Code gets a session hook; other agents ride the timer.

## Gate

ruff clean; 841 tests pass locally (7 new in `tests/test_setup.py` covering install/idempotency/preservation/detection/removal).

## Live verify

Sandbox `$HOME` run of `neurostack init`: first run installs timer + hook, second run reports "already present" with one `SessionEnd` entry, `--no-hooks` installs nothing, and `hooks status` / `install --type claude-hook` / `remove --type claude-hook` round-trip correctly.

Part of #22
