### PR TITLE
fix(harvest): parse bare-object replies and make the trigger rule explicit

### DIFF
--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -767,7 +767,8 @@ _CLASSIFY_PROMPT_HEAD = (
     "No preamble, no code fence.\n\n"
     "Each object is either:\n"
     '{{"n": N, "verdict": "KEEP", "type": "<bug|decision|convention|learning|'
-    'observation|context>", "summary": "<one sentence>"}}\n'
+    'observation|context>", "summary": "<one sentence>", '
+    '"trigger": "<only when the trigger rule below applies>"}}\n'
     'or {{"n": N, "verdict": "SKIP"}}\n\n'
     "KEEP a message that records any of: an architectural or tooling "
     "decision, a bug's root cause or fix, a rule to follow, a discovered "
@@ -782,14 +783,17 @@ _CLASSIFY_PROMPT_HEAD = (
     "convention=rule to always follow, learning=discovered fact, "
     "observation=durable infrastructure fact, "
     "context=ephemeral/short-lived fact kept only short-term.\n\n"
-    "A message may carry a context line naming the tool the assistant had "
-    "just called and any tool error just before it. When a KEEP is a user "
-    "correction of that tool call, or a fix for that error, add one field "
-    '"trigger" so the memory surfaces next time the same thing happens: '
-    '"calling:<tool name>" for a correction after a tool call, '
-    '"editing:<file path>" for a correction after an edit or write, '
-    '"error:<short distinctive substring of the error>" for a fix after an '
-    "error. Omit the field otherwise.\n\n"
+    "Trigger rule. Some messages carry a line starting \"context:\" that names "
+    "the tool the assistant had just called (and its path) and any tool error "
+    "just before the message. If such a line is present AND the message is a "
+    "user correction or a fix, the KEEP object MUST include \"trigger\":\n"
+    '- user corrects what a tool call did -> "calling:<tool name from the '
+    'context line>"\n'
+    '- user corrects an edit or write to a file -> "editing:<path from the '
+    'context line>"\n'
+    '- assistant fixes the error from the context line -> "error:<short '
+    'distinctive substring of that error>"\n'
+    "No context line, or not a correction or fix: omit \"trigger\".\n\n"
     "Examples:\n"
     "(assistant) Cloning the repo now and reading the layout for you.\n"
     '-> {{"n": 1, "verdict": "SKIP"}}\n'
@@ -813,16 +817,22 @@ def _parse_classify_reply(response: str, batch_len: int) -> dict[int, dict]:
     """Map 0-based candidate index -> verdict object from the model's reply.
 
     Tolerates a code fence or stray prose around the array; ignores objects
-    with an out-of-range or missing ``n``.
+    with an out-of-range or missing ``n``. A bare object (what small models
+    return for a one-candidate batch, including every one-candidate retry)
+    counts as a one-element array.
     """
     response = re.sub(r"<think>.*?</think>", "", response, flags=re.DOTALL)
     start, end = response.find("["), response.rfind("]")
     if start < 0 or end <= start:
-        return {}
+        start, end = response.find("{"), response.rfind("}")
+        if start < 0 or end <= start:
+            return {}
     try:
         items = json.loads(response[start:end + 1])
     except json.JSONDecodeError:
         return {}
+    if isinstance(items, dict):
+        items = [items]
     if not isinstance(items, list):
         return {}
     verdicts: dict[int, dict] = {}

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -17,6 +17,7 @@ from neurostack.harvest import (
     _llm_classify,
     _load_harvest_state,
     _make_summary,
+    _parse_classify_reply,
     _parse_jsonl,
     _prefilter_classify,
     _save_harvest_state,
@@ -1071,6 +1072,22 @@ def _keep(summary, trigger=None, etype="convention"):
     if trigger is not None:
         item["trigger"] = trigger
     return json.dumps([item])
+
+
+class TestParseClassifyReply:
+    def test_bare_object_is_one_element_batch(self):
+        # Small models answer a one-candidate batch (and every one-candidate
+        # retry) with a bare object; before this it parsed as nothing.
+        raw = '{"n": 1, "verdict": "KEEP", "type": "convention", "summary": "s"}'
+        assert _parse_classify_reply(raw, 1) == {0: json.loads(raw)}
+
+    def test_array_still_preferred(self):
+        raw = 'sure: [{"n": 1, "verdict": "SKIP"}, {"n": 2, "verdict": "SKIP"}]'
+        assert set(_parse_classify_reply(raw, 2)) == {0, 1}
+
+    def test_garbage(self):
+        assert _parse_classify_reply("no json here", 1) == {}
+        assert _parse_classify_reply("{broken", 1) == {}
 
 
 class TestTriggerTag:


### PR DESCRIPTION
Part of #135

Live verification of #137 against the LXC 122 deployment (gemma4-e4b-text) found two gaps.

## Parser dropped one-candidate batches

For a one-candidate batch the model answers with a bare JSON object, not a one-element array. `_parse_classify_reply` looked only for `[...]`, so the reply parsed as nothing and harvest logged "answered 0 of 1 candidates". This also hit every one-candidate retry, so a partly answered batch of 5 could lose its last candidate twice. The parser now falls back to the outermost `{...}` and wraps it as a one-element list. Three tests.

## Model omitted the trigger field

With the prompt from #137 the model kept the correction but never emitted `trigger`. The rule now sits in two places the model reads. The KEEP object schema shows the field, and a "Trigger rule" paragraph states when it is required (a `context:` line is present and the message is a correction or fix) with the value to copy for each of the three cases.

Probe against the live model, four candidates in one batch (correction after `vault_write_file`, bastion 503 then fix, correction after an edit to `strake/src/svc/vessel.ts`, and a decision after a plain `read` as control), three runs:

```
["KEEP", "calling:vault_write_file", "when-calling:vault_write_file"]
["KEEP", "error:Bastion-Unavailable (503)", "when-error:bastion-unavailable (503)"]
["KEEP", "editing:strake/src/svc/vessel.ts", "when-editing:strake/src/svc/*"]
["KEEP", null, null]
```

Identical on all three runs; the one-candidate batch also returns the trigger.
