### PR TITLE
feat(memories): trigger tags (when-editing / when-calling / when-error)

### DIFF
--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -301,3 +301,32 @@ def vault_promotion_queue(
         uncovered_sim_floor=uncovered_sim_floor,
         uncovered_limit=uncovered_limit,
     )
+
+
+@registry.tool(tags=["memory", "read"], annotations=_READ_ONLY)
+def vault_triggers(
+    event: str,
+    value: str,
+    workspace: str = None,
+    limit: int = 10,
+) -> dict:
+    """Memories whose trigger tag matches the current moment (issue #131).
+
+    A trigger is a tag with one of three prefixes: 'when-editing:<glob>'
+    (file path of an Edit/Write), 'when-calling:<tool>' (tool name),
+    'when-error:<substring>' (tool error text). Harness hooks call this on
+    tool events and inject the hits; the caller owns once-per-session
+    suppression. Pure read; untagged memories are never returned.
+
+    Args:
+        event: One of "editing", "calling", "error"
+        value: The path, tool name, or error text to match against
+        workspace: Optional vault subdirectory scope
+        limit: Max hits, newest first (default 10)
+    """
+    from ..schema import DB_PATH, get_db
+    from ..triggers import match_triggers
+
+    conn = get_db(DB_PATH)
+    hits = match_triggers(conn, event, value, workspace=workspace, limit=limit)
+    return {"event": event, "value": value, "hits": hits, "count": len(hits)}

