### PR TITLE
feat(triggers): count the triggers the agent obeyed (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- **#159 — a re-issued call is no longer counted as an ignore.** The client hook used to report `followed=false` the moment the blocked call came back byte-identical, which is what a model does when it has read the warning and judged that it does not apply, so ignores were over-counted. Nothing about the next call settles a `when-calling` or `when-editing` trigger now: 5 later tool calls with no outcome reported mark it followed, and a re-issue of the same tool spends one of those 5 whether the input changed or not. The `when-error` rule is untouched, so the same error text coming back still reports an ignore.
+
 - **#155 — the checkpoint runs in the background and puts nothing in the chat.** The omp adapter no longer injects a prompt with `pi.sendUserMessage` or watches for the model's reply: it writes the window to `~/.cache/neurostack/sessions/<session>.window.json` (`{since_index, messages}`) and spawns `neurostack hook checkpoint --run --harness omp --session <id>` detached, so the summarising happens through `checkpoint_command` with nothing in the transcript. `/save` does the same and prints one line — `NeuroStack: checkpoint started in the background`, or `NeuroStack: nothing to save yet (N messages)` under the 5-message floor, which used to be silence. Claude Code's `Stop` entry and `~/.claude/commands/save.md` run `checkpoint --run --harness claude` under `nohup` instead of blocking the turn with exit 2. `checkpoint --run` reads the window file when stdin is empty, deletes it once the memories are saved, and takes the session from the newest state file when no id is passed; every `--run` failure now goes to stderr and `learn-status.json` instead of stdout, where a harness would inject it. `checkpoint --save` is unchanged for herdr and hand use.
 
 - Checkpoint prompts now carry assistant text in full; only tool output is clipped at 500 chars (#149)
@@ -15,6 +17,8 @@
 - **#142 — config keys `llm_url` / `llm_model` / `llm_api_key` are now `index_llm_url` / `index_llm_model` / `index_llm_api_key`** (env `NEUROSTACK_INDEX_LLM_URL` / `_MODEL` / `_API_KEY`), naming what the endpoint is for now that nothing calls it on a query. The old TOML keys and `NEUROSTACK_LLM_*` env vars still load into the new fields and log one deprecation line per config load naming every old name seen; setting the new name wins when both appear. `neurostack init` / `install`'s `--llm-model` and `consolidate` / `synthesize`'s `--llm-model` are now `--index-llm-model`; `--summarize-url` keeps its name and feeds `index_llm_url`.
 
 ### Added
+
+- **#159 — the WARN obey count.** `trigger_log` gained `followed` and `outcome_at`, so `vault_trigger_outcome` marks the firing it belongs to instead of writing nothing when the agent obeyed — NULL is pending, 1 is followed, 0 is ignored. The tool takes a `session_hint` and puts the outcome on that session's newest pending firing, falling back to the newest pending firing of any session for a client that sends no hint. New `trigger_stats(conn, days=30)` returns fired, followed, ignored and pending counts plus the followed share of the settled firings, per memory and in total. `neurostack triggers stats [--days N]` prints it, `vault_stats` carries the totals under `triggers.last_30d`, and the `neurostack status` LEARN block gained one line: `WARN: N fired, M followed, K ignored (30d)`.
 - **#151 — LEARN visibility.** Every checkpoint attempt now writes `~/.cache/neurostack/learn-status.json` (`last_ok_at`, `last_error_at`, `last_error`, `saved_today`, `session`, `harness`), and `neurostack hook session-start` prints one line from it before the brief: `LEARN: ok, N memories today, last HH:MM`, `LEARN: FAILING since <when>: <error>`, `LEARN: stale, no checkpoint since <when>` past 48 hours, or `LEARN: never ran`. The line comes first so it survives a truncated brief, and it prints on its own when the server is unreachable. `neurostack status` shows the same line, a 7-day table of memories by `source_agent`, and how many live sessions have a transcript longer than the window the model was last offered. `vault_stats` gained `memories.by_source_7d` for that table — `vault_memories` takes no date filter, so the count is grouped in SQL on the server instead of shipping a week of memories to the client.
 
 - `neurostack hook checkpoint --run` pipes the checkpoint prompt through `checkpoint_command` from `client.toml` (for example `claude -p --model sonnet`) and saves the reply, for timers and herdr where no harness model is at hand. Runs from `$HOME` so a project's agent instructions cannot shape the extraction (#147)
@@ -41,6 +45,7 @@
 
 - v21 → v22: `memories_archive` table (#90).
 - v24 → v25: `trigger_log` table (#136).
+- v25 → v26: `trigger_log.followed`, `outcome_at` (#159).
 
 ## v0.16.0 — Retrieval & extraction fixes (2026-06-11)
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ neurostack hooks install                 # hourly harvest timer
 neurostack hooks install --harness claude   # or: omp
 neurostack hooks status
 
+# Trigger memories: did the warnings change anything?
+neurostack triggers stats                # fired, followed, ignored per memory (30d)
+neurostack triggers stats --days 7
+
 # Checkpoint: a background model writes the memories, mid-session
 neurostack hook checkpoint --run --session <id>  # summarise and save, silently
 neurostack hook checkpoint --save               # a model's JSON reply on stdin

--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -51,6 +51,7 @@ from .setup import (
     cmd_uninstall,
     cmd_update,
 )
+from .triggers import cmd_triggers
 from .utils import _handle_error
 from .writeback import cmd_migrate, cmd_sync
 
@@ -785,6 +786,13 @@ def main():
     # stats
     p = sub.add_parser("stats", help="Show index stats")
     p.set_defaults(func=cmd_stats)
+
+    # triggers (issue #159)
+    p = sub.add_parser("triggers", help="Report how often trigger memories were followed")
+    trig_sub = p.add_subparsers(dest="triggers_command")
+    tp = trig_sub.add_parser("stats", help="Fired, followed, and ignored counts per memory")
+    tp.add_argument("--days", type=int, default=30, help="Window in days (default: 30)")
+    p.set_defaults(func=cmd_triggers)
 
     # record-usage
     p = sub.add_parser(

--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -38,8 +38,10 @@ from .learn_status import cache_dir, learn_line, record_error, record_ok
 EVENTS = ("session-start", "prompt", "tool-call", "tool-result", "checkpoint",
           "session-end")
 
-# After a trigger fires, watch this many later tool calls: a byte-identical
-# re-issue means the memory was ignored, silence means it was followed (#136).
+# After a calling/editing trigger fires, watch this many later tool calls: the
+# next call says nothing either way — re-issuing the blocked call unchanged is
+# what a model does when it decides the warning does not apply — so only the
+# window elapsing settles the outcome, as followed (#136, #159).
 OUTCOME_WINDOW = 5
 # 20 fired on "retry the mcp" and "do it", which carry no retrievable topic.
 MIN_PROMPT_LEN = 40
@@ -293,16 +295,8 @@ def _error_key(text: str) -> str:
     return text.strip()[:120].lower()
 
 
-def _call_key(tool: str, tool_input) -> str:
-    try:
-        body = json.dumps(tool_input, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        body = ""
-    return f"{tool}\x00{body}"
-
-
 # ---------------------------------------------------------------------------
-# Triggers and outcomes (issues #131 / #136)
+# Triggers and outcomes (issues #131 / #136 / #159)
 # ---------------------------------------------------------------------------
 
 def _valid_hit(hit) -> bool:
@@ -357,19 +351,20 @@ def _report_outcome(
     state.pending.pop(memory_id, None)
     client.call(
         "vault_trigger_outcome",
-        {"memory_id": memory_id, "followed": followed, "note": note},
+        {"memory_id": memory_id, "followed": followed, "note": note,
+         "session_hint": state.session},
     )
 
 
-def _observe_call(client: McpClient, state: SessionState, tool: str, tool_input) -> None:
-    """Settle pending outcomes and advance the window on every tool call."""
-    if not state.pending:
-        return
-    key = _call_key(tool, tool_input)
+def _observe_call(client: McpClient, state: SessionState) -> None:
+    """Advance the window on every tool call, and settle it when it runs out.
+
+    Nothing about the next call marks a calling/editing trigger as ignored: a
+    re-issue of the blocked call, byte-identical or not, is how a model acts on
+    a warning it has read and judged (#159). Only the error rule below can
+    report an ignore.
+    """
     for memory_id, pending in list(state.pending.items()):
-        if pending.get("kind") in ("calling", "editing") and pending.get("key") == key:
-            _report_outcome(client, state, memory_id, False, f"re-issued {tool} unchanged")
-            continue
         pending["remaining"] = int(pending.get("remaining", OUTCOME_WINDOW)) - 1
         if pending["remaining"] <= 0:
             _report_outcome(
@@ -473,7 +468,7 @@ def _event_tool_call(client: McpClient, payload: dict, state: SessionState,
     tool = _first_str(payload, "tool", "tool_name")
     tool_input = _tool_input(payload)
     state.calls += 1
-    _observe_call(client, state, tool, tool_input)
+    _observe_call(client, state)
     workspace = _workspace(cfg, payload)
     hits: list[dict] = []
     for name in _tool_names(tool, tool_input):
@@ -482,11 +477,9 @@ def _event_tool_call(client: McpClient, payload: dict, state: SessionState,
         hits += _fetch_triggers(client, state, "editing", path, workspace)
     if not hits:
         return Verdict()
-    key = _call_key(tool, tool_input)
     for hit in hits:
         state.pending[hit["memory_id"]] = {
             "kind": "editing" if hit["trigger"].startswith("when-editing:") else "calling",
-            "key": key,
             "remaining": OUTCOME_WINDOW,
         }
     return Verdict(

--- a/src/neurostack/cli/learn_status.py
+++ b/src/neurostack/cli/learn_status.py
@@ -105,13 +105,22 @@ def learn_line(status: dict | None = None, now: datetime | None = None) -> str:
             f"last {last_ok.strftime('%H:%M')}")
 
 
+def warn_line(warn: dict | None) -> str:
+    """Did the trigger warnings change anything? (issue #159)"""
+    if warn is None:
+        return "WARN: unavailable (the server predates issue #159)"
+    return (f"WARN: {warn['fired']} fired, {warn['followed']} followed, "
+            f"{warn['ignored']} ignored ({warn['days']}d)")
+
+
 def learn_report(client=None, cfg=None) -> dict:
     """The LEARN block for `neurostack status`.
 
     The 7-day counts come from the server's `vault_stats`, which groups them
     in SQL. `vault_memories` returns rows and takes no date filter, so
     counting client-side would mean shipping every memory of the week over
-    MCP — a server-side count is the cheap answer (issue #151).
+    MCP — a server-side count is the cheap answer (issue #151). The same reply
+    carries the 30-day trigger counts behind the WARN line (issue #159).
     """
     from ..client import McpClient, load_client_config
     from .hook import sessions_behind
@@ -120,6 +129,7 @@ def learn_report(client=None, cfg=None) -> dict:
         "line": learn_line(),
         "by_source": {},
         "sessions_behind": sessions_behind(),
+        "warn": None,
         "error": None,
     }
     client = client or McpClient(cfg or load_client_config())
@@ -130,6 +140,7 @@ def learn_report(client=None, cfg=None) -> dict:
     if stats is None:
         report["error"] = client.errors[0] if client.errors else "vault_stats did not answer"
         return report
+    report["warn"] = _warn_counts(stats.get("triggers"))
     memories = stats.get("memories")
     counts = memories.get("by_source_7d") if isinstance(memories, dict) else None
     if not isinstance(counts, dict):
@@ -138,6 +149,21 @@ def learn_report(client=None, cfg=None) -> dict:
     report["by_source"] = {str(k): int(v) for k, v in counts.items()
                            if isinstance(v, int) and not isinstance(v, bool)}
     return report
+
+
+def _warn_counts(triggers) -> dict | None:
+    """`triggers.last_30d` from vault_stats, or None when the server lacks it."""
+    window = triggers.get("last_30d") if isinstance(triggers, dict) else None
+    if not isinstance(window, dict):
+        return None
+    out = {key: _count(window.get(key))
+           for key in ("fired", "followed", "ignored", "pending")}
+    out["days"] = _count(window.get("days")) or 30
+    return out
+
+
+def _count(value) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 def _now() -> datetime:

--- a/src/neurostack/cli/setup.py
+++ b/src/neurostack/cli/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .. import __version__
 from ..config import _LEGACY_LLM_KEYS, CONFIG_PATH, get_config
-from .learn_status import learn_report
+from .learn_status import learn_report, warn_line
 from .utils import _get_vault_template_dir
 
 
@@ -1972,3 +1972,4 @@ def _print_learn(report: dict) -> None:
     else:
         print("  Memories (7d):  none")
     print(f"  Sessions behind: {report['sessions_behind']}")
+    print(f"  {warn_line(report.get('warn'))}")

--- a/src/neurostack/cli/triggers.py
+++ b/src/neurostack/cli/triggers.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Raphael Southall
+"""Trigger CLI commands (issue #159): did the warnings change anything?"""
+
+import json
+
+
+def cmd_triggers(args):
+    """Report fired-versus-followed counts for trigger memories."""
+    from ..schema import DB_PATH, get_db
+    from ..triggers import trigger_stats
+
+    subcmd = getattr(args, "triggers_command", None)
+    if subcmd != "stats":
+        print("Usage: neurostack triggers stats [--days N]")
+        return
+
+    stats = trigger_stats(get_db(DB_PATH), days=args.days)
+    if args.json:
+        print(json.dumps(stats, indent=2, default=str))
+        return
+
+    print(
+        f"Triggers ({stats['days']}d): {stats['fired']} fired,"
+        f" {stats['followed']} followed, {stats['ignored']} ignored,"
+        f" {stats['pending']} pending{_rate(stats['followed_rate'])}"
+    )
+    if not stats["memories"]:
+        print("No trigger fired in the window.")
+        return
+    print()
+    print(f"{'ID':<8}{'FIRED':<7}{'FOLLOWED':<10}{'IGNORED':<9}{'PENDING':<9}RATE")
+    for entry in stats["memories"]:
+        rate = entry["followed_rate"]
+        print(
+            f"{entry['memory_id']:<8}{entry['fired']:<7}{entry['followed']:<10}"
+            f"{entry['ignored']:<9}{entry['pending']:<9}"
+            f"{'-' if rate is None else f'{rate * 100:.0f}%'}"
+        )
+        print(f"        {entry['trigger'] or 'no trigger tag'}: {entry['content']}")
+
+
+def _rate(rate: float | None) -> str:
+    """The followed share, or nothing at all while no outcome is in."""
+    return "" if rate is None else f" ({rate * 100:.0f}% followed)"

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,7 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -263,15 +263,20 @@ CREATE INDEX IF NOT EXISTS idx_pred_errors_unresolved
 -- Trigger firings (issue #136): one row each time vault_triggers returned a
 -- memory. Together with prediction_errors rows of type 'trigger_ignored' this
 -- tells the promotion queue which triggers fire but get ignored.
+-- `followed` (issue #159) closes the other half: NULL is pending, 1 followed,
+-- 0 ignored, so a fired trigger has an obey count and not only an ignore count.
 CREATE TABLE IF NOT EXISTS trigger_log (
     log_id INTEGER PRIMARY KEY AUTOINCREMENT,
     memory_id INTEGER NOT NULL REFERENCES memories(memory_id) ON DELETE CASCADE,
     event TEXT NOT NULL,
     value TEXT NOT NULL,
     session_hint TEXT,
-    fired_at TEXT NOT NULL DEFAULT (datetime('now'))
+    fired_at TEXT NOT NULL DEFAULT (datetime('now')),
+    followed INTEGER,
+    outcome_at TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_trigger_log_memory ON trigger_log(memory_id);
+CREATE INDEX IF NOT EXISTS idx_trigger_log_fired ON trigger_log(fired_at);
 
 -- Agent-written memories (write-back layer)
 CREATE TABLE IF NOT EXISTS memories (
@@ -1201,6 +1206,40 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (25)")
         conn.commit()
         log.info("Migration to v25 complete.")
+
+    if current < 26:
+        log.info(
+            "Migrating schema v25 -> v26: trigger_log.followed/outcome_at — "
+            "count the triggers the agent obeyed, not only the ignored ones "
+            "(issue #159)..."
+        )
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS trigger_log (
+                log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id INTEGER NOT NULL
+                    REFERENCES memories(memory_id) ON DELETE CASCADE,
+                event TEXT NOT NULL,
+                value TEXT NOT NULL,
+                session_hint TEXT,
+                fired_at TEXT NOT NULL DEFAULT (datetime('now')),
+                followed INTEGER,
+                outcome_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_trigger_log_memory
+                ON trigger_log(memory_id);
+            CREATE INDEX IF NOT EXISTS idx_trigger_log_fired
+                ON trigger_log(fired_at);
+        """)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(trigger_log)")}
+        # Firings logged before this migration have no reported outcome, so
+        # they stay pending: NULL, never 0.
+        if "followed" not in cols:
+            conn.execute("ALTER TABLE trigger_log ADD COLUMN followed INTEGER")
+        if "outcome_at" not in cols:
+            conn.execute("ALTER TABLE trigger_log ADD COLUMN outcome_at TEXT")
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (26)")
+        conn.commit()
+        log.info("Migration to v26 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/src/neurostack/tools/memory_tools.py
+++ b/src/neurostack/tools/memory_tools.py
@@ -342,11 +342,13 @@ def vault_trigger_outcome(
     memory_id: int,
     followed: bool,
     note: str = None,
+    session_hint: str = None,
 ) -> dict:
     """Report whether a fired trigger memory was followed (issue #136).
 
     Call once per fired memory, a few tool calls after vault_triggers returned
-    it. followed=true writes nothing. followed=false records a
+    it. Either outcome marks the logged firing (trigger_log.followed), so the
+    obey count is measurable too (issue #159). followed=false also records a
     'trigger_ignored' prediction error; the promotion queue's drift bucket
     lists the memory with its running ignore count and suggests retiring the
     trigger after three. Nothing is deleted automatically.
@@ -354,10 +356,14 @@ def vault_trigger_outcome(
     Args:
         memory_id: The memory vault_triggers returned
         followed: True if the agent changed course because of it
-        note: Optional short reason, e.g. "re-issued the same call unchanged"
+        note: Optional short reason, e.g. "the call came back changed"
+        session_hint: The same client session id passed to vault_triggers, so
+            the outcome lands on that session's firing
     """
     from ..schema import DB_PATH, get_db
     from ..triggers import record_outcome
 
     conn = get_db(DB_PATH)
-    return record_outcome(conn, memory_id, followed=followed, note=note)
+    return record_outcome(
+        conn, memory_id, followed=followed, note=note, session_hint=session_hint
+    )

--- a/src/neurostack/tools/search_tools.py
+++ b/src/neurostack/tools/search_tools.py
@@ -496,6 +496,7 @@ def vault_stats() -> dict:
     from ..memories import get_memory_source_counts, get_memory_stats
     from ..schema import DB_PATH, get_db
     from ..search import get_dormancy_report
+    from ..triggers import trigger_stats
 
     conn = get_db(DB_PATH)
 
@@ -560,6 +561,15 @@ def vault_stats() -> dict:
         "cooccurrence_total_reinforcement": cooc_stats["total_reinforcement"],
         # `neurostack status` reads by_source_7d for its LEARN table (#151).
         "memories": {**mem_stats, "by_source_7d": get_memory_source_counts(conn)},
+        # And triggers.last_30d for its WARN line (#159). The per-memory
+        # breakdown stays behind `neurostack triggers stats` — this reply is
+        # read on every status check.
+        "triggers": {
+            "last_30d": {
+                k: v for k, v in trigger_stats(conn, days=30).items()
+                if k != "memories"
+            }
+        },
     }
     return result
 

--- a/src/neurostack/triggers.py
+++ b/src/neurostack/triggers.py
@@ -19,6 +19,11 @@ the client reports whether the agent followed the memory. An ignored trigger
 becomes a ``prediction_errors`` row of type ``trigger_ignored`` that the
 promotion queue's drift bucket surfaces; after ``RETIRE_AFTER_IGNORES`` the
 queue suggests retiring the trigger. Nothing is deleted or decayed here.
+
+Issue #159 makes the other outcome countable. The reported outcome lands on
+the firing itself (``trigger_log.followed``, ``outcome_at``), so
+``trigger_stats`` can say how often a trigger was obeyed and not only how
+often it was ignored.
 """
 
 from __future__ import annotations
@@ -31,6 +36,7 @@ TRIGGER_EVENTS = ("editing", "calling", "error")
 _PREFIX = "when-"
 IGNORED_ERROR_TYPE = "trigger_ignored"
 RETIRE_AFTER_IGNORES = 3
+PREVIEW_CHARS = 120
 
 
 def parse_trigger(tag: str) -> tuple[str, str] | None:
@@ -149,18 +155,47 @@ def ignored_count(conn: sqlite3.Connection, memory_id: int) -> int:
     ).fetchone()[0]
 
 
+def _pending_firing(
+    conn: sqlite3.Connection,
+    memory_id: int,
+    session_hint: str | None,
+) -> sqlite3.Row | None:
+    """The firing an outcome report belongs to: the newest pending row.
+
+    Same session first, because a second harness session can fire the same
+    memory while the first has not reported yet. The fallback to the newest
+    pending row of any session keeps clients that send no hint working.
+    """
+    sql = (
+        "SELECT log_id, event, value FROM trigger_log"
+        " WHERE memory_id = ? AND followed IS NULL"
+    )
+    order = " ORDER BY fired_at DESC, log_id DESC LIMIT 1"
+    if session_hint:
+        row = conn.execute(
+            f"{sql} AND session_hint = ?{order}", (memory_id, session_hint)
+        ).fetchone()
+        if row is not None:
+            return row
+    return conn.execute(sql + order, (memory_id,)).fetchone()
+
+
 def record_outcome(
     conn: sqlite3.Connection,
     memory_id: int,
     followed: bool,
     note: str | None = None,
+    session_hint: str | None = None,
 ) -> dict:
     """Record whether the agent followed a fired trigger.
 
-    ``followed=True`` writes nothing. ``followed=False`` inserts one
-    ``prediction_errors`` row (``error_type='trigger_ignored'``, ``context`` =
-    the trigger tag that fired, ``query`` = the caller's note). The reply
-    carries the running ignore count and ``suggest: "retire"`` once it reaches
+    Either way the newest pending ``trigger_log`` row for this memory (and
+    session hint, when given) gets ``followed`` and ``outcome_at`` set, so the
+    obey count is as measurable as the ignore count (issue #159).
+    ``followed=False`` also inserts one ``prediction_errors`` row
+    (``error_type='trigger_ignored'``, ``context`` = the trigger tag that
+    fired, ``query`` = the caller's note). The reply carries the running
+    ignore count and ``suggest: "retire"`` once it reaches
     ``RETIRE_AFTER_IGNORES``; the memory row itself is never touched.
     """
     row = conn.execute(
@@ -168,12 +203,14 @@ def record_outcome(
     ).fetchone()
     if row is None:
         return {"error": f"Memory {memory_id} not found", "memory_id": memory_id}
+    fired = _pending_firing(conn, memory_id, session_hint)
+    if fired is not None:
+        conn.execute(
+            "UPDATE trigger_log SET followed = ?, outcome_at = datetime('now')"
+            " WHERE log_id = ?",
+            (1 if followed else 0, fired["log_id"]),
+        )
     if not followed:
-        fired = conn.execute(
-            "SELECT event, value FROM trigger_log WHERE memory_id = ?"
-            " ORDER BY fired_at DESC, log_id DESC LIMIT 1",
-            (memory_id,),
-        ).fetchone()
         tags = _trigger_tags(row["tags"])
         if fired is not None:
             # Prefer the tag that actually matched the logged firing.
@@ -190,9 +227,63 @@ def record_outcome(
             " VALUES ('', ?, ?, 0.0, ?, ?)",
             (memory_id, note or "", IGNORED_ERROR_TYPE, context),
         )
-        conn.commit()
+    conn.commit()
     count = ignored_count(conn, memory_id)
     out = {"memory_id": memory_id, "followed": followed, "ignored_count": count}
     if count >= RETIRE_AFTER_IGNORES:
         out["suggest"] = "retire"
     return out
+
+
+def _followed_rate(followed: int, ignored: int) -> float | None:
+    """Share of settled firings that were followed, None while none settled."""
+    settled = followed + ignored
+    return followed / settled if settled else None
+
+
+def trigger_stats(conn: sqlite3.Connection, days: int = 30) -> dict:
+    """Fired-versus-followed counts over the last ``days`` (issue #159).
+
+    Totals at the top level, one entry per memory that fired in the window
+    under ``memories``. Pending firings count as neither followed nor ignored,
+    so ``followed_rate`` is the share of the outcomes actually reported.
+    """
+    days = max(int(days), 1)
+    rows = conn.execute(
+        "SELECT l.memory_id AS memory_id, COUNT(*) AS fired,"
+        # `followed = 1` is NULL for a pending row, and SUM of only NULLs is
+        # NULL, so each branch has to fall through to a zero.
+        " SUM(CASE WHEN l.followed = 1 THEN 1 ELSE 0 END) AS followed,"
+        " SUM(CASE WHEN l.followed = 0 THEN 1 ELSE 0 END) AS ignored,"
+        " SUM(CASE WHEN l.followed IS NULL THEN 1 ELSE 0 END) AS pending,"
+        " m.content AS content, m.tags AS tags"
+        " FROM trigger_log l LEFT JOIN memories m ON m.memory_id = l.memory_id"
+        " WHERE l.fired_at >= datetime('now', ?)"
+        " GROUP BY l.memory_id"
+        " ORDER BY fired DESC, l.memory_id",
+        (f"-{days} days",),
+    ).fetchall()
+
+    totals = {"fired": 0, "followed": 0, "ignored": 0, "pending": 0}
+    memories = []
+    for row in rows:
+        tags = _trigger_tags(row["tags"])
+        entry = {
+            "memory_id": row["memory_id"],
+            "trigger": tags[0] if tags else None,
+            "content": (row["content"] or "")[:PREVIEW_CHARS],
+            "fired": row["fired"],
+            "followed": row["followed"],
+            "ignored": row["ignored"],
+            "pending": row["pending"],
+            "followed_rate": _followed_rate(row["followed"], row["ignored"]),
+        }
+        for key in totals:
+            totals[key] += entry[key]
+        memories.append(entry)
+    return {
+        "days": days,
+        **totals,
+        "followed_rate": _followed_rate(totals["followed"], totals["ignored"]),
+        "memories": memories,
+    }

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -183,21 +183,55 @@ def test_error_trigger_then_followed_after_quiet_window(server):
         assert len(outcomes) == (1 if i == 4 else 0), f"after {i + 1} calls"
 
     assert outcomes == [{"memory_id": 1808, "followed": True,
-                         "note": "window elapsed without a repeat"}]
+                         "note": "window elapsed without a repeat",
+                         "session_hint": "s5"}]
     assert json.loads(_state_path("s5").read_text())["pending"] == {}
 
 
-def test_identical_reissue_reports_ignored(server):
+def test_five_quiet_calls_report_followed(server):
     server.replies["vault_triggers"] = _triggers(
         {("calling", "vault_write_file"): [TRIGGER_HIT]}
     )
     call = {"session": "s6", "tool": "vault_write_file", "input": {"path": "a.md"}}
     assert run_event("tool-call", call, cfg=_cfg(server)).block is True
+
+    for i in range(5):
+        run_event("tool-call", {"session": "s6", "tool": f"read-{i}"}, cfg=_cfg(server))
+        outcomes = _tool_calls(server, "vault_trigger_outcome")
+        assert len(outcomes) == (1 if i == 4 else 0), f"after {i + 1} calls"
+
+    assert outcomes == [{"memory_id": 2164, "followed": True,
+                         "note": "window elapsed without a repeat",
+                         "session_hint": "s6"}]
+
+
+def test_a_reissue_with_a_different_path_settles_nothing_yet(server):
+    server.replies["vault_triggers"] = _triggers(
+        {("calling", "vault_write_file"): [TRIGGER_HIT]}
+    )
+    session = {"session": "s6b", "tool": "vault_write_file"}
+    assert run_event(
+        "tool-call", {**session, "input": {"path": "a.md"}}, cfg=_cfg(server)
+    ).block is True
+
+    run_event("tool-call", {**session, "input": {"path": "b.md"}}, cfg=_cfg(server))
+
+    assert _tool_calls(server, "vault_trigger_outcome") == []
+    assert json.loads(_state_path("s6b").read_text())["pending"]["2164"]["remaining"] == 4
+
+
+def test_a_byte_identical_reissue_settles_nothing_yet(server):
+    """The old ignore rule is gone: only the window decides (issue #159)."""
+    server.replies["vault_triggers"] = _triggers(
+        {("calling", "vault_write_file"): [TRIGGER_HIT]}
+    )
+    call = {"session": "s6c", "tool": "vault_write_file", "input": {"path": "a.md"}}
+    assert run_event("tool-call", call, cfg=_cfg(server)).block is True
+
     run_event("tool-call", call, cfg=_cfg(server))
-    assert _tool_calls(server, "vault_trigger_outcome") == [
-        {"memory_id": 2164, "followed": False,
-         "note": "re-issued vault_write_file unchanged"},
-    ]
+
+    assert _tool_calls(server, "vault_trigger_outcome") == []
+    assert json.loads(_state_path("s6c").read_text())["pending"]["2164"]["remaining"] == 4
 
 
 def test_recurring_error_reports_ignored(server):
@@ -208,7 +242,8 @@ def test_recurring_error_reports_ignored(server):
     run_event("tool-result", {"session": "s7", "error": text}, cfg=_cfg(server))
     run_event("tool-result", {"session": "s7", "error": text}, cfg=_cfg(server))
     assert _tool_calls(server, "vault_trigger_outcome") == [
-        {"memory_id": 55, "followed": False, "note": "same error recurred"},
+        {"memory_id": 55, "followed": False, "note": "same error recurred",
+         "session_hint": "s7"},
     ]
 
 

--- a/tests/test_learn_status.py
+++ b/tests/test_learn_status.py
@@ -283,6 +283,47 @@ def test_status_json_carries_the_learn_block(server, isolated_home):
     assert learn["by_source"] == {"checkpoint/cli": 3}
     assert learn["sessions_behind"] == 0
     assert learn["error"] is None
+    assert learn["warn"] is None
+
+
+# ---------------------------------------------------------------------------
+# The WARN line — did the trigger warnings change anything (issue #159)
+# ---------------------------------------------------------------------------
+
+def test_status_prints_the_warn_line_from_the_server(server, isolated_home):
+    server.replies["vault_stats"] = {
+        "memories": {"by_source_7d": {"checkpoint/omp": 2}},
+        "triggers": {"last_30d": {"days": 30, "fired": 7, "followed": 4,
+                                  "ignored": 2, "pending": 1,
+                                  "followed_rate": 4 / 6}},
+    }
+
+    proc = _run_status(isolated_home, server.url)
+
+    assert proc.returncode == 0
+    assert "WARN: 7 fired, 4 followed, 2 ignored (30d)" in proc.stdout
+
+
+def test_status_says_so_when_the_server_has_no_trigger_counts(server, isolated_home):
+    server.replies["vault_stats"] = {"memories": {"by_source_7d": {"checkpoint/omp": 2}}}
+
+    proc = _run_status(isolated_home, server.url)
+
+    assert "WARN: unavailable (the server predates issue #159)" in proc.stdout
+
+
+def test_status_json_carries_the_warn_counts(server, isolated_home):
+    server.replies["vault_stats"] = {
+        "memories": {"by_source_7d": {"checkpoint/cli": 3}},
+        "triggers": {"last_30d": {"days": 7, "fired": 3, "followed": 1,
+                                  "ignored": 1, "pending": 1}},
+    }
+
+    proc = _run_status(isolated_home, server.url, "--json")
+
+    assert json.loads(proc.stdout)["learn"]["warn"] == {
+        "days": 7, "fired": 3, "followed": 1, "ignored": 1, "pending": 1,
+    }
 
 
 def _run_status(home, url, *flags):

--- a/tests/test_trigger_outcome.py
+++ b/tests/test_trigger_outcome.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024-2026 Raphael Southall
-"""Tests for fired-but-ignored triggers (issue #136)."""
+"""Tests for fired-but-ignored triggers (#136) and the obey count (#159)."""
 
 import json
 
@@ -12,6 +12,7 @@ from neurostack.triggers import (
     match_triggers,
     record_fired,
     record_outcome,
+    trigger_stats,
 )
 
 
@@ -50,6 +51,15 @@ def _fire(conn, event, value, session_hint=None):
     return hits
 
 
+def _log_rows(conn, mid):
+    """(followed, outcome reported?) per firing, oldest first."""
+    rows = conn.execute(
+        "SELECT followed, outcome_at FROM trigger_log WHERE memory_id = ?"
+        " ORDER BY log_id", (mid,),
+    ).fetchall()
+    return [(r["followed"], r["outcome_at"] is not None) for r in rows]
+
+
 class TestTriggerLog:
     def test_one_row_per_hit(self, db):
         a = _add_memory(db, "Use vault_update_memory for existing notes",
@@ -79,12 +89,45 @@ class TestTriggerLog:
 
 
 class TestRecordOutcome:
-    def test_followed_writes_nothing(self, db):
+    def test_followed_marks_the_firing_and_writes_no_error(self, db):
         mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
         _fire(db, "calling", "vault_write_file")
         out = record_outcome(db, mid, followed=True)
         assert out == {"memory_id": mid, "followed": True, "ignored_count": 0}
         assert _ignored_rows(db, mid) == []
+        assert _log_rows(db, mid) == [(1, True)]
+
+    def test_ignored_marks_the_firing_zero(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=False)
+        assert _log_rows(db, mid) == [(0, True)]
+
+    def test_only_the_newest_pending_firing_is_marked(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=True)
+        # Oldest first: the second firing took the outcome, the first waits.
+        assert _log_rows(db, mid) == [(None, False), (1, True)]
+        record_outcome(db, mid, followed=False)
+        assert _log_rows(db, mid) == [(0, True), (1, True)]
+
+    def test_session_hint_picks_that_session_firing(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file", session_hint="sess-a")
+        _fire(db, "calling", "vault_write_file", session_hint="sess-b")
+        record_outcome(db, mid, followed=True, session_hint="sess-a")
+        rows = db.execute(
+            "SELECT session_hint, followed FROM trigger_log ORDER BY log_id"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("sess-a", 1), ("sess-b", None)]
+
+    def test_unknown_session_hint_falls_back_to_the_newest_firing(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file", session_hint="sess-a")
+        record_outcome(db, mid, followed=True, session_hint="sess-gone")
+        assert _log_rows(db, mid) == [(1, True)]
 
     def test_ignored_writes_one_prediction_error(self, db):
         mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
@@ -164,6 +207,113 @@ class TestDriftBucket:
         assert "ignored_trigger" not in q["drift"][0]
 
 
+class TestTriggerStats:
+    def test_counts_and_followed_rate(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        for _ in range(4):
+            _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=True)
+        record_outcome(db, mid, followed=True)
+        record_outcome(db, mid, followed=False)
+
+        stats = trigger_stats(db)
+
+        assert stats["days"] == 30
+        assert (stats["fired"], stats["followed"], stats["ignored"],
+                stats["pending"]) == (4, 2, 1, 1)
+        # Pending firings count as neither, so the rate is 2 of 3 settled.
+        assert stats["followed_rate"] == 2 / 3
+        entry = stats["memories"][0]
+        assert entry["memory_id"] == mid
+        assert entry["trigger"] == "when-calling:vault_write_file"
+        assert entry["content"] == "m"
+        assert (entry["fired"], entry["followed"], entry["ignored"],
+                entry["pending"]) == (4, 2, 1, 1)
+        assert entry["followed_rate"] == 2 / 3
+
+    def test_pending_only_has_no_rate(self, db):
+        _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        stats = trigger_stats(db)
+        assert (stats["fired"], stats["pending"]) == (1, 1)
+        assert stats["followed_rate"] is None
+        assert stats["memories"][0]["followed_rate"] is None
+
+    def test_empty_window(self, db):
+        stats = trigger_stats(db)
+        assert (stats["fired"], stats["followed"], stats["ignored"],
+                stats["pending"]) == (0, 0, 0, 0)
+        assert stats["followed_rate"] is None
+        assert stats["memories"] == []
+
+    def test_window_excludes_older_firings(self, db):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        db.execute(
+            "INSERT INTO trigger_log (memory_id, event, value, fired_at, followed,"
+            " outcome_at) VALUES (?, 'calling', 'vault_write_file',"
+            " datetime('now', '-40 days'), 1, datetime('now', '-40 days'))",
+            (mid,),
+        )
+        db.commit()
+        assert trigger_stats(db, days=30)["fired"] == 0
+        assert trigger_stats(db, days=60)["followed"] == 1
+
+    def test_one_row_per_memory(self, db):
+        a = _add_memory(db, "first", ["when-calling:vault_write_file"])
+        b = _add_memory(db, "second", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, a, followed=True)
+
+        stats = trigger_stats(db)
+
+        assert stats["fired"] == 2
+        by_id = {e["memory_id"]: e for e in stats["memories"]}
+        assert by_id[a]["followed"] == 1
+        assert by_id[b]["pending"] == 1
+
+
+class TestTriggersCli:
+    def _run(self, days=30, as_json=False):
+        from argparse import Namespace
+
+        from neurostack.cli.triggers import cmd_triggers
+
+        cmd_triggers(Namespace(triggers_command="stats", days=days, json=as_json))
+
+    def test_stats_prints_totals_and_a_row_per_memory(self, db, capsys):
+        mid = _add_memory(db, "Use vault_update_memory for existing notes",
+                          ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=True)
+
+        self._run()
+
+        out = capsys.readouterr().out
+        assert ("Triggers (30d): 2 fired, 1 followed, 0 ignored, 1 pending"
+                " (100% followed)") in out
+        assert f"{mid}" in out
+        assert "when-calling:vault_write_file" in out
+
+    def test_stats_says_so_on_an_empty_window(self, db, capsys):
+        self._run()
+        out = capsys.readouterr().out
+        assert "Triggers (30d): 0 fired, 0 followed, 0 ignored, 0 pending" in out
+        assert "No trigger fired in the window." in out
+
+    def test_stats_json_carries_the_memories(self, db, capsys):
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        _fire(db, "calling", "vault_write_file")
+        record_outcome(db, mid, followed=False)
+
+        self._run(days=7, as_json=True)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["days"] == 7
+        assert payload["followed_rate"] == 0.0
+        assert payload["memories"][0]["memory_id"] == mid
+
+
 class TestMigration:
     def test_creates_trigger_log_when_absent(self, db):
         from neurostack.schema import SCHEMA_VERSION, _run_migrations
@@ -174,4 +324,52 @@ class TestMigration:
         _run_migrations(db)
         assert db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == SCHEMA_VERSION
         cols = {r[1] for r in db.execute("PRAGMA table_info(trigger_log)")}
-        assert {"log_id", "memory_id", "event", "value", "session_hint", "fired_at"} <= cols
+        assert {"log_id", "memory_id", "event", "value", "session_hint", "fired_at",
+                "followed", "outcome_at"} <= cols
+
+    def test_v25_to_v26_adds_the_outcome_columns(self, db):
+        from neurostack.schema import SCHEMA_VERSION, _run_migrations
+
+        mid = _add_memory(db, "m", ["when-calling:vault_write_file"])
+        # The v25 table shape: a firing, no outcome to put on it.
+        db.executescript("""
+            DROP TABLE trigger_log;
+            CREATE TABLE trigger_log (
+                log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id INTEGER NOT NULL
+                    REFERENCES memories(memory_id) ON DELETE CASCADE,
+                event TEXT NOT NULL,
+                value TEXT NOT NULL,
+                session_hint TEXT,
+                fired_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+        """)
+        db.execute(
+            "INSERT INTO trigger_log (memory_id, event, value, session_hint)"
+            " VALUES (?, 'calling', 'vault_write_file', 'sess-old')",
+            (mid,),
+        )
+        db.execute("UPDATE schema_version SET version = 25")
+        db.commit()
+
+        _run_migrations(db)
+
+        assert db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == SCHEMA_VERSION
+        cols = {r[1] for r in db.execute("PRAGMA table_info(trigger_log)")}
+        assert {"followed", "outcome_at"} <= cols
+        # The firing survives, and it is pending rather than ignored.
+        row = db.execute(
+            "SELECT value, session_hint, followed, outcome_at FROM trigger_log"
+        ).fetchone()
+        assert tuple(row) == ("vault_write_file", "sess-old", None, None)
+
+    def test_v26_migration_skips_columns_that_exist(self, db):
+        from neurostack.schema import _run_migrations
+
+        # A v25 stamp on a table that already has both columns — an unguarded
+        # ALTER would raise "duplicate column name".
+        db.execute("UPDATE schema_version SET version = 25")
+        db.commit()
+        _run_migrations(db)
+        cols = {r[1] for r in db.execute("PRAGMA table_info(trigger_log)")}
+        assert {"followed", "outcome_at"} <= cols


### PR DESCRIPTION
Part of #159

## What

`vault_trigger_outcome(followed=true)` used to write nothing, so a month of WARN blocks left an ignore count and no obey count. The reported outcome now lands on the firing itself.

- **Schema v26.** `trigger_log` gains `followed INTEGER` (NULL pending, 1 followed, 0 ignored) and `outcome_at TEXT`, plus an index on `fired_at` for the window query. Migration `current < 26` creates the table when it is absent and adds each column only when it is missing, so rows logged under v25 survive as pending.
- **`record_outcome(conn, memory_id, followed, note, session_hint)`** marks the newest pending row for that memory and session hint, and falls back to the newest pending row of any session for a client that sends no hint. `followed=False` still inserts the `trigger_ignored` prediction error, so `suggest: retire` at three ignores is unchanged.
- **`trigger_stats(conn, days=30)`** returns fired, followed, ignored and pending counts with the followed share of the settled firings, in total and per memory. `neurostack triggers stats [--days N]` prints it (`--json` for the raw dict), `vault_stats` carries the totals under `triggers.last_30d`, and the `neurostack status` LEARN block gained the line `WARN: N fired, M followed, K ignored (30d)`.
- **Client rule change.** The hook no longer reports an ignore when the blocked call comes back byte-identical, because that is what a model does after reading the warning and judging it inapplicable. For `when-calling` and `when-editing`, only the 5-call window settles the outcome, and a re-issue spends one call of the window whether the input changed or not. The `when-error` rule is untouched, so the same error text coming back still reports an ignore. `_call_key` is gone with the rule it served, and the outcome call now carries `session_hint`.

## Gate

- `uv run ruff check src/ tests/` passed clean, exit code 0.
- `uv run pytest -q` passed 997 tests, exit code 0.

## Verified against a running server

A throwaway DB plus `neurostack serve --transport http --port 8199`, driven through the real CLI:

- `neurostack triggers stats` on 4 firings, 2 followed, 1 ignored, 1 pending printed `Triggers (30d): 4 fired, 2 followed, 1 ignored, 1 pending (67% followed)` with the per-memory row.
- `neurostack status` printed `WARN: 4 fired, 2 followed, 1 ignored (30d)` from the server's `vault_stats.triggers.last_30d`.
- `neurostack hook tool-call` on `vault_write_file` blocked with exit 2, and after 5 calls of other tools the firing came back `followed=1` with `outcome_at` set and no new `prediction_errors` row.
- A byte-identical re-issue in a fresh session left the firing pending with `remaining: 4` and wrote no outcome, which is the rule this PR changes.

## Note on the issue text

Acceptance 5 and the description of the window disagree. The description says the outcome is followed when 5 calls pass "without the same tool and same path being called again", while acceptance 5 requires a byte-identical re-issue to settle nothing and leave the decision to the window. This PR implements acceptance 5, so every later tool call counts down the window and no re-issue resets or settles it.
