### PR TITLE
fix(checkpoint): save on the harvest budget and guard a dropped reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 - **#90 — archive-on-forget.** Every memory delete path (`vault_forget`/`memories forget`, merge source, TTL expiry, prune) now moves the row to a `memories_archive` table instead of destroying it. Archived rows are outside search/FTS/drift by construction but stay greppable and restorable. New CLI: `neurostack memories archived [-w] [--limit N]` and `neurostack memories restore ID` (restored rows re-embed via `backfill memories`). `memories stats` gains `archived`; MCP `vault_forget` result carries `archived: true`.
 
+### Fixed
+
+- **#153 — a checkpoint save no longer drops the reply the model wrote.** `neurostack hook checkpoint --save` now spends the `harvest_timeout_s` budget (600 s by default) on each `vault_remember` instead of the 5 s interactive `timeout_s`, because the server embeds every memory as it stores it. A non-empty reply that parses to zero items records `reply had no items: <first 120 chars>` in `learn-status.json` and puts the window back on offer, so prose can no longer pass for a clean checkpoint of nothing. A literal `[]` still counts as ok with 0 saved and settles the window, and an empty body keeps the window on offer without recording an error. Every `--save` writes its raw stdin to `~/.cache/neurostack/last-capture.txt`, so a capture bug is inspectable after the fact. The omp adapter waits for a JSON-shaped reply and skips up to 3 prose messages before it gives up with an empty save, which stops a model that thinks out loud first from losing its own summary.
+
 ### Schema
 
 - v21 → v22: `memories_archive` table (#90).

--- a/src/neurostack/adapters/omp_neurostack.ts
+++ b/src/neurostack/adapters/omp_neurostack.ts
@@ -4,8 +4,14 @@
 // retrieval and suppression decision belongs to the CLI, never to this file.
 //
 // The checkpoint (#143) needs the session's own model. omp's extension API has no
-// completion call, so the prompt goes in as a user message and the next assistant
-// message is piped to `checkpoint --save`.
+// completion call, so the prompt goes in as a user message and the first JSON-shaped
+// assistant message after it is piped to `checkpoint --save` (#153).
+//
+// Neither message can be hidden from the transcript: `pi.sendUserMessage(content,
+// { deliverAs })` takes no display flag (extensions.md, "Message delivery
+// semantics"), `display: false` belongs to `pi.sendMessage` custom payloads which
+// the model never reads, and the reply is the model's own entry either way. The
+// prompt is tagged so it reads as machinery, and it asks for JSON only.
 type Block = { type?: string; text?: string };
 type Content = string | Block[] | undefined;
 type Msg = { role?: string; content?: Content };
@@ -28,6 +34,11 @@ const EVERY_MESSAGES = 40;
 const QUIET_MS = 30 * 60_000;
 const MIN_MESSAGES = 5;
 const TICK_MS = 60_000;
+// Prose is the model answering the user, not the checkpoint, so it is skipped
+// instead of piped to `--save` as a reply that parses to nothing. Three of those
+// and the window goes back on offer (#153).
+const MAX_REPLY_TRIES = 3;
+const JSON_SHAPE = /^[[{]|```(?:json)?\s*[[{]|\[\s*\{/;
 
 function spawn(args: string[], stdin: string) {
   const proc = Bun.spawn([BIN, "hook", ...args], { stdin: "pipe", stdout: "pipe", stderr: "ignore" });
@@ -53,6 +64,13 @@ export default function neurostack(pi: Pi): void {
   let baseline = 0;
   let lastMessageAt = Date.now();
   let awaiting = false;
+  let tries = 0;
+
+  function save(reply: string) {
+    // An empty body tells the CLI the answer never arrived, so it re-offers
+    // the window rather than counting it as summarized.
+    spawn(["checkpoint", "--save", "--harness", "omp", "--session", SESSION], reply).unref();
+  }
 
   async function checkpoint() {
     if (awaiting || seen.length <= baseline) return;
@@ -60,6 +78,7 @@ export default function neurostack(pi: Pi): void {
     if (!text) return;
     baseline = seen.length;
     awaiting = true;
+    tries = 0;
     pi.sendUserMessage(`<neurostack-checkpoint>\n${text}\n</neurostack-checkpoint>`, { deliverAs: "followUp" });
   }
 
@@ -98,13 +117,22 @@ export default function neurostack(pi: Pi): void {
     next[i] = { ...messages[i], content: append(messages[i].content, `\n\n${text}`) };
     return { messages: next };
   });
-  // The model's answer to the checkpoint prompt arrives as an ordinary reply.
+  // The model's answer to the checkpoint prompt arrives as an ordinary reply, and
+  // not always the first one: it may talk to the user before it answers.
   pi.on("message_end", (e) => {
     const message = e.message ?? e;
     if (!awaiting || message.role !== "assistant") return;
-    awaiting = false;
     const reply = textOf(message.content).trim();
-    if (reply) spawn(["checkpoint", "--save", "--harness", "omp", "--session", SESSION], reply).unref();
+    if (JSON_SHAPE.test(reply)) {
+      awaiting = false;
+      tries = 0;
+      save(reply);
+      return;
+    }
+    if (++tries < MAX_REPLY_TRIES) return;
+    awaiting = false;
+    tries = 0;
+    save("");
   });
   // Harvest outlives the session: hand the transcript id over and detach.
   pi.on("session_shutdown", (_e, ctx) => {

--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -743,8 +743,8 @@ def _event_checkpoint(client: McpClient, payload: dict, state: SessionState,
     ))
 
 
-def _parse_items(reply: str) -> list[dict]:
-    """The model's reply as memory items.
+def _reply_json(reply: str):
+    """The JSON the model meant, dug out of a fence or a sentence, or None.
 
     Models fence their JSON, wrap it in a sentence, or send a single object
     instead of an array. All three are accepted: a checkpoint is too cheap to
@@ -762,6 +762,12 @@ def _parse_items(reply: str) -> list[dict]:
                 parsed = _loose_json(match.group(0))
                 if parsed is not None:
                     break
+    return parsed
+
+
+def _parse_items(reply: str) -> list[dict]:
+    """The model's reply as memory items."""
+    parsed = _reply_json(reply)
     if isinstance(parsed, dict):
         parsed = [parsed]
     if not isinstance(parsed, list):
@@ -775,6 +781,47 @@ def _loose_json(blob: str):
         return json.loads(blob)
     except ValueError:
         return None
+
+
+def _lost_reply(reply: str, items: list[dict]) -> str | None:
+    """Why a reply that saved nothing was a dropped reply, or None (issue #153).
+
+    Zero items is only the honest answer when the model said so: an empty
+    body, or an empty JSON container. Prose, a truncated array, or items
+    without content mean a window was summarized and then thrown away, which
+    has to cost a repeat prompt instead of passing for a clean checkpoint.
+    """
+    if items:
+        return None
+    blob = reply.strip()
+    if not blob:
+        return None
+    parsed = _reply_json(reply)
+    if isinstance(parsed, (list, dict)) and not parsed:
+        return None
+    return f"reply had no items: {blob[:120]}"
+
+
+def last_capture_path() -> Path:
+    """The raw reply of the most recent `--save` (issue #153).
+
+    A capture bug is invisible from the outside: `saved 0 of 0` reads the same
+    whether the model kept nothing or the harness handed over the wrong text.
+    One overwritten file settles which.
+    """
+    return cache_dir() / "last-capture.txt"
+
+
+def _write_last_capture(reply: str) -> None:
+    path = last_capture_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(reply, encoding="utf-8")
+        # This is the one copy of the reply that redaction never touched, so
+        # it stays readable by its owner alone.
+        path.chmod(0o600)
+    except OSError as exc:
+        print(f"neurostack hook checkpoint: capture not written: {exc}", file=sys.stderr)
 
 
 def _remember_args(item: dict, harness: str, workspace: str | None) -> dict:
@@ -810,22 +857,33 @@ def run_checkpoint_save(reply: str, session: str, harness: str = "cli",
     cfg = cfg or load_client_config()
     client = client or McpClient(cfg)
     state = load_state(session)
+    _write_last_capture(reply)
     items = _parse_items(reply)
+    lost = _lost_reply(reply, items)
+    # An empty body is the harness giving up on capturing an answer, not the
+    # model declining: nothing failed, but the window has not been summarized.
+    answered = bool(reply.strip())
     workspace = cfg.workspace_for(os.getcwd())
     saved = 0
     try:
         for item in items:
+            # One write per memory against a server that embeds each one, so
+            # this gets the harvest budget: the interactive timeout exists to
+            # keep tool calls responsive, and spending it here loses the
+            # memories the model already wrote (issue #153).
             if client.call_json("vault_remember",
-                                _remember_args(item, harness, workspace)) is not None:
+                                _remember_args(item, harness, workspace),
+                                timeout_s=cfg.harvest_timeout_s) is not None:
                 saved += 1
-        if saved == len(items):
+        if answered and lost is None and saved == len(items):
             # The index moves on whatever the model chose to keep: it was asked
             # about this window, and asking twice is what the dedup prevents.
             state.since_index = max(state.since_index, state.offered_index)
             state.last_checkpoint_at = time.time()
         else:
-            # An unreachable server must cost a repeat prompt, not the
-            # memories: put the window back on offer.
+            # An unreachable server, a dropped reply, or a harness that never
+            # got the answer must cost a repeat prompt, not the memories: put
+            # the window back on offer.
             state.offered_index = state.since_index
         state.save()
     finally:
@@ -834,6 +892,9 @@ def run_checkpoint_save(reply: str, session: str, harness: str = "cli",
         print(f"neurostack hook checkpoint: {client.errors[0]}", file=sys.stderr)
     # Every attempt ends in the health file, so a login that expired weeks ago
     # shows up in the next session brief instead of a journal (issue #151).
+    if lost is not None:
+        record_error(session, harness, lost)
+        return Verdict(f"neurostack: checkpoint {lost}")
     if saved == len(items):
         record_ok(session, harness, saved)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import textwrap
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
@@ -201,6 +202,10 @@ class FakeMcpHandler(BaseHTTPRequestHandler):
             name = params.get("name")
             args = params.get("arguments") or {}
             self.server.calls.append((name, args))
+            # A real server embeds every memory it stores, which outlasts the
+            # interactive timeout; `delay_s` makes that testable (issue #153).
+            if self.server.delay_s:
+                time.sleep(self.server.delay_s)
             reply = self.server.replies.get(name)
             payload = reply(args) if callable(reply) else ({} if reply is None else reply)
             self._send({"jsonrpc": "2.0", "id": body.get("id"),
@@ -229,6 +234,7 @@ def server():
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), FakeMcpHandler)
     httpd.calls = []
     httpd.replies = {}
+    httpd.delay_s = 0.0
     httpd.url = f"http://127.0.0.1:{httpd.server_address[1]}/mcp"
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     thread.start()

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -10,6 +10,7 @@ does with the JSON that comes back. Both run against the fake MCP endpoint in
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -24,7 +25,14 @@ from neurostack.adapters import (
     install_claude_adapter,
     install_omp_adapter,
 )
-from neurostack.cli.hook import _state_path, run_checkpoint, run_checkpoint_save, run_event
+from neurostack.cli.hook import (
+    _state_path,
+    last_capture_path,
+    run_checkpoint,
+    run_checkpoint_save,
+    run_event,
+)
+from neurostack.cli.learn_status import load_learn_status, record_ok
 from neurostack.client import ClientConfig
 
 LONG_OUTPUT = "x" * 2000
@@ -387,7 +395,11 @@ console.log(log.join("\\n"));
 _FAKE_BIN = """\
 #!/bin/sh
 printf '%s\\n' "$*" >>"$NEUROSTACK_TEST_LOG"
-cat >/dev/null
+if [ -n "$NEUROSTACK_TEST_SAVES" ] && [ "$3" = "--save" ]; then
+  { printf '<<<'; cat; printf '>>>\\n'; } >>"$NEUROSTACK_TEST_SAVES"
+else
+  cat >/dev/null
+fi
 case "$2 $3" in
   "checkpoint --save") ;;
   checkpoint*) echo "a checkpoint prompt" ;;
@@ -508,3 +520,161 @@ def test_assistant_text_goes_in_whole(server):
     ]
     verdict = run_event("checkpoint", _payload(messages), cfg=_cfg(server))
     assert long_answer.strip() in verdict.text
+
+
+# ---------------------------------------------------------------------------
+# Issue #153 — a save never loses the reply the model already wrote
+# ---------------------------------------------------------------------------
+
+def test_a_slow_server_still_saves_on_the_harvest_budget(server):
+    """Every memory is embedded server-side, which outlasts the tool timeout."""
+    server.delay_s = 0.6
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 9}
+    cfg = ClientConfig(url=server.url, timeout_s=0.2, harvest_timeout_s=60.0)
+    verdict = run_checkpoint_save(REPLY, "ck", "omp", cfg=cfg)
+    assert "saved 2 of 2" in verdict.text
+    assert len(_tool_calls(server, "vault_remember")) == 2
+
+
+def test_the_interactive_budget_would_have_lost_the_same_save(server):
+    """What the harvest budget buys: the 5 s tool timeout drops both memories."""
+    server.delay_s = 0.6
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 9}
+    cfg = ClientConfig(url=server.url, timeout_s=0.2, harvest_timeout_s=0.2)
+    verdict = run_checkpoint_save(REPLY, "ck", "omp", cfg=cfg)
+    assert "saved 0 of 2" in verdict.text
+
+
+def test_prose_records_an_error_and_re_offers_the_window(server):
+    messages = _messages(20)
+    run_event("checkpoint", _payload(messages), cfg=_cfg(server))
+    verdict = run_checkpoint_save("Nothing new here.", "ck", "omp", cfg=_cfg(server))
+    assert server.calls == []
+    assert "no items" in verdict.text
+    state = _state("ck")
+    assert state["since_index"] == 0
+    assert state["offered_index"] == 0
+    assert "no items" in load_learn_status()["last_error"]
+    # The window comes back rather than dying with the dropped reply.
+    assert run_event("checkpoint", _payload(messages), cfg=_cfg(server)).text != ""
+
+
+def test_a_literal_empty_array_settles_the_window_as_ok(server):
+    """`[]` is the model saying nothing here is worth keeping."""
+    record_ok("ck", "omp", 3)
+    run_event("checkpoint", _payload(_messages(20)), cfg=_cfg(server))
+    verdict = run_checkpoint_save("[]", "ck", "omp", cfg=_cfg(server))
+    assert "saved 0 of 0" in verdict.text
+    assert _state("ck")["since_index"] == 40
+    status = load_learn_status()
+    assert status["last_error"] is None
+    assert status["saved_today"] == 3
+
+
+def test_an_empty_body_keeps_the_window_without_an_error(server):
+    """The adapter sends an empty body when the answer never came."""
+    messages = _messages(20)
+    run_event("checkpoint", _payload(messages), cfg=_cfg(server))
+    verdict = run_checkpoint_save("", "ck", "omp", cfg=_cfg(server))
+    assert "saved 0 of 0" in verdict.text
+    state = _state("ck")
+    assert state["since_index"] == 0
+    assert state["offered_index"] == 0
+    assert load_learn_status()["last_error"] is None
+    assert run_event("checkpoint", _payload(messages), cfg=_cfg(server)).text != ""
+
+
+def test_every_save_writes_the_reply_to_the_capture_file(server):
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 10}
+    for reply in (REPLY, "Nothing new here.", ""):
+        run_checkpoint_save(reply, "ck", "omp", cfg=_cfg(server))
+        assert last_capture_path().read_text(encoding="utf-8") == reply
+
+
+def test_the_capture_file_holds_the_bytes_the_cli_read(server, isolated_home):
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 11}
+    _run_cli(["checkpoint", "--session", "cap-1"],
+             json.dumps({"messages": _messages(20), "since_index": 0}),
+             server.url, isolated_home)
+    saved = _run_cli(["checkpoint", "--save"], REPLY, server.url, isolated_home)
+    assert saved.returncode == 0
+    assert last_capture_path().read_bytes() == REPLY.encode()
+
+
+_REPLY_DRIVER = """\
+import extension from "{adapter}";
+
+const injected: string[] = [];
+const handlers: Record<string, (e: unknown, c: unknown) => unknown> = {{}};
+
+extension({{
+  on: (e, h) => {{ handlers[e] = h; }},
+  sendMessage: () => {{}},
+  sendUserMessage: (_t: string, o?: object) => {{ injected.push(JSON.stringify(o ?? null)); }},
+  registerCommand: () => {{}},
+}} as never);
+
+const ctx = {{ setInterval: () => {{}} }};
+await handlers.session_start?.({{}}, ctx);
+const settle = () => new Promise((r) => setTimeout(r, 400));
+const messages = Array.from({{ length: 40 }}, (_v, i) => ({{
+  role: i % 2 === 0 ? "user" : "assistant",
+  content: `message ${{i}}`,
+}}));
+await handlers.context?.({{ messages }}, ctx);
+await settle();
+
+for (const content of {replies} as string[]) {{
+  handlers.message_end?.({{ message: {{ role: "assistant", content }} }}, ctx);
+  await settle();
+}}
+console.log(`options=${{injected[0]}}`);
+"""
+
+
+def _drive_replies(isolated_home, tmp_path, replies):
+    """Drive the generated extension through a run of assistant replies."""
+    calls = tmp_path / "calls.txt"
+    saves = tmp_path / "saves.txt"
+    saves.write_text("")
+    fake_bin = tmp_path / "neurostack"
+    fake_bin.write_text(_FAKE_BIN)
+    fake_bin.chmod(0o755)
+    adapter = _install_omp(isolated_home, binary=str(fake_bin))
+    driver = tmp_path / "driver.ts"
+    driver.write_text(_REPLY_DRIVER.format(adapter=adapter, replies=json.dumps(replies)))
+    result = subprocess.run(
+        [BUN, "run", str(driver)], capture_output=True, text=True, timeout=120,
+        env={**os.environ, "NEUROSTACK_TEST_LOG": str(calls),
+             "NEUROSTACK_TEST_SAVES": str(saves)},
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout, re.findall(r"<<<(.*?)>>>", saves.read_text(), re.DOTALL)
+
+
+@pytest.mark.skipif(BUN is None, reason="bun not installed")
+def test_the_adapter_waits_past_prose_for_the_json_reply(isolated_home, tmp_path):
+    stdout, bodies = _drive_replies(
+        isolated_home, tmp_path,
+        ["I read the window. One thought before the list.", '[{"content": "x"}]'],
+    )
+    assert bodies == ['[{"content": "x"}]']
+    # The prompt goes in through the prompt flow, which takes no display flag.
+    assert '"deliverAs":"followUp"' in stdout
+
+
+@pytest.mark.skipif(BUN is None, reason="bun not installed")
+def test_three_prose_replies_give_up_with_an_empty_save(isolated_home, tmp_path):
+    _stdout, bodies = _drive_replies(
+        isolated_home, tmp_path,
+        ["first thought", "second thought", "third thought"],
+    )
+    assert bodies == [""]
+
+
+def test_the_adapter_documents_why_the_prompt_stays_visible(isolated_home):
+    """Acceptance 6: `display: false` is unavailable, so the reason is in view."""
+    source = _install_omp(isolated_home).read_text()
+    assert "MAX_REPLY_TRIES = 3" in source
+    assert "display: false" in source
+    assert "sendUserMessage(content" in source

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -308,7 +308,10 @@ def test_omp_adapter_is_generated_without_an_address(isolated_home, tmp_path):
     assert "__NEUROSTACK_BIN__" not in source
     assert not any(part.replace(".", "").isdigit() and part.count(".") == 3
                    for part in source.split())
-    assert len(source.splitlines()) < 120
+    # The adapter maps events and captures the reply; every retrieval rule
+    # stays in the CLI. The ceiling rose once for the reply filter and the
+    # note on what omp's message API cannot hide (issue #153).
+    assert len(source.splitlines()) < 150
 
 
 @pytest.mark.skipif(BUN is None, reason="bun not installed")


### PR DESCRIPTION
Part of #153

## What broke

Two `checkpoint --save` paths lost memories the model had already written. The
first live in-session checkpoint reported `saved 0 of 0` and advanced
`since_index`, so 8 items went nowhere and the window was never re-offered. The
second hit a `ReadTimeout` because `--save` spent the 5 s interactive
`timeout_s` on a server that embeds every memory as it stores it.

## What changed

- Each `vault_remember` in `--save` now runs on `cfg.harvest_timeout_s` (600 s
  by default), the same budget `session-end` uses for an inline harvest.
- A non-empty reply that parses to zero items records
  `reply had no items: <first 120 chars>` in `learn-status.json` and sets
  `offered_index = since_index`, so the window comes back. A literal `[]`
  still counts as ok with 0 saved and settles the window. An empty body records
  ok and keeps the window on offer, which is what the adapter sends when the
  answer never arrived.
- Every `--save` writes its raw stdin to `~/.cache/neurostack/last-capture.txt`
  (mode 0600, overwritten each time), so the next capture bug is inspectable
  instead of invisible.
- The omp adapter's `message_end` handler accepts a reply that starts with `[`
  or `{`, carries a fenced JSON block, or contains a `[{` array-of-objects
  opener. Prose keeps the wait open for up to 3 assistant messages, then the
  adapter gives up with an empty `--save` and the window returns to the queue.
- `_parse_items` was split so `_reply_json` can answer "did the model send an
  empty container, or did we drop its reply?" without a second parser.

## Gate

- `uv run ruff check src/ tests/` passed clean, exit 0.
- `uv run pytest -q` passed, exit 0, with 12 new tests in
  `tests/test_checkpoint.py` including 2 Bun-driven adapter tests.
- The fake MCP server in `tests/conftest.py` gained `delay_s`, a per-`tools/call`
  sleep, which is how the budget is tested without a real embedder.

## Verified

- Old code against a prose reply advanced `since_index` from 0 to 40 and left
  `last_error` unset. New code leaves both indexes at 0 and writes
  `reply had no items: Nothing new here.`
- Old adapter piped the prose message (`<<<I read the window. One thought
  before the list.>>>`) to `--save` and dropped the JSON array that followed.
  New adapter pipes only `[{"content": "x"}]`.
- `test_the_interactive_budget_would_have_lost_the_same_save` holds the
  regression: on a server slower than `timeout_s`, the old budget saves 0 of 2.

## omp `display` finding

`pi.sendUserMessage(content, { deliverAs })` takes no display flag. The
extension docs ("Message delivery semantics") list `deliverAs` and
`triggerTurn` as the whole option surface, and `display` belongs to
`pi.sendMessage` custom payloads, which never reach the model. The model's
reply is its own transcript entry, so neither message can be hidden today.
The adapter header records this, the prompt stays tagged
`<neurostack-checkpoint>`, and the test asserts the reason is still in the
source. An ephemeral `context`-event injection (the `adhd-mode.ts` pattern)
would hide the prompt, but it only shapes the turn already in flight, which
would mix the checkpoint JSON into the answer the user is waiting for.

## Deploy

No server change. `hook.py` and the adapter template are client-side, so the
lead reinstalls with `neurostack hooks install --harness omp` after merge; LXC
122 needs nothing.
