### PR TITLE
docs: reposition NeuroStack as a RAG layer and optimizer for a knowledge base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # NeuroStack - Claude Code Guide
 
-NeuroStack is a neuroscience-grounded knowledge management system. CLI + MCP server + OpenAI-compatible API. Everything runs locally against a Markdown vault indexed in SQLite + FTS5.
+NeuroStack is a local RAG layer and optimizer for a Markdown knowledge base. CLI + MCP server + OpenAI-compatible API. It indexes the vault into SQLite + FTS5 with embeddings and a link graph, serves grounded answers to any AI client, and keeps the base sharp: stale-note detection, session harvesting into memories, synthesis, and promotion of proven memories into notes. Ranking heuristics borrow from memory neuroscience (docs/neuroscience-appendix.md); that is implementation detail, not the pitch.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 [![CI](https://github.com/raphasouthall/neurostack/actions/workflows/ci.yml/badge.svg)](https://github.com/raphasouthall/neurostack/actions/workflows/ci.yml)
 [![MCP](https://img.shields.io/badge/MCP-24%20tools-green)](https://modelcontextprotocol.io)
 
-**Not a note-taking app. A memory layer for the notes you already have.**
+**A local RAG layer and optimizer for the Markdown knowledge base you already have.**
 
-Your AI assistant forgets everything when the conversation ends. You ask it about the paper you summarised last week — it has no idea. You ask it to continue the chapter outline you built together — it starts from scratch.
+Your AI assistant forgets everything when the conversation ends. You ask it about the paper you summarised last week and it has no idea. You ask it to continue the chapter outline you built together and it starts from scratch.
 
-And even when it does find your notes, it might find the wrong version. The thesis argument you reversed, the runbook endpoint you deprecated, the decision you made in April that you overturned in June. It cites these confidently. It has no idea they're wrong.
+And when it does find your notes, it may find the wrong version. The thesis argument you reversed, the runbook endpoint you deprecated, the decision you made in April that you overturned in June. It cites these confidently. It has no idea they are wrong.
 
-NeuroStack reads your existing Markdown notes — from Obsidian, Logseq, Notion exports, or any folder of `.md` files — indexes them into a searchable knowledge graph, and connects that graph to your AI. It detects when notes have gone stale before your AI cites them. Indexing never modifies your files; optional MCP write tools let an AI client author or edit notes through your git history when you want it to.
+NeuroStack does two jobs. **RAG**: it indexes your existing Markdown notes (Obsidian, Logseq, Notion exports, any folder of `.md` files) into a searchable knowledge graph and serves grounded, cited answers to any MCP-capable AI client. **Optimizer**: it keeps that base sharp over time. It flags stale notes before your AI cites them, harvests decisions and root causes from your AI sessions into memories, synthesises recurring memories into learnings, and queues the proven ones for promotion into notes. Indexing never modifies your files; optional MCP write tools let an AI client author or edit notes through your git history when you want it to.
 
 ```bash
 npm install -g neurostack && neurostack init

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neurostack",
   "version": "0.19.0",
-  "description": "Build, maintain, and search your knowledge vault with AI",
+  "description": "Local RAG layer and optimizer for your Markdown knowledge base. CLI + MCP server: grounded answers for any AI client, stale-note detection, session harvesting.",
   "bin": {
     "neurostack": "bin/neurostack.js",
     "ns": "bin/neurostack.js"
@@ -20,7 +20,9 @@
     "fts5",
     "semantic-search",
     "knowledge-graph",
-    "neuroscience",
+    "knowledge-base",
+    "retrieval-augmented-generation",
+    "local-first",
     "cli"
   ],
   "author": "Raphael Southall",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "neurostack"
 version = "0.19.0"
-description = "Build, maintain, and search your knowledge vault. CLI + MCP server with stale note detection, semantic search, and neuroscience-grounded memory."
+description = "Local RAG layer and optimizer for your Markdown knowledge base. CLI + MCP server: grounded answers for any AI client, stale-note detection, session harvesting."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [
     { name = "Raphael Southall" },
 ]
-keywords = ["knowledge-management", "obsidian", "mcp", "neuroscience", "pkm", "zettelkasten", "rag", "local-first", "knowledge-graph", "semantic-search", "ai-memory", "second-brain"]
+keywords = ["knowledge-base", "rag", "retrieval-augmented-generation", "mcp", "obsidian", "local-first", "knowledge-graph", "semantic-search", "ai-memory", "stale-detection", "pkm", "zettelkasten"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/src/neurostack/__init__.py
+++ b/src/neurostack/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024-2026 Raphael Southall
-"""NeuroStack — AI-provider-agnostic, neuroscience-grounded knowledge management."""
+"""NeuroStack — local RAG layer and optimizer for a Markdown knowledge base."""
 
 __version__ = "0.19.0"


### PR DESCRIPTION
Drops the second-brain framing from README, pyproject, npm package,
package docstring and CLAUDE.md. Neuroscience stays as implementation
detail in docs/neuroscience-appendix.md, not the pitch. GitHub repo
description and topics updated to match.
