### PR TITLE
feat(harvest): emit trigger tags for corrections and error-then-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **#135 — harvest emits trigger tags.** Providers stamp each transcript message with the tool call, path and failed result that preceded it; the classifier sees that context and may return a `trigger` field, which harvest normalises and saves as a `when-*` tag. A malformed value is dropped with one log line and the memory still saves. Regex fallback emits none.
+
+- **#131 — trigger tags.** A memory tagged `when-editing:<glob>`, `when-calling:<tool>` or `when-error:<substring>` surfaces at the moment it applies. New `triggers.py` and MCP `vault_triggers(event, value)`; no schema change, per-session fire-once lives in the client hook.
+
 - **#92 — promotion queue.** `neurostack promote` + MCP `vault_promotion_queue`: a deterministic worklist of memories whose knowledge should move into vault notes, in four buckets — `debt` (tagged `promotion-debt`), `drift` (unresolved memory-drift rows), `dead_handoffs` (stale context memories that read as handoffs; `open-thread` tag exempts), `uncovered` (durable memories whose nearest note chunk is below a similarity floor). Pure local compute, no LLM, no writes. `vault_session_end` now returns a soft `promotion_debt_warning` when a session wrote durable memories but no note changed while it ran.
 
 - **#90 — archive-on-forget.** Every memory delete path (`vault_forget`/`memories forget`, merge source, TTL expiry, prune) now moves the row to a `memories_archive` table instead of destroying it. Archived rows are outside search/FTS/drift by construction but stay greppable and restorable. New CLI: `neurostack memories archived [-w] [--limit N]` and `neurostack memories restore ID` (restored rows re-embed via `backfill memories`). `memories stats` gains `archived`; MCP `vault_forget` result carries `archived: true`.

--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -82,9 +82,83 @@ class SessionFile:
 
 @dataclass
 class Message:
-    """A single extracted message from a session transcript."""
+    """A single extracted message from a session transcript.
+
+    ``prev_*`` carry the tool context that preceded this message (issue #135):
+    the last tool the assistant called, the path that call targeted, and the
+    first line of the most recent failed tool result. The classifier uses them
+    to attach a trigger to a user correction or an error-then-fix.
+    """
     role: str  # "user" or "assistant"
     text: str
+    prev_tool: str | None = None
+    prev_path: str | None = None
+    prev_error: str | None = None
+
+
+# A failed tool result stays attached to this many following messages: the fix
+# usually lands in the next assistant turn, sometimes one or two later.
+_ERROR_CONTEXT_MESSAGES = 3
+_PATH_KEYS = ("file_path", "filePath", "path", "notebook_path")
+_HASHLINE_HEADER = re.compile(r"^\[([^\]#]+)#[0-9A-Fa-f]{4}\]", re.MULTILINE)
+
+
+class _ToolContext:
+    """Rolling tool state a provider stamps onto each message it emits."""
+
+    def __init__(self) -> None:
+        self.tool: str | None = None
+        self.path: str | None = None
+        self.error: str | None = None
+        self._error_left = 0
+
+    def call(self, name, args) -> None:
+        if not isinstance(name, str) or not name:
+            return
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except (json.JSONDecodeError, ValueError):
+                args = {}
+        if not isinstance(args, dict):
+            args = {}
+        path = next((args[k] for k in _PATH_KEYS if isinstance(args.get(k), str)), None)
+        if path is None and isinstance(args.get("input"), str):
+            # omp hashline edits name the file in a ``[path#TAG]`` header.
+            m = _HASHLINE_HEADER.search(args["input"])
+            path = m.group(1) if m else None
+        # Claude Code exposes MCP tools as ``mcp__<server>__<tool>``; omp routes
+        # them through ``write`` to ``xd://mcp__<server>_<tool>``. Record the
+        # name the harness would report for the call, minus the MCP plumbing.
+        if path and path.startswith("xd://"):
+            name = path[len("xd://"):].removeprefix("mcp__")
+        elif name.startswith("mcp__") and "__" in name[5:]:
+            name = name.rsplit("__", 1)[1]
+        self.tool, self.path = name, path
+
+    def result(self, is_error, content) -> None:
+        if not is_error:
+            return
+        if isinstance(content, list):
+            content = "\n".join(
+                p["text"] for p in content
+                if isinstance(p, dict) and isinstance(p.get("text"), str)
+            )
+        if not isinstance(content, str):
+            return
+        first = next((ln.strip() for ln in content.splitlines() if ln.strip()), "")
+        if first:
+            self.error = first[:200]
+            self._error_left = _ERROR_CONTEXT_MESSAGES
+
+    def stamp(self, msg: Message) -> Message:
+        msg.prev_tool, msg.prev_path = self.tool, self.path
+        if self._error_left > 0:
+            msg.prev_error = self.error
+            self._error_left -= 1
+        else:
+            self.error = None
+        return msg
 
 
 class SessionProvider(Protocol):
