### PR TITLE
feat(triggers): log firings and record ignored triggers as drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **#136 — fired-but-ignored triggers.** `vault_triggers` logs every hit to a new `trigger_log` table; new tool `vault_trigger_outcome(memory_id, followed, note)` records whether the agent followed it. An ignored trigger becomes a `prediction_errors` row of type `trigger_ignored`; the promotion queue's `drift` bucket lists the memory once with `ignored_trigger` and `ignored_count`, and adds `suggest: retire` at three. Nothing is deleted or decayed automatically.
+
 - **#135 — harvest emits trigger tags.** Providers stamp each transcript message with the tool call, path and failed result that preceded it; the classifier sees that context and may return a `trigger` field, which harvest normalises and saves as a `when-*` tag. A malformed value is dropped with one log line and the memory still saves. Regex fallback emits none.
 
 - **#131 — trigger tags.** A memory tagged `when-editing:<glob>`, `when-calling:<tool>` or `when-error:<substring>` surfaces at the moment it applies. New `triggers.py` and MCP `vault_triggers(event, value)`; no schema change, per-session fire-once lives in the client hook.
@@ -15,6 +17,7 @@
 ### Schema
 
 - v21 → v22: `memories_archive` table (#90).
+- v24 → v25: `trigger_log` table (#136).
 
 ## v0.16.0 — Retrieval & extraction fixes (2026-06-11)
 

--- a/src/neurostack/promotion.py
+++ b/src/neurostack/promotion.py
@@ -10,7 +10,9 @@ worklist in four buckets — no LLM calls, no writes — for a downstream agent
 - **debt**: memories explicitly tagged ``promotion-debt`` by a session that
   ended without running its vault-save step.
 - **drift**: unresolved ``memory_drift`` prediction errors (issue #38) — the
-  memory no longer matches the notes it references.
+  memory no longer matches the notes it references — and, since issue #136,
+  memories whose trigger fired but was ignored (``trigger_ignored`` rows, one
+  entry per memory with the running count; ``suggest: retire`` at three).
 - **dead_handoffs**: ``context`` memories that read as handoff/continuation
   state and are older than a grace window. Consumed handoffs stored as if
   live are the single biggest volatile-layer polluter. Memories tagged
@@ -76,7 +78,7 @@ def _drift_bucket(conn: sqlite3.Connection, workspace: str | None) -> list[dict]
         sql += " AND m.workspace = ?"
         params.append(workspace)
     sql += " ORDER BY p.cosine_distance DESC"
-    return [
+    out = [
         _entry(
             dict(r),
             drifted_from=r["note_path"],
@@ -85,6 +87,38 @@ def _drift_bucket(conn: sqlite3.Connection, workspace: str | None) -> list[dict]
         )
         for r in conn.execute(sql, params).fetchall()
     ]
+    out.extend(_ignored_trigger_entries(conn, workspace))
+    return out
+
+
+def _ignored_trigger_entries(
+    conn: sqlite3.Connection, workspace: str | None
+) -> list[dict]:
+    """One entry per memory whose trigger fired and was ignored (issue #136)."""
+    from .triggers import IGNORED_ERROR_TYPE, RETIRE_AFTER_IGNORES
+
+    sql = (
+        "SELECT m.*, COUNT(*) AS ignored_count, MAX(p.detected_at) AS detected_at,"
+        " MAX(p.context) AS ignored_trigger"
+        " FROM prediction_errors p JOIN memories m ON m.memory_id = p.memory_id"
+        " WHERE p.resolved_at IS NULL AND p.error_type = ?"
+    )
+    params: list = [IGNORED_ERROR_TYPE]
+    if workspace:
+        sql += " AND m.workspace = ?"
+        params.append(workspace)
+    sql += " GROUP BY m.memory_id ORDER BY ignored_count DESC, detected_at DESC"
+    out = []
+    for r in conn.execute(sql, params).fetchall():
+        extra = {
+            "ignored_trigger": r["ignored_trigger"],
+            "ignored_count": r["ignored_count"],
+            "detected_at": r["detected_at"],
+        }
+        if r["ignored_count"] >= RETIRE_AFTER_IGNORES:
+            extra["suggest"] = "retire"
+        out.append(_entry(dict(r), **extra))
+    return out
 
 
 def _dead_handoff_bucket(

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -259,6 +259,19 @@ CREATE INDEX IF NOT EXISTS idx_pred_errors_memory
     ON prediction_errors(memory_id) WHERE memory_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_pred_errors_unresolved
     ON prediction_errors(resolved_at) WHERE resolved_at IS NULL;
+
+-- Trigger firings (issue #136): one row each time vault_triggers returned a
+-- memory. Together with prediction_errors rows of type 'trigger_ignored' this
+-- tells the promotion queue which triggers fire but get ignored.
+CREATE TABLE IF NOT EXISTS trigger_log (
+    log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_id INTEGER NOT NULL REFERENCES memories(memory_id) ON DELETE CASCADE,
+    event TEXT NOT NULL,
+    value TEXT NOT NULL,
+    session_hint TEXT,
+    fired_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_trigger_log_memory ON trigger_log(memory_id);
 
 -- Agent-written memories (write-back layer)
 CREATE TABLE IF NOT EXISTS memories (
@@ -1165,6 +1178,29 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (24)")
         conn.commit()
         log.info("Migration to v24 complete.")
+
+    if current < 25:
+        log.info(
+            "Migrating schema v24 -> v25: trigger_log — "
+            "record each trigger firing so ignored triggers are measurable "
+            "(issue #136)..."
+        )
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS trigger_log (
+                log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id INTEGER NOT NULL
+                    REFERENCES memories(memory_id) ON DELETE CASCADE,
+                event TEXT NOT NULL,
+                value TEXT NOT NULL,
+                session_hint TEXT,
+                fired_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_trigger_log_memory
+                ON trigger_log(memory_id);
+        """)
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (25)")
+        conn.commit()
+        log.info("Migration to v25 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -303,12 +303,13 @@ def vault_promotion_queue(
     )
 
 
-@registry.tool(tags=["memory", "read"], annotations=_READ_ONLY)
+@registry.tool(tags=["memory", "read"])
 def vault_triggers(
     event: str,
     value: str,
     workspace: str = None,
     limit: int = 10,
+    session_hint: str = None,
 ) -> dict:
     """Memories whose trigger tag matches the current moment (issue #131).
 
@@ -316,17 +317,47 @@ def vault_triggers(
     (file path of an Edit/Write), 'when-calling:<tool>' (tool name),
     'when-error:<substring>' (tool error text). Harness hooks call this on
     tool events and inject the hits; the caller owns once-per-session
-    suppression. Pure read; untagged memories are never returned.
+    suppression. Each hit is logged to trigger_log (issue #136) so the hook
+    can later report with vault_trigger_outcome whether it was followed.
+    Untagged memories are never returned.
 
     Args:
         event: One of "editing", "calling", "error"
         value: The path, tool name, or error text to match against
         workspace: Optional vault subdirectory scope
         limit: Max hits, newest first (default 10)
+        session_hint: Optional opaque client session id stored with the log row
     """
     from ..schema import DB_PATH, get_db
-    from ..triggers import match_triggers
+    from ..triggers import match_triggers, record_fired
 
     conn = get_db(DB_PATH)
     hits = match_triggers(conn, event, value, workspace=workspace, limit=limit)
+    record_fired(conn, hits, event, value, session_hint=session_hint)
     return {"event": event, "value": value, "hits": hits, "count": len(hits)}
+
+
+@registry.tool(tags=["memory", "write"])
+def vault_trigger_outcome(
+    memory_id: int,
+    followed: bool,
+    note: str = None,
+) -> dict:
+    """Report whether a fired trigger memory was followed (issue #136).
+
+    Call once per fired memory, a few tool calls after vault_triggers returned
+    it. followed=true writes nothing. followed=false records a
+    'trigger_ignored' prediction error; the promotion queue's drift bucket
+    lists the memory with its running ignore count and suggests retiring the
+    trigger after three. Nothing is deleted automatically.
+
+    Args:
+        memory_id: The memory vault_triggers returned
+        followed: True if the agent changed course because of it
+        note: Optional short reason, e.g. "re-issued the same call unchanged"
+    """
+    from ..schema import DB_PATH, get_db
+    from ..triggers import record_outcome
+
+    conn = get_db(DB_PATH)
+    return record_outcome(conn, memory_id, followed=followed, note=note)

--- a/src/neurostack/triggers.py
+++ b/src/neurostack/triggers.py
@@ -9,9 +9,16 @@ should be shown, not what it is about:
 - ``when-calling:<tool>``     matched against a tool name (case-insensitive)
 - ``when-error:<substring>``  matched against tool error text (case-insensitive)
 
-No schema change: triggers live in ``memories.tags``. Matching is a pure read.
-Per-session "fire once" suppression belongs to the client (the harness hook),
-because the server has no notion of a harness session per tool call.
+No schema change for the tags themselves: triggers live in ``memories.tags``.
+Matching is a pure read. Per-session "fire once" suppression belongs to the
+client (the harness hook), because the server has no notion of a harness
+session per tool call.
+
+Issue #136 adds the feedback half. Every hit is logged to ``trigger_log``, and
+the client reports whether the agent followed the memory. An ignored trigger
+becomes a ``prediction_errors`` row of type ``trigger_ignored`` that the
+promotion queue's drift bucket surfaces; after ``RETIRE_AFTER_IGNORES`` the
+queue suggests retiring the trigger. Nothing is deleted or decayed here.
 """
 
 from __future__ import annotations
@@ -22,6 +29,8 @@ import sqlite3
 
 TRIGGER_EVENTS = ("editing", "calling", "error")
 _PREFIX = "when-"
+IGNORED_ERROR_TYPE = "trigger_ignored"
+RETIRE_AFTER_IGNORES = 3
 
 
 def parse_trigger(tag: str) -> tuple[str, str] | None:
@@ -101,4 +110,89 @@ def match_triggers(
         })
         if len(out) >= limit:
             break
+    return out
+
+
+def record_fired(
+    conn: sqlite3.Connection,
+    hits: list[dict],
+    event: str,
+    value: str,
+    session_hint: str | None = None,
+) -> int:
+    """Log one ``trigger_log`` row per hit. Returns the row count written."""
+    if not hits:
+        return 0
+    conn.executemany(
+        "INSERT INTO trigger_log (memory_id, event, value, session_hint)"
+        " VALUES (?, ?, ?, ?)",
+        [(h["memory_id"], event, value, session_hint) for h in hits],
+    )
+    conn.commit()
+    return len(hits)
+
+
+def _trigger_tags(tags_raw) -> list[str]:
+    try:
+        tags = json.loads(tags_raw) if isinstance(tags_raw, str) else (tags_raw or [])
+    except (json.JSONDecodeError, TypeError):
+        return []
+    return [t for t in tags if parse_trigger(t)]
+
+
+def ignored_count(conn: sqlite3.Connection, memory_id: int) -> int:
+    """Unresolved ``trigger_ignored`` rows for one memory."""
+    return conn.execute(
+        "SELECT COUNT(*) FROM prediction_errors"
+        " WHERE memory_id = ? AND error_type = ? AND resolved_at IS NULL",
+        (memory_id, IGNORED_ERROR_TYPE),
+    ).fetchone()[0]
+
+
+def record_outcome(
+    conn: sqlite3.Connection,
+    memory_id: int,
+    followed: bool,
+    note: str | None = None,
+) -> dict:
+    """Record whether the agent followed a fired trigger.
+
+    ``followed=True`` writes nothing. ``followed=False`` inserts one
+    ``prediction_errors`` row (``error_type='trigger_ignored'``, ``context`` =
+    the trigger tag that fired, ``query`` = the caller's note). The reply
+    carries the running ignore count and ``suggest: "retire"`` once it reaches
+    ``RETIRE_AFTER_IGNORES``; the memory row itself is never touched.
+    """
+    row = conn.execute(
+        "SELECT tags FROM memories WHERE memory_id = ?", (memory_id,)
+    ).fetchone()
+    if row is None:
+        return {"error": f"Memory {memory_id} not found", "memory_id": memory_id}
+    if not followed:
+        fired = conn.execute(
+            "SELECT event, value FROM trigger_log WHERE memory_id = ?"
+            " ORDER BY fired_at DESC, log_id DESC LIMIT 1",
+            (memory_id,),
+        ).fetchone()
+        tags = _trigger_tags(row["tags"])
+        if fired is not None:
+            # Prefer the tag that actually matched the logged firing.
+            matched = [
+                t for t in tags
+                if (p := parse_trigger(t)) and p[0] == fired["event"]
+                and _match(p[0], p[1], fired["value"])
+            ]
+            tags = matched or tags
+        context = tags[0] if tags else None
+        conn.execute(
+            "INSERT INTO prediction_errors"
+            " (note_path, memory_id, query, cosine_distance, error_type, context)"
+            " VALUES ('', ?, ?, 0.0, ?, ?)",
+            (memory_id, note or "", IGNORED_ERROR_TYPE, context),
+        )
+        conn.commit()
+    count = ignored_count(conn, memory_id)
+    out = {"memory_id": memory_id, "followed": followed, "ignored_count": count}
+    if count >= RETIRE_AFTER_IGNORES:
+        out["suggest"] = "retire"
     return out

--- a/tests/test_trigger_outcome.py
+++ b/tests/test_trigger_outcome.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Tests for fired-but-ignored triggers (issue #136)."""
+
+import json
+
+import pytest
+
+from neurostack import config as nsconfig
+from neurostack.triggers import (
+    RETIRE_AFTER_IGNORES,
+    match_triggers,
+    record_fired,
+    record_outcome,
+)
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEUROSTACK_DB_DIR", str(tmp_path))
+    nsconfig._config = None
+    from neurostack.schema import get_db
+
+    conn = get_db()
+    yield conn
+    conn.close()
+    nsconfig._config = None
+
+
+def _add_memory(conn, content, tags):
+    cur = conn.execute(
+        "INSERT INTO memories (content, entity_type, tags)"
+        " VALUES (?, 'convention', ?)",
+        (content, json.dumps(tags)),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _ignored_rows(conn, mid):
+    return conn.execute(
+        "SELECT note_path, cosine_distance, context, resolved_at FROM prediction_errors"
+        " WHERE memory_id = ? AND error_type = 'trigger_ignored'", (mid,),
+    ).fetchall()
+
+
+def _fire(conn, event, value, session_hint=None):
+    hits = match_triggers(conn, event, value)
+    record_fired(conn, hits, event, value, session_hint=session_hint)
+    return hits
+
+
+class TestTriggerLog:
+    def test_one_row_per_hit(self, db):
+        a = _add_memory(db, "Use vault_update_memory for existing notes",
+                        ["when-calling:vault_write_file"])
+        b = _add_memory(db, "Push after every vault write", ["when-calling:vault_write_file"])
+        hits = _fire(db, "calling", "vault_write_file", session_hint="sess-1")
+        assert {h["memory_id"] for h in hits} == {a, b}
+        rows = db.execute(
+            "SELECT memory_id, event, value, session_hint FROM trigger_log ORDER BY memory_id"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [
+            (a, "calling", "vault_write_file", "sess-1"),
+            (b, "calling", "vault_write_file", "sess-1"),
+        ]
+
+    def test_zero_hits_write_nothing(self, db):
+        _add_memory(db, "Unrelated", ["when-calling:other_tool"])
+        assert _fire(db, "calling", "vault_write_file") == []
+        assert db.execute("SELECT COUNT(*) FROM trigger_log").fetchone()[0] == 0
+
+    def test_cascade_on_memory_delete(self, db):
+        mid = _add_memory(db, "m", ["when-calling:x"])
+        _fire(db, "calling", "x")
+        db.execute("DELETE FROM memories WHERE memory_id = ?", (mid,))
+        db.commit()
+        assert db.execute("SELECT COUNT(*) FROM trigger_log").fetchone()[0] == 0
+
+
+class TestRecordOutcome:
+    def test_followed_writes_nothing(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        out = record_outcome(db, mid, followed=True)
+        assert out == {"memory_id": mid, "followed": True, "ignored_count": 0}
+        assert _ignored_rows(db, mid) == []
+
+    def test_ignored_writes_one_prediction_error(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        out = record_outcome(db, mid, followed=False, note="re-issued the same call")
+        assert out["ignored_count"] == 1
+        assert "suggest" not in out
+        rows = _ignored_rows(db, mid)
+        assert len(rows) == 1
+        note_path, dist, context, resolved = rows[0]
+        assert (note_path, dist, resolved) == ("", 0.0, None)
+        # context names the trigger that fired, not the caller's free-text note.
+        assert context == "when-calling:vault_write_file"
+
+    def test_third_ignore_suggests_retire(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        for i in range(RETIRE_AFTER_IGNORES):
+            _fire(db, "calling", "vault_write_file")
+            out = record_outcome(db, mid, followed=False)
+        assert out["ignored_count"] == RETIRE_AFTER_IGNORES
+        assert out["suggest"] == "retire"
+        # The memory row itself is untouched: no auto-delete, no decay.
+        assert db.execute("SELECT COUNT(*) FROM memories WHERE memory_id = ?",
+                          (mid,)).fetchone()[0] == 1
+
+    def test_unknown_memory(self, db):
+        out = record_outcome(db, 999, followed=False)
+        assert "error" in out
+        assert db.execute("SELECT COUNT(*) FROM prediction_errors").fetchone()[0] == 0
+
+    def test_never_fired_falls_back_to_tag(self, db):
+        # No trigger_log row (older client): context still names the trigger tag.
+        mid = _add_memory(db, "m", ["misc", "when-error:no commits between"])
+        record_outcome(db, mid, followed=False)
+        assert _ignored_rows(db, mid)[0][2] == "when-error:no commits between"
+
+
+class TestDriftBucket:
+    def test_ignored_trigger_in_drift_bucket(self, db):
+        from neurostack.promotion import compute_promotion_queue
+
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=False)
+        q = compute_promotion_queue(db)
+        assert q["counts"]["drift"] == 1
+        entry = q["drift"][0]
+        assert entry["memory_id"] == mid
+        assert entry["ignored_trigger"] == "when-calling:vault_write_file"
+        assert entry["ignored_count"] == 1
+        assert "suggest" not in entry
+
+    def test_three_ignores_collapse_to_one_entry_with_retire(self, db):
+        from neurostack.promotion import compute_promotion_queue
+
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        for _ in range(RETIRE_AFTER_IGNORES):
+            record_outcome(db, mid, followed=False)
+        q = compute_promotion_queue(db)
+        assert q["counts"]["drift"] == 1
+        assert q["drift"][0]["ignored_count"] == RETIRE_AFTER_IGNORES
+        assert q["drift"][0]["suggest"] == "retire"
+
+    def test_memory_drift_rows_unchanged(self, db):
+        from neurostack.promotion import compute_promotion_queue
+
+        mid = _add_memory(db, "Drifted memory", ["x"])
+        db.execute(
+            "INSERT INTO prediction_errors (note_path, query, cosine_distance,"
+            " error_type, memory_id) VALUES ('a.md', '', 0.7, 'memory_drift', ?)",
+            (mid,),
+        )
+        db.commit()
+        q = compute_promotion_queue(db)
+        assert q["counts"]["drift"] == 1
+        assert q["drift"][0]["drifted_from"] == "a.md"
+        assert "ignored_trigger" not in q["drift"][0]
+
+
+class TestMigration:
+    def test_creates_trigger_log_when_absent(self, db):
+        from neurostack.schema import SCHEMA_VERSION, _run_migrations
+
+        db.execute("DROP TABLE trigger_log")
+        db.execute("UPDATE schema_version SET version = 24")
+        db.commit()
+        _run_migrations(db)
+        assert db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == SCHEMA_VERSION
+        cols = {r[1] for r in db.execute("PRAGMA table_info(trigger_log)")}
+        assert {"log_id", "memory_id", "event", "value", "session_hint", "fired_at"} <= cols


### PR DESCRIPTION
Part of #136

## What

A trigger memory that fires and gets ignored is noise forever. This PR makes that measurable through the table the promotion queue already reads, instead of decaying a confidence score on the memory.

- Schema v25 adds `trigger_log(log_id, memory_id, event, value, session_hint, fired_at)`, cascade on memory delete. `vault_triggers` writes one row per hit and gains an optional `session_hint`. Its read-only annotation is gone because it now writes.
- New tool `vault_trigger_outcome(memory_id, followed, note=None)`. `followed=true` writes nothing. `followed=false` inserts a `prediction_errors` row with `error_type='trigger_ignored'`, `note_path=''`, `cosine_distance=0`, `context` set to the trigger tag that matched the last logged firing (falls back to the memory's first trigger tag when nothing was logged), `query` set to the caller's note. The reply carries `ignored_count` and `suggest: "retire"` once the count reaches `RETIRE_AFTER_IGNORES` (3). The memory row is never touched.
- `promotion._drift_bucket` keeps the `memory_drift` query as it was and appends one entry per memory with unresolved `trigger_ignored` rows, carrying `ignored_trigger`, `ignored_count`, `detected_at`, and `suggest: retire` at three.

## Tests

`tests/test_trigger_outcome.py`, 12 tests covering the six acceptance cases in #136 plus cascade delete, unknown memory, and the never-fired fallback. Existing `memory_drift` tests in `tests/test_promotion.py` are unchanged and still pass. Full suite 884 passed.

## Client half, outside this repo

`~/.omp/agent/extensions/neurostack-brief.ts` keeps a `pendingOutcome` map keyed by memory id with a 5-call window. A `when-calling` or `when-editing` memory is reported ignored when the blocked call is re-issued byte-identical (same tool, same JSON input); a `when-error` memory is reported ignored when the same error text recurs. Silence for 5 calls reports followed. Verified in Bun with a fake MCP server. A blocked `write` re-issued unchanged produced `{memory_id: 42, followed: false}`, an error trigger with no recurrence produced `{memory_id: 77, followed: true}` after 5 calls.

## Not in this PR

Confidence scores or decay on the memory row. Automatic deletion. A Claude Code PreToolUse hook.