--- a/src/neurostack/triggers.py
+++ b/src/neurostack/triggers.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Trigger tags (issue #131): memories that surface when they apply.
+
+A trigger is an ordinary tag with one of three prefixes. It says WHEN a memory
+should be shown, not what it is about:
+
+- ``when-editing:<glob>``     matched against the path of an Edit/Write
+- ``when-calling:<tool>``     matched against a tool name (case-insensitive)
+- ``when-error:<substring>``  matched against tool error text (case-insensitive)
+
+No schema change: triggers live in ``memories.tags``. Matching is a pure read.
+Per-session "fire once" suppression belongs to the client (the harness hook),
+because the server has no notion of a harness session per tool call.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import sqlite3
+
+TRIGGER_EVENTS = ("editing", "calling", "error")
+_PREFIX = "when-"
+
+
+def parse_trigger(tag: str) -> tuple[str, str] | None:
+    """Return ``(event, value)`` for a well-formed trigger tag, else None.
+
+    Malformed prefixes (``when-writing:x``, ``when-editing:``) are plain tags.
+    """
+    if not isinstance(tag, str) or not tag.startswith(_PREFIX):
+        return None
+    head, sep, value = tag[len(_PREFIX):].partition(":")
+    if not sep or head not in TRIGGER_EVENTS or not value:
+        return None
+    return head, value
+
+
+def _match(event: str, pattern: str, value: str) -> bool:
+    if event == "editing":
+        # fnmatch's ``*`` spans ``/``, so ``**`` needs no special casing.
+        if fnmatch.fnmatch(value, pattern):
+            return True
+        return not pattern.startswith("/") and fnmatch.fnmatch(value, "*/" + pattern)
+    if event == "calling":
+        return value.lower() == pattern.lower()
+    if event == "error":
+        return pattern.lower() in value.lower()
+    return False
+
+
+def match_triggers(
+    conn: sqlite3.Connection,
+    event: str,
+    value: str,
+    workspace: str | None = None,
+    limit: int = 10,
+) -> list[dict]:
+    """Memories whose ``when-<event>:`` trigger matches ``value``.
+
+    Newest first. Expired memories are excluded; untagged memories are never
+    touched (the SQL prefilter only sees rows containing the prefix).
+    """
+    if event not in TRIGGER_EVENTS or not value:
+        return []
+    sql = (
+        "SELECT memory_id, content, tags, entity_type, workspace, created_at"
+        " FROM memories"
+        " WHERE COALESCE(tags, '') LIKE ?"
+        " AND (expires_at IS NULL OR expires_at > datetime('now'))"
+    )
+    params: list = [f"%{_PREFIX}{event}:%"]
+    if workspace:
+        ws = workspace.strip("/")
+        sql += " AND (workspace = ? OR workspace LIKE ? || '/%')"
+        params.extend([ws, ws])
+    sql += " ORDER BY created_at DESC"
+
+    out: list[dict] = []
+    for row in conn.execute(sql, params):
+        try:
+            tags = json.loads(row["tags"]) or []
+        except (json.JSONDecodeError, TypeError):
+            continue
+        hit = None
+        for tag in tags:
+            parsed = parse_trigger(tag)
+            if parsed and parsed[0] == event and _match(event, parsed[1], value):
+                hit = tag
+                break
+        if hit is None:
+            continue
+        out.append({
+            "memory_id": row["memory_id"],
+            "content": row["content"],
+            "entity_type": row["entity_type"],
+            "workspace": row["workspace"],
+            "trigger": hit,
+            "created_at": row["created_at"],
+        })
+        if len(out) >= limit:
+            break
+    return out

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for trigger tags (issue #131)."""
+
+import json
+
+import pytest
+
+from neurostack import config as nsconfig
+from neurostack.triggers import match_triggers, parse_trigger
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db()
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _add_memory(conn, content, tags=None, workspace=None, expires_at=None):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, tags, workspace, expires_at)"
+        " VALUES (?, 'learning', ?, ?, ?)",
+        (content, json.dumps(tags) if tags is not None else None, workspace, expires_at),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def test_parse_trigger_accepts_three_prefixes_only():
+    assert parse_trigger("when-editing:src/**/*.ts") == ("editing", "src/**/*.ts")
+    assert parse_trigger("when-calling:vault_write_file") == ("calling", "vault_write_file")
+    assert parse_trigger("when-error:bastion-unavailable") == ("error", "bastion-unavailable")
+    # Non-goal and malformed shapes are plain tags.
+    assert parse_trigger("when-writing:loop-with-bound") is None
+    assert parse_trigger("when-editing:") is None
+    assert parse_trigger("when-editing") is None
+    assert parse_trigger("promotion-debt") is None
+    assert parse_trigger(None) is None
+
+
+def test_editing_glob_matches_absolute_path(db):
+    mid = _add_memory(db, "never bump row_version server-side",
+                      tags=["when-editing:strake/src/**/*.ts"])
+    hits = match_triggers(db, "editing", "/home/r/strake/src/svc/vessel.ts")
+    assert [h["memory_id"] for h in hits] == [mid]
+    assert hits[0]["trigger"] == "when-editing:strake/src/**/*.ts"
+    assert match_triggers(db, "editing", "/home/r/strake/test/vessel.test.ts") == []
+    assert match_triggers(db, "editing", "/home/r/other/src/x.ts") == []
+
+
+def test_calling_matches_tool_name_case_insensitive(db):
+    mid = _add_memory(db, "vault_write_file commits and pushes",
+                      tags=["when-calling:vault_write_file"])
+    assert [h["memory_id"] for h in match_triggers(db, "calling", "Vault_Write_File")] == [mid]
+    assert match_triggers(db, "calling", "vault_read_file") == []
+
+
+def test_error_matches_substring_of_error_text(db):
+    mid = _add_memory(db, "use ssh-proxy-chain when bastion is down",
+                      tags=["when-error:bastion-unavailable"])
+    text = "az network bastion ssh: ERROR Bastion-Unavailable (503) retry later"
+    assert [h["memory_id"] for h in match_triggers(db, "error", text)] == [mid]
+    assert match_triggers(db, "error", "connection refused") == []
+
+
+def test_untagged_expired_and_wrong_event_are_ignored(db):
+    _add_memory(db, "plain memory mentioning when-calling:x in content", tags=None)
+    _add_memory(db, "plain tags", tags=["notes", "when-writing:loop"])
+    _add_memory(db, "expired trigger", tags=["when-calling:x"],
+                expires_at="2000-01-01T00:00:00+00:00")
+    _add_memory(db, "other event", tags=["when-editing:x"])
+    assert match_triggers(db, "calling", "x") == []
+    assert match_triggers(db, "bogus", "x") == []
+    assert match_triggers(db, "calling", "") == []
+
+
+def test_workspace_scope_and_limit(db):
+    a = _add_memory(db, "a", tags=["when-calling:t"], workspace="home/projects/neurostack")
+    b = _add_memory(db, "b", tags=["when-calling:t"], workspace="work/other")
+    hits = match_triggers(db, "calling", "t", workspace="home/projects")
+    assert [h["memory_id"] for h in hits] == [a]
+    assert len(match_triggers(db, "calling", "t")) == 2
+    assert len(match_triggers(db, "calling", "t", limit=1)) == 1
+    assert b  # created
+
+
+def test_vault_remember_stores_trigger_tags_verbatim(db):
+    from neurostack.memories import save_memory
+
+    m = save_memory(db, content="trigger via public path",
+                    tags=["when-calling:vault_write_file", "when-bogus:x"])
+    row = db.execute("SELECT tags FROM memories WHERE memory_id = ?", (m.memory_id,)).fetchone()
+    tags = json.loads(row["tags"])
+    assert "when-calling:vault_write_file" in tags
+    assert "when-bogus:x" in tags
+    hits = match_triggers(db, "calling", "vault_write_file")
+    assert [h["memory_id"] for h in hits] == [m.memory_id]


### PR DESCRIPTION
Part of #131

## What

Trigger tags: a memory tagged `when-editing:<glob>`, `when-calling:<tool>` or `when-error:<substring>` surfaces at the moment it applies, instead of waiting for a lucky search.

## How

- `triggers.py`: `parse_trigger` accepts the three prefixes only; anything else stays a plain tag. `match_triggers` is a pure read over `memories.tags` (SQL prefix prefilter with `COALESCE(tags,'')`, then Python matching: fnmatch for paths, case-insensitive equality for tool names, case-insensitive substring for error text). Expired rows excluded. No schema change.
- New MCP tool `vault_triggers(event, value, workspace, limit)`.
- Once-per-session suppression lives in the harness hook (omp extension `neurostack-brief.ts`, outside this repo): `tool_call` blocks the first matching call once and returns the memories as the reason; `tool_result` appends error-trigger hits to failed results.

## Gate

`uv run ruff check src/ tests/` clean. `uv run pytest -q`: 855 passed. `tests/test_triggers.py` covers the 6 acceptance cases from #131 (glob on absolute path, tool name case-insensitive, error substring, untagged/expired/wrong-event ignored, workspace + limit, `save_memory` stores trigger tags verbatim).

## Non-goals

Content-pattern triggers (`when-writing:*`), confidence scores, background observer.
