### PR TITLE
fix(harvest): let the LLM judge every qualified message, not only keyword hits

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -734,8 +734,13 @@ def _llm_classify(
             response = re.sub(r"<think>.*?</think>", "", response, flags=re.DOTALL)
         except Exception as exc:
             log.warning("LLM classify failed: %s - falling back to regex", exc)
-            # Fallback: keep all candidates with regex classification
+            # Fallback: keep only keyword-hit candidates (issue #125 widened
+            # the batch to every qualified message; without a keyword type
+            # there is nothing to classify them as, and saving them all would
+            # turn one LLM outage into a hundred junk memories).
             for c in batch:
+                if not c["prefilter_type"]:
+                    continue
                 c["summary"] = _make_summary(c["text"])
                 c["entity_type"] = c["prefilter_type"]
                 results.append(c)
@@ -765,7 +770,7 @@ def _llm_classify(
                 if etype in valid:
                     c["entity_type"] = etype
                 else:
-                    c["entity_type"] = c["prefilter_type"]
+                    c["entity_type"] = c["prefilter_type"] or "observation"
                 c["summary"] = m.group(3).strip()
                 results.append(c)
 
@@ -812,6 +817,11 @@ def _harvest_messages(
 
     candidates = []
 
+    # The keyword prefilter gates only the regex paths. With an LLM available
+    # every qualified message is a candidate: measured on a real 167-message
+    # session, the keyword gate passed 0 of 145 length-qualified messages, so
+    # whole sessions never reached the classifier (issue #125). The keyword
+    # hit survives as a type hint the LLM path falls back on.
     for msg in messages:
         if not msg.text or len(msg.text) < _MIN_LEN:
             continue
@@ -820,7 +830,7 @@ def _harvest_messages(
             continue
 
         prefilter_type = _prefilter_classify(msg.text, msg.role)
-        if not prefilter_type:
+        if not prefilter_type and not use_llm:
             continue
 
         candidates.append({

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -606,6 +606,58 @@ class TestLlmClassify:
         assert out == []
         assert "dropped unclassified" not in caplog.text
 
+    def test_invalid_type_without_keyword_hint_becomes_observation(self, monkeypatch):
+        # Issue #125: candidates without a keyword hit carry prefilter_type None.
+        self._stub_llm(monkeypatch, "[1] KEEP type=wat summary=Something worth keeping")
+        candidates = [{"text": "x" * 50, "role": "assistant", "prefilter_type": None}]
+        out = _llm_classify(candidates, "http://llm.test", "model")
+        assert out[0]["entity_type"] == "observation"
+
+    def test_llm_failure_keeps_only_keyword_hits(self, monkeypatch):
+        # One LLM outage must not save every widened candidate as a memory.
+        import httpx
+
+        def _boom(*a, **k):
+            raise httpx.ConnectError("down")
+
+        monkeypatch.setattr(httpx, "post", _boom)
+        cfg = SimpleNamespace(llm_api_key=None)
+        monkeypatch.setattr("neurostack.config.get_config", lambda: cfg)
+        monkeypatch.setattr("neurostack.config._auth_headers", lambda _key: {})
+        candidates = [
+            {"text": "The root cause was a stale cache entry in the loader.",
+             "role": "assistant", "prefilter_type": "bug"},
+            {"text": "Cloning the repository now and reading the layout.",
+             "role": "assistant", "prefilter_type": None},
+        ]
+        out = _llm_classify(candidates, "http://llm.test", "model")
+        assert [c["entity_type"] for c in out] == ["bug"]
+
+
+class TestPrefilterRecall:
+    """Issue #125: with an LLM the keyword gate is a hint, not a filter."""
+
+    _PLAIN = "Cloning the website repo now and reading the Svelte layout for you."
+
+    def test_llm_sees_messages_without_keywords(self, in_memory_db, tmp_path, monkeypatch):
+        import neurostack.harvest as harvest_mod
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        seen = []
+        real = harvest_mod._llm_classify
+        harvest_mod._llm_classify = lambda cands, *a, **k: seen.extend(cands) or []
+        try:
+            harvest_transcript(_claude_line("assistant", self._PLAIN) + "\n",
+                               session_id="s", source_agent="claude-code", use_llm=True)
+        finally:
+            harvest_mod._llm_classify = real
+        assert [c["prefilter_type"] for c in seen] == [None]
+
+    def test_regex_path_still_gated_by_keywords(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        report = harvest_transcript(_claude_line("assistant", self._PLAIN) + "\n",
+                                    session_id="s", source_agent="claude-code", use_llm=False)
+        assert report["saved"] == [] and report["counts"] == {}
+
 
 # ---------------------------------------------------------------------------
 # harvest_sessions — per-type TTL on harvest-created memories (issue #36)


### PR DESCRIPTION
## What

With an LLM available, harvest now sends every length-qualified message to the classifier. The keyword prefilter no longer gates candidates; its hit survives only as a type hint.

## Why

Measured on a real 167-message omp session: 145 messages passed the length check, 0 matched the keyword patterns, so the classifier never saw the session. A 15-session nightly re-post made one LLM call in total.

## How

- `_harvest_messages`: skip on no-keyword only when `use_llm` is False.
- `_llm_classify`: invalid type with no hint falls back to `observation`; the LLM-failure fallback keeps keyword hits only, so an outage cannot save a hundred unclassified messages.
- Regex-only paths unchanged.

## Gate

ruff clean; 88 harvest tests pass (4 new: no-hint type fallback, outage keeps keyword hits only, LLM sees keyword-free messages, regex path still gated).

## Live verify

Same 167-message session, dry run against gemma4-e4b-text (16k ctx) from the branch: 0 → 71 would-save in 119 s, 0 dedup skips.

Known, out of scope (#117 family): some batches still partially answered ("answered 1 of 10"), and precision is loose (a few KEEPs are narration). Now measurable because recall exists.

Part of #125