@@ -125,13 +199,25 @@ class ClaudeCodeProvider:
 
     def extract_messages(self, path: Path) -> list[Message]:
         messages = []
+        ctx = _ToolContext()
         for entry in _parse_jsonl(path):
             role = entry.get("message", {}).get("role", entry.get("type", ""))
             if role not in ("assistant", "user"):
                 continue
             text = _extract_text_claude(entry)
             if text:
-                messages.append(Message(role=role, text=text))
+                messages.append(ctx.stamp(Message(role=role, text=text)))
+            # Observe this entry's tool blocks AFTER stamping: ``prev_*`` means
+            # what came before the message, not what it did itself.
+            content = entry.get("message", {}).get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "tool_use":
+                        ctx.call(block.get("name"), block.get("input"))
+                    elif block.get("type") == "tool_result":
+                        ctx.result(block.get("is_error"), block.get("content"))
         return messages
 
 
@@ -407,6 +493,7 @@ class OmpProvider:
 
     def extract_messages(self, path: Path) -> list[Message]:
         messages = []
+        ctx = _ToolContext()
         for entry in _parse_jsonl(path):
             if entry.get("type") != "message":
                 continue
@@ -414,23 +501,33 @@ class OmpProvider:
             if not isinstance(msg, dict):
                 continue
             role = msg.get("role", "")
+            content = msg.get("content")
+            if role == "toolResult":
+                ctx.result(msg.get("isError"), content)
+                continue
             if role not in ("assistant", "user"):
                 continue
-            content = msg.get("content")
+            calls = []
             if isinstance(content, str):
                 text = content
             elif isinstance(content, list):
-                # Only "text" parts — "thinking" and "toolCall" parts are noise.
-                parts = [
-                    p["text"] for p in content
-                    if isinstance(p, dict) and p.get("type") == "text"
-                    and isinstance(p.get("text"), str)
-                ]
+                # Only "text" parts are transcript; "thinking" is noise and
+                # "toolCall" parts feed the tool context for LATER messages.
+                parts = []
+                for p in content:
+                    if not isinstance(p, dict):
+                        continue
+                    if p.get("type") == "text" and isinstance(p.get("text"), str):
+                        parts.append(p["text"])
+                    elif p.get("type") == "toolCall":
+                        calls.append(p)
                 text = "\n".join(parts)
             else:
                 continue
             if text:
-                messages.append(Message(role=role, text=text))
+                messages.append(ctx.stamp(Message(role=role, text=text)))
+            for p in calls:
+                ctx.call(p.get("name"), p.get("arguments"))
         return messages
 
 
@@ -683,6 +780,14 @@ _CLASSIFY_PROMPT_HEAD = (
     "convention=rule to always follow, learning=discovered fact, "
     "observation=durable infrastructure fact, "
     "context=ephemeral/short-lived fact kept only short-term.\n\n"
+    "A message may carry a context line naming the tool the assistant had "
+    "just called and any tool error just before it. When a KEEP is a user "
+    "correction of that tool call, or a fix for that error, add one field "
+    '"trigger" so the memory surfaces next time the same thing happens: '
+    '"calling:<tool name>" for a correction after a tool call, '
+    '"editing:<file path>" for a correction after an edit or write, '
+    '"error:<short distinctive substring of the error>" for a fix after an '
+    "error. Omit the field otherwise.\n\n"
     "Examples:\n"
     "(assistant) Cloning the repo now and reading the layout for you.\n"
     '-> {{"n": 1, "verdict": "SKIP"}}\n'
@@ -693,7 +798,11 @@ _CLASSIFY_PROMPT_HEAD = (
     'ingress 30s timeout; raised to 120s"}}\n'
     "(assistant) We will use merge commits, not squash, for this repo.\n"
     '-> {{"n": 4, "verdict": "KEEP", "type": "decision", "summary": "Repo uses '
-    'merge commits, not squash"}}\n\n'
+    'merge commits, not squash"}}\n'
+    "(user) No, never force-push to main; open a PR instead.\n"
+    "  context: last tool call git_push on main\n"
+    '-> {{"n": 5, "verdict": "KEEP", "type": "convention", "summary": "Never '
+    'force-push to main; open a PR", "trigger": "calling:git_push"}}\n\n'
     "Messages:\n{messages}\n\nAnswer:"
 )
 
@@ -725,6 +834,19 @@ def _parse_classify_reply(response: str, batch_len: int) -> dict[int, dict]:
     return verdicts
 
 
+def _context_line(c: dict) -> str:
+    """Render a candidate's preceding tool call and error for the classifier."""
+    parts = []
+    if c.get("prev_tool"):
+        call = f"last tool call {c['prev_tool']}"
+        if c.get("prev_path"):
+            call += f" on {c['prev_path']}"
+        parts.append(call)
+    if c.get("prev_error"):
+        parts.append(f'last tool error "{c["prev_error"]}"')
+    return "; ".join(parts)
+
+
 def _classify_batch(
     batch: list[dict], llm_url: str, llm_model: str
 ) -> dict[int, dict]:
@@ -736,7 +858,11 @@ def _classify_batch(
     numbered = []
     for i, c in enumerate(batch):
         role = c.get("role", "assistant")
-        numbered.append(f"[{i + 1}] ({role}) {c['text'][:800]}")
+        line = f"[{i + 1}] ({role}) {c['text'][:800]}"
+        ctx = _context_line(c)
+        if ctx:
+            line += "\n  context: " + ctx
+        numbered.append(line)
     prompt = _CLASSIFY_PROMPT_HEAD.format(
         n=len(batch), messages="\n---\n".join(numbered),
     )
@@ -820,6 +946,9 @@ def _llm_classify(
                 else c["prefilter_type"] or "observation"
             )
             c["summary"] = summary
+            trigger = item.get("trigger")
+            if isinstance(trigger, str) and trigger.strip():
+                c["trigger"] = trigger.strip()
             results.append(c)
 
         # A batch the model only partly answered is a silent capture loss: the
@@ -833,6 +962,43 @@ def _llm_classify(
             )
 
     return results
+
+
+# Cap on a when-error: value. Error lines run long; the match is a substring,
+# so the head of the line is what matters.
+_MAX_ERROR_TRIGGER = 40
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _trigger_tag(raw) -> str | None:
+    """Turn a classifier-emitted ``<event>:<value>`` into a ``when-*`` tag.
+
+    Normalises what the model is likely to get slightly wrong: tool names and
+    error text are lowercased (matching is case-insensitive anyway, so the tag
+    reads consistently), error text is capped, and a literal file path becomes
+    a glob over its directory so the memory fires for sibling files too.
+    Anything that still fails :func:`triggers.parse_trigger` is dropped with
+    one log line; the memory itself is unaffected.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    from .triggers import parse_trigger
+
+    event, _, value = raw.strip().partition(":")
+    event, value = event.strip().lower(), value.strip()
+    if event == "calling":
+        value = value.lower()
+    elif event == "error":
+        value = value.lower()[:_MAX_ERROR_TRIGGER]
+    elif event == "editing" and value and not (_GLOB_CHARS & set(value)):
+        head, sep, leaf = value.rpartition("/")
+        if sep and "." in leaf:
+            value = head + "/*"
+    tag = f"when-{event}:{value}"
+    if parse_trigger(tag) is None:
+        log.info("harvest: dropping malformed trigger %r", raw)
+        return None
+    return tag
 
 
 # ---------------------------------------------------------------------------
@@ -886,6 +1052,9 @@ def _harvest_messages(
             "role": msg.role,
             "prefilter_type": prefilter_type,
             "provider": provider,
+            "prev_tool": msg.prev_tool,
+            "prev_path": msg.prev_path,
+            "prev_error": msg.prev_error,
         })
 
     # Tier 2: LLM classification
@@ -912,6 +1081,11 @@ def _harvest_messages(
             continue
 
         tags = _extract_tags(item["text"])
+        # A model-emitted trigger becomes a when-* tag so the memory surfaces
+        # the next time the same tool call or error happens (issue #135).
+        trigger = _trigger_tag(item.get("trigger"))
+        if trigger:
+            tags.append(trigger)
         # Harvest-created rows only: agent-written memories keep their
         # caller-chosen TTL. Auto-captured context goes stale in a week;
         # auto-captured observations get 30 days to be synthesized into a
@@ -919,6 +1093,8 @@ def _harvest_messages(
         ttl = {"context": 168.0, "observation": 720.0}.get(etype)
         record = {"content": summary, "entity_type": etype, "tags": tags,
                   "ttl_hours": ttl, "provider": provider}
+        if trigger:
+            record["trigger"] = trigger
         if redacted:
             record["redacted"] = redacted
 

--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -9,7 +9,9 @@ its session files and extract text from its transcript format.
 Two-tier classification:
   1. Broad regex pre-filter selects candidate messages
   2. Local LLM classifies and summarizes candidates
-Falls back to regex-only if LLM is unavailable.
+Falls back to regex-only if LLM is unavailable. With an LLM, a user
+correction after a tool call or a fix after a tool error may be saved with a
+``when-*`` trigger tag (issue #135) so it surfaces when the same thing recurs.
 """
 
 from __future__ import annotations

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -20,6 +20,7 @@ from neurostack.harvest import (
     _parse_jsonl,
     _prefilter_classify,
     _save_harvest_state,
+    _trigger_tag,
     get_provider_names,
     harvest_transcript,
 )
@@ -1042,3 +1043,242 @@ class TestHarvestTranscript:
                                    source_agent="claude-code", use_llm=False)
         assert "note" not in retry
         assert len(retry["saved"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Harvest-emitted trigger tags (issue #135)
+# ---------------------------------------------------------------------------
+
+def _claude_entry(role, content):
+    return json.dumps({"type": role, "message": {"role": role, "content": content}})
+
+
+def _omp_entry(role, content):
+    return json.dumps({"type": "message", "message": {"role": role, "content": content}})
+
+
+_CORRECTION = ("No, do not use vault_write_file to change an existing note; use "
+               "vault_update_memory so the history is kept.")
+_BASTION_FIX = ("Bastion is down, so I am switching to the ssh proxy chain through "
+                "the laptop, which does not depend on the bastion host.")
+_VESSEL_CORRECTION = ("No, vessel types belong in the shared types package; do not "
+                      "add them to the service module.")
+_HASHLINE_EDIT = "[strake/src/svc/vessel.ts#A1B2]\nPUT 3.=3:\n+x"
+
+
+def _keep(summary, trigger=None, etype="convention"):
+    item = {"n": 1, "verdict": "KEEP", "type": etype, "summary": summary}
+    if trigger is not None:
+        item["trigger"] = trigger
+    return json.dumps([item])
+
+
+class TestTriggerTag:
+    """Model-emitted ``<event>:<value>`` becomes a ``when-<event>:`` tag, or nothing."""
+
+    def test_calling_lowercased(self):
+        assert _trigger_tag("calling:Vault_Write_File") == "when-calling:vault_write_file"
+
+    def test_error_lowercased_and_capped_at_40(self):
+        raw = "error:" + "Bastion-Unavailable (503) " + "x" * 60
+        tag = _trigger_tag(raw)
+        assert tag == "when-error:" + ("bastion-unavailable (503) " + "x" * 60)[:40]
+
+    def test_editing_path_becomes_directory_glob(self):
+        assert _trigger_tag("editing:strake/src/svc/vessel.ts") == "when-editing:strake/src/svc/*"
+
+    def test_editing_glob_kept(self):
+        assert _trigger_tag("editing:src/**/*.tf") == "when-editing:src/**/*.tf"
+
+    def test_malformed_dropped(self, caplog):
+        with caplog.at_level(logging.INFO, logger="neurostack"):
+            assert _trigger_tag("writing:x") is None
+            assert _trigger_tag("calling:") is None
+            assert _trigger_tag("") is None
+            assert _trigger_tag(None) is None
+        # One line per malformed string; empty and None return silently.
+        assert sum("trigger" in r.getMessage() for r in caplog.records) == 2
+
+
+class TestProviderToolContext:
+    """Providers stamp each message with the tool call and error that preceded it."""
+
+    def test_claude_tool_use_and_error(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text("\n".join([
+            _claude_entry("assistant", [
+                {"type": "text", "text": "Saving the note now."},
+                {"type": "tool_use", "name": "mcp__neurostack__vault_write_file",
+                 "input": {"path": "notes/x.md", "content": "body"}},
+            ]),
+            _claude_entry("user", [
+                {"type": "tool_result", "is_error": True,
+                 "content": "Bastion-Unavailable (503): host not reachable\nmore"},
+            ]),
+            _claude_entry("user", _CORRECTION),
+        ]) + "\n")
+        msgs = ClaudeCodeProvider().extract_messages(f)
+        first = msgs[0]
+        assert (first.prev_tool, first.prev_path, first.prev_error) == (None, None, None)
+        last = msgs[-1]
+        assert last.text == _CORRECTION
+        assert last.prev_tool == "vault_write_file"
+        assert last.prev_path == "notes/x.md"
+        assert last.prev_error == "Bastion-Unavailable (503): host not reachable"
+
+    def test_omp_toolcall_hashline_path_and_xd_device(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        f.write_text("\n".join([
+            _omp_entry("assistant", [
+                {"type": "text", "text": "Editing the service module."},
+                {"type": "toolCall", "name": "edit",
+                 "arguments": json.dumps({"input": _HASHLINE_EDIT})},
+            ]),
+            _omp_entry("toolResult", [{"type": "text", "text": "ok"}]),
+            _omp_entry("user", [{"type": "text", "text": _VESSEL_CORRECTION}]),
+            _omp_entry("assistant", [
+                {"type": "toolCall", "name": "write",
+                 "arguments": {"path": "xd://mcp__neurostack_vault_write_file", "content": "{}"}},
+            ]),
+            _omp_entry("toolResult", [{"type": "text", "text": "saved"}]),
+            _omp_entry("user", [{"type": "text", "text": _CORRECTION}]),
+        ]) + "\n")
+        msgs = OmpProvider().extract_messages(f)
+        vessel = msgs[1]
+        assert vessel.text == _VESSEL_CORRECTION
+        assert (vessel.prev_tool, vessel.prev_path) == ("edit", "strake/src/svc/vessel.ts")
+        assert vessel.prev_error is None
+        assert (msgs[2].prev_tool, msgs[2].prev_path) == (
+            "neurostack_vault_write_file", "xd://mcp__neurostack_vault_write_file")
+
+    def test_error_context_expires_after_three_messages(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        lines = [
+            _claude_entry("assistant", [{"type": "tool_use", "name": "Bash", "input": {}}]),
+            _claude_entry("user", [{"type": "tool_result", "is_error": True, "content": "boom"}]),
+        ]
+        lines += [_claude_entry("assistant", f"assistant reply number {i}") for i in range(4)]
+        f.write_text("\n".join(lines) + "\n")
+        msgs = ClaudeCodeProvider().extract_messages(f)
+        # The tool_result echo ("boom", role user) precedes the error it carries,
+        # so the window covers the next three assistant replies only.
+        assert [m.prev_error for m in msgs] == [None, "boom", "boom", "boom", None]
+
+
+class TestHarvestTriggers:
+    """Acceptance for issue #135: harvest saves memories already carrying a trigger."""
+
+    @staticmethod
+    def _llm(monkeypatch, content):
+        import httpx
+
+        sent = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": content}}]}
+
+        def post(*a, **k):
+            sent["prompt"] = k["json"]["messages"][0]["content"]
+            return _Resp()
+
+        monkeypatch.setattr(httpx, "post", post)
+        monkeypatch.setattr("neurostack.config._auth_headers", lambda _key: {})
+        return sent
+
+    @staticmethod
+    def _tags(conn):
+        return [json.loads(r[0]) for r in conn.execute("SELECT tags FROM memories")]
+
+    def test_correction_after_tool_call(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        sent = self._llm(monkeypatch, _keep(
+            "Use vault_update_memory, not vault_write_file, to change an existing note",
+            trigger="calling:vault_write_file"))
+        transcript = "\n".join([
+            _claude_entry("assistant", [
+                {"type": "text", "text": "Saving the note now."},
+                {"type": "tool_use", "name": "mcp__neurostack__vault_write_file",
+                 "input": {"path": "notes/x.md", "content": "body"}},
+            ]),
+            _claude_entry("user", [{"type": "tool_result", "is_error": None, "content": "ok"}]),
+            _claude_entry("user", _CORRECTION),
+        ])
+        report = harvest_transcript(transcript, session_id="s1", source_agent="claude-code")
+        assert [r["status"] for r in report["saved"]] == ["saved"]
+        assert report["saved"][0]["trigger"] == "when-calling:vault_write_file"
+        assert "when-calling:vault_write_file" in self._tags(in_memory_db)[0]
+        # The classifier saw what the assistant had just done.
+        assert "vault_write_file" in sent["prompt"] and "notes/x.md" in sent["prompt"]
+
+    def test_error_then_fix(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        sent = self._llm(monkeypatch, _keep(
+            "When bastion returns 503, fall back to the ssh proxy chain",
+            trigger="error:Bastion-Unavailable", etype="bug"))
+        transcript = "\n".join([
+            _claude_entry("assistant", [{"type": "tool_use", "name": "Bash",
+                                         "input": {"command": "az network bastion ssh"}}]),
+            _claude_entry("user", [{"type": "tool_result", "is_error": True,
+                                    "content": "Bastion-Unavailable (503): host not reachable"}]),
+            _claude_entry("assistant", _BASTION_FIX),
+        ])
+        report = harvest_transcript(transcript, session_id="s2", source_agent="claude-code")
+        assert report["saved"][0]["trigger"] == "when-error:bastion-unavailable"
+        assert "when-error:bastion-unavailable" in self._tags(in_memory_db)[0]
+        assert "Bastion-Unavailable (503)" in sent["prompt"]
+
+    def test_correction_after_edit(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        self._llm(monkeypatch, _keep(
+            "Vessel types live in the shared types package, not the service module",
+            trigger="editing:strake/src/svc/vessel.ts"))
+        transcript = "\n".join([
+            _omp_entry("assistant", [
+                {"type": "toolCall", "name": "edit",
+                 "arguments": json.dumps({"input": _HASHLINE_EDIT})},
+            ]),
+            _omp_entry("toolResult", [{"type": "text", "text": "ok"}]),
+            _omp_entry("user", [{"type": "text", "text": _VESSEL_CORRECTION}]),
+        ])
+        report = harvest_transcript(transcript, session_id="s3", source_agent="omp")
+        assert report["saved"][0]["trigger"] == "when-editing:strake/src/svc/*"
+        assert "when-editing:strake/src/svc/*" in self._tags(in_memory_db)[0]
+
+    def test_malformed_trigger_saves_without_tag(self, in_memory_db, tmp_path, monkeypatch, caplog):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        self._llm(monkeypatch, _keep("Use vault_update_memory for existing notes",
+                                     trigger="writing:x"))
+        with caplog.at_level(logging.INFO, logger="neurostack"):
+            report = harvest_transcript(_claude_entry("user", _CORRECTION),
+                                        session_id="s4", source_agent="claude-code")
+        assert [r["status"] for r in report["saved"]] == ["saved"]
+        assert "trigger" not in report["saved"][0]
+        assert not [t for t in self._tags(in_memory_db)[0] if t.startswith("when-")]
+        assert sum("trigger" in r.getMessage() for r in caplog.records) == 1
+
+    def test_reply_without_trigger_unchanged(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        self._llm(monkeypatch, _keep("Use vault_update_memory for existing notes"))
+        report = harvest_transcript(_claude_entry("user", _CORRECTION),
+                                    session_id="s5", source_agent="claude-code")
+        assert [r["status"] for r in report["saved"]] == ["saved"]
+        assert "trigger" not in report["saved"][0]
+        assert report["saved"][0]["tags"] == _extract_tags(_CORRECTION)
+
+    def test_regex_fallback_emits_none(self, in_memory_db, tmp_path, monkeypatch):
+        TestHarvestTranscript._setup(in_memory_db, tmp_path, monkeypatch)
+        transcript = "\n".join([
+            _claude_entry("assistant", [{"type": "tool_use", "name": "Bash", "input": {}}]),
+            _claude_entry("user", [{"type": "tool_result", "is_error": True,
+                                    "content": "Bastion-Unavailable (503)"}]),
+            _claude_entry("assistant", _BUG_INSIGHT),
+        ])
+        report = harvest_transcript(transcript, session_id="s6", source_agent="claude-code",
+                                    use_llm=False)
+        assert [r["status"] for r in report["saved"]] == ["saved"]
+        assert "trigger" not in report["saved"][0]
+        assert not [t for t in self._tags(in_memory_db)[0] if t.startswith("when-")]


### PR DESCRIPTION
Part of #135

## What

Harvest now saves a memory already carrying a trigger tag when the classifier sees a user correction after a tool call, or a fix after a tool error.

- `Message` gains `prev_tool`, `prev_path`, `prev_error`. `ClaudeCodeProvider` and `OmpProvider` stamp each message with the tool context that preceded it through a small `_ToolContext` (last `tool_use`/`toolCall` and its path, first line of the most recent failed result, kept for 3 messages). Other providers are unchanged and default to `None`.
- `_classify_batch` appends a `context:` line to a candidate when it has tool context. The prompt describes an optional `"trigger"` field (`calling:<tool>`, `editing:<path>`, `error:<substring>`) with one worked example. Replies without the field behave exactly as before.
- `_trigger_tag` normalises the model's value (lowercase tool and error, error capped at 40 characters, a literal file path becomes a glob over its directory) and validates it with `triggers.parse_trigger`. A malformed value is dropped with one INFO line; the memory still saves.
- MCP tool names are recorded the way the harness reports them. Claude Code `mcp__neurostack__vault_write_file` becomes `vault_write_file`; an omp `write` to `xd://mcp__neurostack_vault_write_file` becomes `neurostack_vault_write_file`.
- The harvest report shows `trigger` on a saved record when one was attached.

## Tests

20 new tests in `tests/test_harvest.py`: `_trigger_tag` normalisation, provider tool context (Claude Code tool_use/tool_result, omp toolCall with hashline path and xd:// device, error window expiry), and the six acceptance cases from #135 through `harvest_transcript` with a stubbed LLM. The omp provider test now asserts `prev_tool` stays `None` on the message that made the call, since `prev_*` means strictly preceding.

## Not in this PR

Confidence scores, a background observer, changes to `vault_triggers` matching. Claude Code tool_result echoes still count as user text, as before this change.
