### PR TITLE
fix: serialize conversation checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- **#163 — checkpoint overlap and retry races.** A nonblocking OS lock now covers checkpoint state, model execution, and saves per conversation, while other conversations remain independent. omp uses its stable harness session ID across resumes. Checkpoint state merges with interactive hook state, settled cursors stay monotonic, and Python persists each frozen payload before model execution. The runner persists the extracted reply and exact acknowledged-item receipts, so partial retries skip confirmed saves without discarding corrected facts. LEARN count updates use a short file lock. A network failure after a remote commit but before its acknowledgement can still duplicate that item because `vault_remember` has no server idempotency key.
+
+  The generated omp adapter now sends each frozen message window to the locked CLI on stdin; Python persists that payload before invoking the model. Reinstall the adapter and restart omp after upgrading. Legacy `.window.json` handovers remain readable for migration, but NeuroStack leaves them in place because an old publisher cannot coordinate a safe pathname deletion.
+
 - **#153 — a checkpoint save no longer drops the reply the model wrote.** `neurostack hook checkpoint --save` now spends the `harvest_timeout_s` budget (600 s by default) on each `vault_remember` instead of the 5 s interactive `timeout_s`, because the server embeds every memory as it stores it. A non-empty reply that parses to zero items records `reply had no items: <first 120 chars>` in `learn-status.json` and puts the window back on offer, so prose can no longer pass for a clean checkpoint of nothing. A literal `[]` still counts as ok with 0 saved and settles the window, and an empty body keeps the window on offer without recording an error. Every `--save` writes its raw stdin to `~/.cache/neurostack/last-capture.txt`, so a capture bug is inspectable after the fact. The omp adapter waits for a JSON-shaped reply and skips up to 3 prose messages before it gives up with an empty save, which stops a model that thinks out loud first from losing its own summary.
 
 ### Schema

--- a/README.md
+++ b/README.md
@@ -405,7 +405,10 @@ neurostack triggers stats --days 7
 # Checkpoint: a background model writes the memories, mid-session
 neurostack hook checkpoint --run --session <id>  # summarise and save, silently
 neurostack hook checkpoint --save               # a model's JSON reply on stdin
+```
 
+
+```
 # Client setup
 neurostack setup-client cursor           # or: windsurf, gemini, vscode, claude-code
 neurostack setup-client --list
@@ -416,6 +419,14 @@ neurostack stats                         # index health
 neurostack doctor                        # validate all subsystems
 neurostack demo                          # interactive demo with sample vault
 ```
+Checkpoint runners use a nonblocking OS lock per conversation. Overlapping saves for one
+conversation return `checkpoint already running`, while separate conversations can save at
+the same time. The runner keeps the extracted reply and a receipt for each acknowledged
+item, so a partial retry does not call the model again or repeat confirmed saves. Each
+conversation retains the 256 most recent SHA-256 receipts of exact redacted content. Changed
+facts produce different receipts. A connection can still fail after the server commits but
+before it acknowledges the write. Avoiding that remote duplicate requires server-side
+idempotency, which the current `vault_remember` contract does not provide.
 
 </details>
 

--- a/src/neurostack/adapters/omp_neurostack.ts
+++ b/src/neurostack/adapters/omp_neurostack.ts
@@ -3,12 +3,10 @@
 // blocks the call and stdout is the reason, stdout otherwise gets injected. Every
 // retrieval and suppression decision belongs to the CLI, never to this file.
 //
-// The checkpoint (#155) says nothing to the session model. omp can hide neither a
-// user message nor the reply to it, so instead of asking, the adapter writes the
-// window to `<session>.window.json` and spawns `hook checkpoint --run` detached:
-// the CLI summarizes through `checkpoint_command` and saves, with nothing in the
-// transcript. `/save` is the same call plus one line, because a command the user
-// typed has to answer.
+// Checkpoints say nothing to the session model. The adapter sends one frozen
+// message window to `hook checkpoint --run`; Python persists it before running
+// `checkpoint_command`, then saves outside the chat. `/save` starts the same
+// path and displays one brief status line.
 type Block = { type?: string; text?: string };
 type Content = string | Block[] | undefined;
 type Msg = { role?: string; content?: Content };
@@ -24,16 +22,13 @@ type Pi = {
 };
 
 const BIN = "__NEUROSTACK_BIN__";
-const SESSION = `omp-${Date.now().toString(36)}-${process.pid}`;
+const FALLBACK_SESSION = `omp-${Date.now().toString(36)}-${process.pid}`;
+let session = FALLBACK_SESSION;
 // Checkpoint cadence: 40 new messages, or 30 quiet minutes with at least 5.
 const EVERY_MESSAGES = 40;
 const QUIET_MS = 30 * 60_000;
 const MIN_MESSAGES = 5;
 const TICK_MS = 60_000;
-// The session id is built above out of safe characters, so it is also the
-// filename the CLI derives from it.
-const CACHE = process.env.XDG_CACHE_HOME || `${process.env.HOME}/.cache`;
-const WINDOW = `${CACHE}/neurostack/sessions/${SESSION}.window.json`;
 
 function spawn(args: string[], stdin: string) {
   const proc = Bun.spawn([BIN, "hook", ...args], { stdin: "pipe", stdout: "pipe", stderr: "ignore" });
@@ -42,7 +37,7 @@ function spawn(args: string[], stdin: string) {
   return proc;
 }
 function event(name: string, payload: Record<string, unknown>, args: string[] = []) {
-  return spawn([name, ...args], JSON.stringify({ session: SESSION, workspace: process.cwd(), ...payload }));
+  return spawn([name, ...args], JSON.stringify({ session, workspace: process.cwd(), ...payload }));
 }
 async function hook(name: string, payload: Record<string, unknown>) {
   const proc = event(name, payload);
@@ -54,24 +49,45 @@ const textOf = (c: Content): string =>
 const append = (c: Content, note: string): Content =>
   typeof c === "string" ? c + note : [...(c ?? []), { type: "text", text: note }];
 
+async function cursor(): Promise<number> {
+  const { text } = await hook("checkpoint-cursor", {});
+  try {
+    const value = JSON.parse(text).since_index;
+    return typeof value === "number" && value >= 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export default function neurostack(pi: Pi): void {
   let seen: Msg[] = [];
-  let baseline = 0;
+  let settled = 0;
+  let offered = 0;
   let lastMessageAt = Date.now();
 
-  // Returns how many messages were pending, so `/save` can say why it did
-  // nothing. The checkpoint itself outlives this call and this process.
-  async function checkpoint(): Promise<number> {
-    const pending = seen.length - baseline;
-    if (pending < MIN_MESSAGES) return pending;
-    await Bun.write(WINDOW, JSON.stringify({ since_index: baseline, messages: seen.slice(baseline) }));
-    baseline = seen.length;
-    Bun.spawn([BIN, "hook", "checkpoint", "--run", "--harness", "omp", "--session", SESSION],
-      { stdin: "ignore", stdout: "ignore", stderr: "ignore" }).unref();
-    return pending;
+  async function checkpoint(): Promise<{ pending: number; busy: boolean }> {
+    const pending = seen.length - settled;
+    if (pending < MIN_MESSAGES) return { pending, busy: false };
+    if (offered > settled) return { pending, busy: true };
+    offered = seen.length;
+    const submittedStart = settled;
+    const submittedEnd = offered;
+    const proc = event("checkpoint", { since_index: submittedStart,
+      messages: seen.slice(submittedStart, submittedEnd) },
+      ["--run", "--harness", "omp", "--session", session]);
+    void new Response(proc.stdout).text().then(async () => {
+      settled = Math.max(settled, await cursor());
+    }).finally(() => {
+      offered = settled;
+    });
+    proc.unref();
+    return { pending, busy: false };
   }
 
   pi.on("session_start", async (_e, ctx) => {
+    session = ctx?.sessionManager?.getSessionId?.() || FALLBACK_SESSION;
+    settled = await cursor();
+    offered = settled;
     const { text } = await hook("session-start", {});
     if (text) pi.sendMessage({ customType: "neurostack-brief", content: text, display: true });
     ctx?.setInterval?.(() => {
@@ -81,11 +97,12 @@ export default function neurostack(pi: Pi): void {
   pi.registerCommand("save", {
     description: "Checkpoint this session into NeuroStack memory",
     handler: async () => {
-      const pending = await checkpoint();
+      const result = await checkpoint();
       pi.sendMessage({
         customType: "neurostack-save",
-        content: pending < MIN_MESSAGES
-          ? `NeuroStack: nothing to save yet (${pending} messages)`
+        content: result.pending < MIN_MESSAGES
+          ? `NeuroStack: nothing to save yet (${result.pending} messages)`
+          : result.busy ? "NeuroStack: checkpoint already running"
           : "NeuroStack: checkpoint started in the background",
         display: true,
       });
@@ -104,9 +121,7 @@ export default function neurostack(pi: Pi): void {
     const messages = e.messages ?? [];
     seen = messages;
     lastMessageAt = Date.now();
-    // Compaction shortens the history; a baseline past its end would never fire.
-    if (baseline > messages.length) baseline = 0;
-    if (messages.length - baseline >= EVERY_MESSAGES) void checkpoint();
+    if (messages.length - settled >= EVERY_MESSAGES) void checkpoint();
     const i = messages.map((m) => m.role).lastIndexOf("user");
     if (i < 0) return;
     const { text } = await hook("prompt", { prompt: textOf(messages[i].content) });
@@ -117,6 +132,6 @@ export default function neurostack(pi: Pi): void {
   });
   // Harvest outlives the session: hand the transcript id over and detach.
   pi.on("session_shutdown", (_e, ctx) => {
-    event("session-end", { session: ctx?.sessionManager?.getSessionId?.() ?? SESSION, format: "omp" }).unref();
+    event("session-end", { session: ctx?.sessionManager?.getSessionId?.() ?? session, format: "omp" }).unref();
   });
 }

--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -21,22 +21,25 @@ unexpected exception prints one line to stderr and exits 0.
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
 import re
 import sys
 import time
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..client import ClientConfig, McpClient, load_client_config
 from ..redact import redact_secrets
 from ..triggers import parse_trigger
-from .learn_status import cache_dir, learn_line, record_error, record_ok
+from .learn_status import cache_dir, learn_line, record_busy, record_error, record_ok
 
+_CURSOR_EVENT = "checkpoint-cursor"
 EVENTS = ("session-start", "prompt", "tool-call", "tool-result", "checkpoint",
-          "session-end")
+          _CURSOR_EVENT, "session-end")
 
 # After a calling/editing trigger fires, watch this many later tool calls: the
 # next call says nothing either way — re-issuing the blocked call unchanged is
@@ -61,6 +64,8 @@ BEHIND_WINDOW_S = 7 * 86400
 # An adapter hands the window over on disk, beside the session state.
 _WINDOW_SUFFIX = ".window.json"
 _HASHLINE_HEADER = re.compile(r"^\[([^\]#]+)#[0-9A-Fa-f]{4}\]", re.MULTILINE)
+_LOCK_SUFFIX = ".checkpoint.lock"
+_STATE_LOCK_SUFFIX = ".state.lock"
 _XD_PREFIX = "xd://"
 
 
@@ -90,23 +95,57 @@ class SessionState:
     since_index: int = 0
     offered_index: int = 0
     last_checkpoint_at: float = 0.0
+    checkpoint_start: int = 0
+    checkpoint_end: int = 0
+    checkpoint_window: str = ""
+    checkpoint_reply: str = ""
+    checkpoint_receipts: set[str] = field(default_factory=set)
+    content_receipts: list[str] = field(default_factory=list)
+    checkpoint_messages: list[dict] = field(default_factory=list)
 
-    def save(self) -> None:
-        data = {
-            "fired": sorted(self.fired),
-            "checked": sorted(self.checked),
-            "pending": {str(k): v for k, v in self.pending.items()},
-            "prompts": sorted(self.prompts),
-            "calls": self.calls,
-            "since_index": self.since_index,
-            "offered_index": self.offered_index,
-            "last_checkpoint_at": self.last_checkpoint_at,
-        }
+    def save(self, *, checkpoint: bool = False, locked: bool = False) -> None:
+        """Merge one state domain under a short lock before replacing the file."""
         try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = self.path.with_suffix(".json.tmp")
-            tmp.write_text(json.dumps(data), encoding="utf-8")
-            tmp.replace(self.path)
+            manager = nullcontext(True) if locked else _file_lock(
+                _lock_path(self.session, "state"))
+            with manager:
+                current = load_state(self.session)
+                if checkpoint:
+                    self.fired = current.fired
+                    self.checked = current.checked
+                    self.prompts = current.prompts
+                    self.pending = current.pending
+                    self.calls = current.calls
+                else:
+                    self.since_index = current.since_index
+                    self.offered_index = current.offered_index
+                    self.last_checkpoint_at = current.last_checkpoint_at
+                    self.checkpoint_start = current.checkpoint_start
+                    self.checkpoint_end = current.checkpoint_end
+                    self.checkpoint_window = current.checkpoint_window
+                    self.checkpoint_reply = current.checkpoint_reply
+                    self.checkpoint_receipts = current.checkpoint_receipts
+                    self.content_receipts = current.content_receipts
+                    self.checkpoint_messages = current.checkpoint_messages
+                data = {
+                    "fired": sorted(self.fired), "checked": sorted(self.checked),
+                    "pending": {str(k): v for k, v in self.pending.items()},
+                    "prompts": sorted(self.prompts), "calls": self.calls,
+                    "since_index": self.since_index, "offered_index": self.offered_index,
+                    "last_checkpoint_at": self.last_checkpoint_at,
+                    "checkpoint_start": self.checkpoint_start,
+                    "checkpoint_end": self.checkpoint_end,
+                    "checkpoint_window": self.checkpoint_window,
+                    "checkpoint_reply": self.checkpoint_reply,
+                    "checkpoint_receipts": sorted(self.checkpoint_receipts),
+                    "content_receipts": self.content_receipts[-256:],
+                    "checkpoint_messages": self.checkpoint_messages,
+                }
+                tmp = self.path.with_suffix(f".{os.getpid()}.json.tmp")
+                fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(json.dumps(data))
+                tmp.replace(self.path)
         except OSError as exc:
             print(f"neurostack hook: state not saved: {exc}", file=sys.stderr)
 
@@ -129,6 +168,46 @@ def _state_path(session: str) -> Path:
 def _window_path(session: str) -> Path:
     """Where an adapter leaves the window for a detached `--run` (issue #155)."""
     return sessions_dir() / f"{_slug(session)}{_WINDOW_SUFFIX}"
+
+
+def _lock_path(session: str, kind: str = "checkpoint") -> Path:
+    suffix = _LOCK_SUFFIX if kind == "checkpoint" else _STATE_LOCK_SUFFIX
+    return sessions_dir() / f"{_slug(session)}{suffix}"
+
+
+@contextmanager
+def _file_lock(path: Path, *, blocking: bool = True):
+    """Hold an OS lock; stale lock filenames are harmless after process exit."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    try:
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(handle.fileno(), flags)
+        except BlockingIOError:
+            yield False
+            return
+        yield True
+    finally:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+def _window_id(start: int, messages: list) -> str:
+    normalized = []
+    for raw in messages:
+        normalized_keys = ("role", "text", "tools", "outputs")
+        if isinstance(raw, dict) and all(key in raw for key in normalized_keys):
+            normalized.append(raw)
+        else:
+            message = _norm_message(raw)
+            if message is not None:
+                normalized.append(message)
+    body = json.dumps({"since_index": start, "messages": normalized}, sort_keys=True,
+                      separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 
 def _state_files() -> list[Path]:
@@ -155,12 +234,6 @@ def _read_window(session: str) -> dict | None:
     return None
 
 
-def _clear_window(session: str) -> None:
-    """Drop the window file once its messages are saved."""
-    try:
-        _window_path(session).unlink(missing_ok=True)
-    except OSError as exc:
-        print(f"neurostack hook checkpoint: window not cleared: {exc}", file=sys.stderr)
 
 
 def load_state(session: str, fresh: bool = False) -> SessionState:
@@ -185,10 +258,23 @@ def load_state(session: str, fresh: bool = False) -> SessionState:
                 state.pending[int(key)] = value
     if isinstance(raw.get("calls"), int):
         state.calls = raw["calls"]
-    for name in ("since_index", "offered_index"):
+    for name in ("since_index", "offered_index", "checkpoint_start", "checkpoint_end"):
         value = raw.get(name)
         if isinstance(value, int) and value >= 0:
             setattr(state, name, value)
+    for name in ("checkpoint_window", "checkpoint_reply"):
+        value = raw.get(name)
+        if isinstance(value, str):
+            setattr(state, name, value)
+    state.checkpoint_receipts = {
+        str(value) for value in raw.get("checkpoint_receipts", []) if isinstance(value, str)
+    }
+    state.content_receipts = [
+        str(value) for value in raw.get("content_receipts", []) if isinstance(value, str)
+    ][-256:]
+    messages = raw.get("checkpoint_messages")
+    if isinstance(messages, list):
+        state.checkpoint_messages = [value for value in messages if isinstance(value, dict)]
     if isinstance(raw.get("last_checkpoint_at"), (int, float)):
         state.last_checkpoint_at = float(raw["last_checkpoint_at"])
     return state
@@ -219,6 +305,7 @@ def _tool_input(payload: dict):
 
 def _xd_device(value: str) -> str | None:
     """Bare tool name behind an xd:// device path, or None.
+
 
     `xd://mcp__neurostack_vault_write_file` -> `vault_write_file`: omp turns an
     MCP tool call into a `write` to a device path, and the trigger tag records
@@ -695,9 +782,18 @@ def _checkpoint_window(payload: dict, state: SessionState) -> tuple[int, list[di
         start = given.get("since_index")
         if not (isinstance(start, int) and start >= 0):
             start = state.since_index
-        messages = [m for m in (_norm_message(r) for r in given["messages"])
-                    if m is not None]
-        return start, messages
+        normalized = []
+        for raw in given["messages"]:
+            if isinstance(raw, dict) and all(
+                    key in raw for key in ("role", "text", "tools", "outputs")):
+                normalized.append(raw)
+            else:
+                message = _norm_message(raw)
+                if message is not None:
+                    normalized.append(message)
+        skip = min(max(state.since_index - start, 0), len(normalized))
+        start += skip
+        return start, normalized[skip:]
     source = _first_str(payload, "format", "source_agent") or "claude-code"
     messages = _transcript_messages(payload, state.session, source)
     start = min(state.since_index, len(messages))
@@ -771,8 +867,6 @@ def _checkpoint_body(window: list[dict]) -> str:
 def _event_checkpoint(client: McpClient, payload: dict, state: SessionState,
                       cfg: ClientConfig) -> Verdict:
     """Print the prompt the harness model answers. Never calls an LLM."""
-    # Claude Code sets this once its Stop hook has already blocked; asking
-    # again would hold the session open in a loop.
     if payload.get("stop_hook_active") is True:
         return Verdict()
     start, window = _checkpoint_window(payload, state)
@@ -780,6 +874,14 @@ def _event_checkpoint(client: McpClient, payload: dict, state: SessionState,
     if end <= state.offered_index or _checkpoint_skip(window):
         return Verdict()
     state.offered_index = end
+    state.checkpoint_start = start
+    state.checkpoint_end = end
+    window_id = _window_id(start, window)
+    if state.checkpoint_window != window_id:
+        state.checkpoint_receipts.clear()
+    state.checkpoint_messages = window
+    state.checkpoint_window = window_id
+    state.checkpoint_reply = ""
     return Verdict(_CHECKPOINT_PROMPT.format(
         count=len(window), session=state.session, body=_checkpoint_body(window),
     ))
@@ -894,97 +996,146 @@ def _remember_args(item: dict, harness: str, workspace: str | None) -> dict:
 
 def run_checkpoint_save(reply: str, session: str, harness: str = "cli",
                         cfg: ClientConfig | None = None,
-                        client: McpClient | None = None) -> Verdict:
-    """Save the model's checkpoint reply, then advance the saved index."""
+                        client: McpClient | None = None,
+                        _locked: bool = False) -> Verdict:
+    """Save one frozen reply, recording each acknowledged item before retry."""
+    if not _locked:
+        with _file_lock(_lock_path(session), blocking=False) as acquired:
+            if not acquired:
+                record_busy(session, harness)
+                return Verdict("neurostack: checkpoint already running")
+            return run_checkpoint_save(reply, session, harness, cfg, client, _locked=True)
     cfg = cfg or load_client_config()
     client = client or McpClient(cfg)
     state = load_state(session)
-    _write_last_capture(reply)
-    items = _parse_items(reply)
+    captured_reply = reply
+    supplied_items = _parse_items(reply)
+    supplied_lost = _lost_reply(reply, supplied_items)
+    if state.checkpoint_reply:
+        reply = state.checkpoint_reply
+        items = _parse_items(reply)
+    else:
+        items = supplied_items
+        if reply.strip() and supplied_lost is None:
+            state.checkpoint_reply = reply
+            state.save(checkpoint=True)
+    _write_last_capture(captured_reply)
     lost = _lost_reply(reply, items)
-    # An empty body is the harness giving up on capturing an answer, not the
-    # model declining: nothing failed, but the window has not been summarized.
     answered = bool(reply.strip())
     workspace = cfg.workspace_for(os.getcwd())
     saved = 0
+    duplicates = 0
     try:
-        for item in items:
-            # One write per memory against a server that embeds each one, so
-            # this gets the harvest budget: the interactive timeout exists to
-            # keep tool calls responsive, and spending it here loses the
-            # memories the model already wrote (issue #153).
-            if client.call_json("vault_remember",
-                                _remember_args(item, harness, workspace),
+        for index, item in enumerate(items):
+            args = _remember_args(item, harness, workspace)
+            content_receipt = hashlib.sha256(args["content"].encode("utf-8")).hexdigest()
+            item_receipt = f"{state.checkpoint_window}:{index}:{content_receipt}"
+            if item_receipt in state.checkpoint_receipts or \
+                    content_receipt in state.content_receipts:
+                duplicates += 1
+                continue
+            if client.call_json("vault_remember", args,
                                 timeout_s=cfg.harvest_timeout_s) is not None:
                 saved += 1
-        if answered and lost is None and saved == len(items):
-            # The index moves on whatever the model chose to keep: it was asked
-            # about this window, and asking twice is what the dedup prevents.
-            state.since_index = max(state.since_index, state.offered_index)
+                state.checkpoint_receipts.add(item_receipt)
+                state.content_receipts.append(content_receipt)
+                state.content_receipts = state.content_receipts[-256:]
+                state.save(checkpoint=True)
+        settled = answered and lost is None and saved + duplicates == len(items)
+        if settled:
+            state.since_index = max(state.since_index, state.checkpoint_end)
+            state.offered_index = max(state.offered_index, state.since_index)
             state.last_checkpoint_at = time.time()
-            # These messages are in the vault now, so the file an adapter left
-            # for this save has nothing left to offer (issue #155).
-            _clear_window(session)
-        else:
-            # An unreachable server, a dropped reply, or a harness that never
-            # got the answer must cost a repeat prompt, not the memories: put
-            # the window back on offer.
+            state.checkpoint_start = state.checkpoint_end = 0
+            state.checkpoint_window = ""
+            state.checkpoint_reply = ""
+            state.checkpoint_messages = []
+            state.checkpoint_receipts.clear()
+        elif state.offered_index == state.checkpoint_end:
             state.offered_index = state.since_index
-        state.save()
+        state.save(checkpoint=True)
     finally:
         client.close()
     if client.errors:
         print(f"neurostack hook checkpoint: {client.errors[0]}", file=sys.stderr)
-    # Every attempt ends in the health file, so a login that expired weeks ago
-    # shows up in the next session brief instead of a journal (issue #151).
     if lost is not None:
         record_error(session, harness, lost)
         return Verdict(f"neurostack: checkpoint {lost}")
-    if saved == len(items):
+    if saved:
         record_ok(session, harness, saved)
-    else:
+    if saved + duplicates != len(items):
         record_error(session, harness, client.errors[0] if client.errors
-                     else f"saved {saved} of {len(items)} memories")
-    return Verdict(f"neurostack: saved {saved} of {len(items)} checkpoint memories")
+                     else f"saved {saved} of {len(items) - duplicates} remaining memories")
+    elif not saved:
+        record_ok(session, harness, 0)
+    return Verdict(f"neurostack: saved {saved} of {len(items) - duplicates} checkpoint memories; "
+                   f"skipped {duplicates} acknowledged duplicates; "
+                   f"settled through {state.since_index}")
 
 
 def run_checkpoint(payload: dict, harness: str = "cli",
                    cfg: ClientConfig | None = None) -> Verdict:
-    """`--run`: prompt, pipe it through `checkpoint_command`, save the reply.
-
-    The command is a shell line so a model flag or wrapper script fits.
-    Anything but a clean exit puts the window back on offer, same as a failed
-    save. Nobody is watching a `--run`: an adapter spawns it detached and a
-    timer runs it from cron, so every failure goes to stderr and to the LEARN
-    status, never to stdout where a harness would inject it (issue #155).
-    """
+    """Run one checkpoint while holding its conversation's OS lock."""
     import subprocess
 
     cfg = cfg or load_client_config()
     payload = _with_session(payload)
     session = _session_id(payload)
-    if not cfg.checkpoint_command:
-        return _run_failed(session, harness, "no checkpoint_command in client.toml")
-    prompt = run_event("checkpoint", payload, cfg)
-    if not prompt.text:
-        return Verdict()
     try:
-        # Run from $HOME: inside a project the command would inherit that
-        # project's agent instructions and answer like an agent, not a parser.
-        proc = subprocess.run(
-            cfg.checkpoint_command, shell=True, input=prompt.text,
-            capture_output=True, text=True, timeout=cfg.checkpoint_timeout_s,
-            cwd=Path.home(),
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        _reoffer(session)
-        return _run_failed(session, harness, f"{type(exc).__name__}: {exc}")
-    if proc.returncode != 0:
-        _reoffer(session)
-        tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
-        return _run_failed(session, harness,
-                           f"command exited {proc.returncode}: {tail[0]}")
-    return run_checkpoint_save(proc.stdout, session, harness, cfg)
+        lock = _file_lock(_lock_path(session), blocking=False)
+        with lock as acquired:
+            if not acquired:
+                record_busy(session, harness)
+                return Verdict("neurostack: checkpoint already running")
+            if not cfg.checkpoint_command:
+                return _run_failed(session, harness, "no checkpoint_command in client.toml")
+            state = load_state(session)
+            if state.checkpoint_end > state.since_index and not state.checkpoint_reply:
+                if state.checkpoint_messages:
+                    payload = {**payload, "since_index": state.checkpoint_start,
+                               "messages": state.checkpoint_messages}
+                state.offered_index = state.since_index
+                state.checkpoint_start = state.checkpoint_end = 0
+                state.checkpoint_window = ""
+                state.checkpoint_messages = []
+                state.checkpoint_receipts.clear()
+                state.save(checkpoint=True)
+            if state.checkpoint_reply:
+                return run_checkpoint_save(state.checkpoint_reply, session, harness, cfg,
+                                           _locked=True)
+            client = McpClient(cfg)
+            state = load_state(session)
+            try:
+                prompt = _event_checkpoint(client, payload, state, cfg)
+            finally:
+                state.save(checkpoint=True)
+                client.close()
+            if not prompt.text:
+                return Verdict()
+            try:
+                proc = subprocess.run(
+                    cfg.checkpoint_command, shell=True, input=prompt.text,
+                    capture_output=True, text=True, timeout=cfg.checkpoint_timeout_s,
+                    cwd=Path.home(),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                _reoffer(session)
+                return _run_failed(session, harness, f"{type(exc).__name__}: {exc}")
+            if proc.returncode != 0:
+                _reoffer(session)
+                tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
+                return _run_failed(session, harness,
+                                   f"command exited {proc.returncode}: {tail[0]}")
+            items = _parse_items(proc.stdout)
+            if _lost_reply(proc.stdout, items) is not None:
+                _reoffer(session)
+                return run_checkpoint_save(proc.stdout, session, harness, cfg, _locked=True)
+            state = load_state(session)
+            state.checkpoint_reply = proc.stdout
+            state.save(checkpoint=True)
+            return run_checkpoint_save(proc.stdout, session, harness, cfg, _locked=True)
+    except OSError as exc:
+        return _run_failed(session, harness, f"lock unavailable: {exc}")
 
 
 def _run_failed(session: str, harness: str, message: str) -> Verdict:
@@ -1009,8 +1160,9 @@ def _with_session(payload: dict) -> dict:
 
 def _reoffer(session: str) -> None:
     state = load_state(session)
-    state.offered_index = state.since_index
-    state.save()
+    if state.offered_index == state.checkpoint_end:
+        state.offered_index = state.since_index
+    state.save(checkpoint=True)
 
 
 def _latest_session() -> str | None:
@@ -1057,19 +1209,42 @@ _HANDLERS = {
     "session-end": _event_session_end,
 }
 
-
 def run_event(event: str, payload: dict, cfg: ClientConfig | None = None,
-              client: McpClient | None = None) -> Verdict:
+              client: McpClient | None = None, _checkpoint_locked: bool = False) -> Verdict:
     """Run one hook event. Used by the CLI and by the tests."""
+    session = _session_id(payload)
+    if event == _CURSOR_EVENT:
+        return Verdict(json.dumps({"since_index": load_state(session).since_index}))
+    if event == "checkpoint" and not _checkpoint_locked:
+        try:
+            with _file_lock(_lock_path(session), blocking=False) as acquired:
+                if not acquired:
+                    record_busy(session, "hook")
+                    return Verdict("neurostack: checkpoint already running")
+                return run_event(event, payload, cfg, client, _checkpoint_locked=True)
+        except OSError as exc:
+            print(f"neurostack hook checkpoint: lock unavailable: {exc}", file=sys.stderr)
+            return Verdict()
     cfg = cfg or load_client_config()
     client = client or McpClient(cfg)
-    session = _session_id(payload)
     state = load_state(session, fresh=(event == "session-start"))
+    if event == "session-start":
+        checkpoint = load_state(session)
+        state.since_index = checkpoint.since_index
+        state.offered_index = checkpoint.offered_index
+        state.last_checkpoint_at = checkpoint.last_checkpoint_at
+        state.checkpoint_start = checkpoint.checkpoint_start
+        state.checkpoint_end = checkpoint.checkpoint_end
+        state.checkpoint_window = checkpoint.checkpoint_window
+        state.checkpoint_reply = checkpoint.checkpoint_reply
+        state.checkpoint_receipts = checkpoint.checkpoint_receipts
+        state.content_receipts = checkpoint.content_receipts
+        state.checkpoint_messages = checkpoint.checkpoint_messages
     try:
         verdict = _HANDLERS[event](client, payload, state, cfg)
     finally:
         if event != "session-end":
-            state.save()
+            state.save(checkpoint=(event == "checkpoint"))
         client.close()
     if client.errors:
         print(f"neurostack hook {event}: {client.errors[0]}", file=sys.stderr)

--- a/src/neurostack/cli/learn_status.py
+++ b/src/neurostack/cli/learn_status.py
@@ -18,9 +18,11 @@ at worst, never a checkpoint.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import sys
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -42,6 +44,18 @@ def learn_status_path() -> Path:
     return cache_dir() / "learn-status.json"
 
 
+@contextmanager
+def _status_lock():
+    path = cache_dir() / "learn-status.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 def load_learn_status() -> dict:
     """The health file, or an empty dict when it is absent or unreadable."""
     try:
@@ -58,33 +72,58 @@ def record_ok(session: str, harness: str, saved: int) -> dict:
     failed — that is what the `FAILING` state reads.
     """
     now = _now()
-    status = load_learn_status()
-    status.update({
-        "last_ok_at": _iso(now),
-        "last_error_at": None,
-        "last_error": None,
-        "saved_today": _saved_today(status, now) + max(saved, 0),
-        "session": session,
-        "harness": harness,
-    })
-    _write(status)
-    return status
+    with _status_lock():
+        status = load_learn_status()
+        status.update({
+            "last_ok_at": _iso(now),
+            "last_error_at": None,
+            "last_error": None,
+            "saved_today": _saved_today(status, now) + max(saved, 0),
+            "session": session,
+            "harness": harness,
+            "last_attempt_at": _iso(now),
+            "last_result": "saved",
+        })
+        _write(status)
+        return status
+
+
+def record_busy(session: str, harness: str) -> dict:
+    """Record overlap without turning a healthy checkpoint into a failure."""
+    now = _now()
+    with _status_lock():
+        status = load_learn_status()
+        status.update({
+            "last_attempt_at": _iso(now),
+            "last_result": "busy",
+            "saved_today": _saved_today(status, now),
+            "session": session,
+            "harness": harness,
+        })
+        status.setdefault("last_ok_at", None)
+        status.setdefault("last_error_at", None)
+        status.setdefault("last_error", None)
+        _write(status)
+        return status
 
 
 def record_error(session: str, harness: str, error: str) -> dict:
     """Record a checkpoint that failed. `last_ok_at` survives untouched."""
     now = _now()
-    status = load_learn_status()
-    status.update({
-        "last_error_at": _iso(now),
-        "last_error": _one_line(error),
-        "saved_today": _saved_today(status, now),
-        "session": session,
-        "harness": harness,
-    })
-    status.setdefault("last_ok_at", None)
-    _write(status)
-    return status
+    with _status_lock():
+        status = load_learn_status()
+        status.update({
+            "last_error_at": _iso(now),
+            "last_error": _one_line(error),
+            "saved_today": _saved_today(status, now),
+            "session": session,
+            "harness": harness,
+            "last_attempt_at": _iso(now),
+            "last_result": "failed",
+        })
+        status.setdefault("last_ok_at", None)
+        _write(status)
+        return status
 
 
 def learn_line(status: dict | None = None, now: datetime | None = None) -> str:
@@ -211,7 +250,7 @@ def _write(status: dict) -> None:
     path = learn_status_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
+        tmp = path.with_suffix(f".{os.getpid()}.json.tmp")
         tmp.write_text(json.dumps(status, indent=2), encoding="utf-8")
         tmp.replace(path)
     except OSError as exc:

--- a/tests/checkpoint_lock_smoke.py
+++ b/tests/checkpoint_lock_smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Deterministic, temp-only subprocess smoke for checkpoint locking."""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+MESSAGES = [
+    {"role": "user", "content": f"question {i}"}
+    if i % 2 == 0
+    else {"role": "assistant", "content": [{"type": "tool_use", "name": "read"}]}
+    for i in range(10)
+]
+MODEL_SOURCE = '''\
+import pathlib
+import sys
+import time
+
+root, count = map(pathlib.Path, sys.argv[1:])
+prompt = sys.stdin.read()
+session = prompt.split("--session ", 1)[1].split()[0]
+marker = root / f"model-started-{session}"
+release = root / f"release-{session}"
+previous = count.read_text() if count.exists() else ""
+count.write_text(previous + session + "\\n")
+marker.touch()
+while not release.exists():
+    time.sleep(0.01)
+print('[{"content":"fact one"},{"content":"fact two"}]')
+'''
+
+
+def wait_for(path: Path) -> None:
+    for _ in range(500):
+        if path.exists():
+            return
+        threading.Event().wait(0.01)
+    raise AssertionError(f"marker not written: {path}")
+
+
+class Mcp(BaseHTTPRequestHandler):
+    calls = []
+    fail_at = None
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        method = body.get("method")
+        if method == "initialize":
+            result = {"protocolVersion": "2025-06-18", "capabilities": {}}
+        elif method == "notifications/initialized":
+            self.send_response(202)
+            self.send_header("content-length", "0")
+            self.end_headers()
+            return
+        else:
+            args = (body.get("params") or {}).get("arguments") or {}
+            self.calls.append(args.get("content"))
+            result = None if self.fail_at == len(self.calls) else {
+                "memory_id": len(self.calls)
+            }
+        response = {
+            "jsonrpc": "2.0",
+            "id": body.get("id"),
+            "result": {"content": [{"type": "text", "text": json.dumps(result)}]},
+        }
+        raw = f"event: message\ndata: {json.dumps(response)}\n\n".encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("mcp-session-id", "smoke")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *_args):
+        pass
+
+
+def main() -> int:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Mcp)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    children = []
+    root = None
+    try:
+        with tempfile.TemporaryDirectory(prefix="neurostack-163-") as raw:
+            root = Path(raw)
+            home = root / "home"
+            cache = root / "cache"
+            home.mkdir()
+            model = root / "model.py"
+            model.write_text(MODEL_SOURCE)
+            count = root / "model-count"
+            config = home / ".config/neurostack/client.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                f'checkpoint_command = "{sys.executable} {model} {root} {count}"\n'
+                f'url = "http://127.0.0.1:{server.server_address[1]}/mcp"\n'
+            )
+            env = {
+                **os.environ,
+                "HOME": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "XDG_CACHE_HOME": str(cache),
+            }
+
+            def window(session):
+                path = cache / f"neurostack/sessions/{session}.window.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(json.dumps({"since_index": 0, "messages": MESSAGES}))
+
+            def command(session):
+                return [sys.executable, "-m", "neurostack", "hook", "checkpoint",
+                        "--run", "--harness", "omp", "--session", session]
+
+            window("same")
+            first = subprocess.Popen(command("same"), env=env, stdout=subprocess.PIPE,
+                                     text=True, start_new_session=True)
+            children.append(first)
+            wait_for(root / "model-started-same")
+            busy = subprocess.run(command("same"), env=env, capture_output=True,
+                                  text=True, timeout=2)
+            assert "already running" in busy.stdout
+            window("other")
+            (root / "release-other").touch()
+            other = subprocess.run(command("other"), env=env, capture_output=True,
+                                   text=True, timeout=10)
+            assert "saved 2" in other.stdout and first.poll() is None
+            (root / "release-same").touch()
+            first.communicate(timeout=10)
+
+            window("killed")
+            killed = subprocess.Popen(command("killed"), env=env, stdout=subprocess.PIPE,
+                                      text=True, start_new_session=True)
+            children.append(killed)
+            wait_for(root / "model-started-killed")
+            os.killpg(killed.pid, signal.SIGTERM)
+            killed.wait(timeout=5)
+            (root / "release-killed").touch()
+            recovered = subprocess.run(command("killed"), env=env, capture_output=True,
+                                       text=True, timeout=10)
+            assert "saved 2" in recovered.stdout
+
+            before = len(Mcp.calls)
+            window("partial")
+            (root / "release-partial").touch()
+            Mcp.fail_at = before + 2
+            partial = subprocess.run(command("partial"), env=env, capture_output=True,
+                                     text=True, timeout=10)
+            assert "saved 1 of 2" in partial.stdout
+            Mcp.fail_at = None
+            retried = subprocess.run(command("partial"), env=env, capture_output=True,
+                                     text=True, timeout=10)
+            assert "skipped 1 acknowledged" in retried.stdout
+            invocations = count.read_text().splitlines()
+            assert invocations.count("partial") == 1
+            assert len(invocations) == 5
+            assert Mcp.calls[before:].count("fact one") == 1
+            assert Mcp.calls[before:].count("fact two") == 2
+            print("PASS busy, independence, kill recovery, partial retry")
+    finally:
+        if root is not None:
+            for path in root.glob("release-*"):
+                path.touch()
+        for child in children:
+            if child.poll() is None:
+                os.killpg(child.pid, signal.SIGTERM)
+                child.wait(timeout=5)
+        server.shutdown()
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -354,7 +354,7 @@ def test_the_omp_adapter_carries_the_cadence_and_a_save_command(isolated_home):
     assert "MIN_MESSAGES = 5" in source
     assert 'registerCommand("save"' in source
     assert '"--run"' in source
-    assert ".window.json" in source
+    assert 'messages: seen.slice(submittedStart, submittedEnd)' in source
     assert " any" not in source and ": any" not in source
 
 
@@ -393,7 +393,10 @@ extension({{
   registerCommand: (n: string, c: {{ handler: () => unknown }}) => {{ commands[n] = c; }},
 }} as never);
 
-const ctx = {{ setInterval: (_f: () => void, ms: number) => {{ intervalMs = ms; }} }};
+const ctx = {{
+  sessionManager: {{ getSessionId: () => "conversation-stable-42" }},
+  setInterval: (_f: () => void, ms: number) => {{ intervalMs = ms; }},
+}};
 await handlers.session_start?.({{}}, ctx);
 
 const settle = () => new Promise((r) => setTimeout(r, 400));
@@ -415,6 +418,10 @@ _FAKE_BIN = """\
 #!/bin/sh
 printf '%s\\n' "$*" >>"$NEUROSTACK_TEST_LOG"
 cat >/dev/null
+case "$*" in
+  *session-start*) ;;
+  *) printf 'neurostack: saved 1 of 1 checkpoint memories; settled through 40\\n' ;;
+esac
 """
 
 
@@ -437,35 +444,32 @@ def _drive(isolated_home, tmp_path, count, save=False):
     )
     assert result.returncode == 0, result.stderr
     reported = json.loads(result.stdout.strip().splitlines()[-1])
-    spawned = [line for line in calls.read_text().splitlines()
-               if line.startswith("hook checkpoint")]
-    return reported, spawned
+    lines = calls.read_text().splitlines()
+    spawned = [line for line in lines if line.startswith("hook checkpoint --run")]
+    cursors = [line for line in lines if line == "hook checkpoint-cursor"]
+    return reported, spawned, cursors
 
 
 @pytest.mark.skipif(BUN is None, reason="bun not installed")
 def test_the_omp_adapter_checkpoints_at_forty_messages(isolated_home, tmp_path):
-    """Acceptance 1: the window goes to disk and `--run` is spawned, silently."""
-    reported, spawned = _drive(isolated_home, tmp_path, 40)
+    """Acceptance 1: the frozen window goes to the locked CLI over stdin."""
+    reported, spawned, cursors = _drive(isolated_home, tmp_path, 40)
     assert reported["injected"] == 0
     assert reported["shown"] == []
     assert reported["timer"] == 60000
+    assert spawned[0].endswith("--session conversation-stable-42")
     assert reported["command"] == "function"
     assert len(spawned) == 1
-    assert spawned[0].startswith("hook checkpoint --run --harness omp --session omp-")
-    windows = _windows()
-    assert len(windows) == 1
-    # The file is named for the session the CLI was told to check point.
-    assert windows[0].name == f"{spawned[0].split()[-1]}.window.json"
-    window = json.loads(windows[0].read_text())
-    assert window["since_index"] == 0
-    assert len(window["messages"]) == 40
+    assert cursors
+    assert _windows() == []
 
 
 @pytest.mark.skipif(BUN is None, reason="bun not installed")
 def test_the_omp_adapter_leaves_a_short_window_alone(isolated_home, tmp_path):
-    reported, spawned = _drive(isolated_home, tmp_path, 12)
+    reported, spawned, cursors = _drive(isolated_home, tmp_path, 12)
     # 12 messages is under the 40-message rule, so the CLI is never asked.
     assert spawned == []
+    assert cursors == ["hook checkpoint-cursor"]
     assert _windows() == []
     assert reported["shown"] == []
 
@@ -473,19 +477,21 @@ def test_the_omp_adapter_leaves_a_short_window_alone(isolated_home, tmp_path):
 @pytest.mark.skipif(BUN is None, reason="bun not installed")
 def test_save_on_three_messages_spawns_nothing_and_says_so(isolated_home, tmp_path):
     """Acceptance 2: `/save` answers the user even when it saves nothing."""
-    reported, spawned = _drive(isolated_home, tmp_path, 3, save=True)
+    reported, spawned, cursors = _drive(isolated_home, tmp_path, 3, save=True)
     assert reported["shown"] == ["NeuroStack: nothing to save yet (3 messages)"]
     assert spawned == []
+    assert cursors == ["hook checkpoint-cursor"]
     assert _windows() == []
     assert reported["injected"] == 0
 
 
 @pytest.mark.skipif(BUN is None, reason="bun not installed")
 def test_save_on_a_worthwhile_window_starts_the_checkpoint(isolated_home, tmp_path):
-    reported, spawned = _drive(isolated_home, tmp_path, 12, save=True)
+    reported, spawned, cursors = _drive(isolated_home, tmp_path, 12, save=True)
     assert reported["shown"] == ["NeuroStack: checkpoint started in the background"]
     assert len(spawned) == 1
-    assert len(json.loads(_windows()[0].read_text())["messages"]) == 12
+    assert len(cursors) == 2
+    assert _windows() == []
 
 
 def test_the_claude_stop_entry_checkpoints_in_the_background():
@@ -550,8 +556,7 @@ def test_run_without_a_command_says_so(server, capsys):
     assert _tool_calls(server, "vault_remember") == []
 
 
-def test_run_reads_the_window_file_and_removes_it(server, tmp_path):
-    """Acceptance 3: the adapter leaves the window on disk; `--run` consumes it."""
+def test_run_reads_legacy_window_once_and_leaves_file(server, tmp_path):
     server.replies["vault_remember"] = {"saved": True, "memory_id": 4}
     window = _write_window("s1", _messages(20))
     reply = tmp_path / "reply.json"
@@ -559,9 +564,10 @@ def test_run_reads_the_window_file_and_removes_it(server, tmp_path):
     verdict = run_checkpoint({"session": "s1"}, "omp",
                              cfg=_cfg(server, checkpoint_command=f"cat {reply}"))
     assert "saved 2 of 2" in verdict.text
+    assert window.exists()
+    assert run_checkpoint({"session": "s1"}, "omp",
+                          cfg=_cfg(server, checkpoint_command=f"cat {reply}")).text == ""
     assert len(_tool_calls(server, "vault_remember")) == 2
-    assert not window.exists()
-    assert _state("s1")["since_index"] == 40
 
 
 def test_a_window_that_saved_nothing_stays_on_disk(server, tmp_path):
@@ -587,8 +593,7 @@ def test_run_without_a_session_takes_the_newest_state_file(server, tmp_path):
     assert load_learn_status()["session"] == "s3"
 
 
-def test_the_cli_checkpoints_a_window_with_nothing_on_stdin(server, isolated_home, tmp_path):
-    """The whole omp path: a window file, no stdin at all, memories saved."""
+def test_cli_checkpoints_legacy_window_once(server, isolated_home, tmp_path):
     server.replies["vault_remember"] = {"saved": True, "memory_id": 7}
     reply = tmp_path / "reply.json"
     reply.write_text(json.dumps([{"content": "a fact worth keeping"}]))
@@ -600,8 +605,11 @@ def test_the_cli_checkpoints_a_window_with_nothing_on_stdin(server, isolated_hom
                       "", server.url, isolated_home)
     assert result.returncode == 0
     assert "saved 1 of 1" in result.stdout
+    assert window.exists()
+    again = _run_cli(["checkpoint", "--run", "--harness", "omp", "--session", "omp-cli"],
+                     "", server.url, isolated_home)
+    assert again.stdout == ""
     assert len(_tool_calls(server, "vault_remember")) == 1
-    assert not window.exists()
 
 
 def test_run_executes_the_command_from_home_not_the_project(server):
@@ -701,3 +709,117 @@ def test_the_capture_file_holds_the_bytes_the_cli_read(server, isolated_home):
     saved = _run_cli(["checkpoint", "--save"], REPLY, server.url, isolated_home)
     assert saved.returncode == 0
     assert last_capture_path().read_bytes() == REPLY.encode()
+
+
+def test_partial_retry_skips_acknowledged_item(server):
+    run_event("checkpoint", _payload(_messages(20)), cfg=_cfg(server))
+    calls = 0
+    def reply(_args):
+        nonlocal calls
+        calls += 1
+        return {"memory_id": calls} if calls != 2 else None
+    server.replies["vault_remember"] = reply
+    run_checkpoint_save(REPLY, "ck", "omp", cfg=_cfg(server))
+    server.replies["vault_remember"] = {"memory_id": 3}
+    retried = run_checkpoint_save("[]", "ck", "omp", cfg=_cfg(server))
+    assert "skipped 1 acknowledged" in retried.text
+    assert len(_tool_calls(server, "vault_remember")) == 3
+    assert _state("ck")["since_index"] == 40
+
+
+def test_exact_receipts_keep_a_corrected_fact(server):
+    server.replies["vault_remember"] = {"memory_id": 1}
+    run_event("checkpoint", _payload(_messages(20), session="receipt"), cfg=_cfg(server))
+    run_checkpoint_save('[{"content":"service uses port 1433"}]', "receipt", cfg=_cfg(server))
+    run_event("checkpoint", _payload(_messages(25), session="receipt"), cfg=_cfg(server))
+    run_checkpoint_save('[{"content":"service uses port 1435"}]', "receipt", cfg=_cfg(server))
+    assert [call["content"] for call in _tool_calls(server, "vault_remember")] == [
+        "service uses port 1433", "service uses port 1435"]
+
+
+def test_newer_window_survives_old_completion(server):
+    server.replies["vault_remember"] = {"memory_id": 1}
+    old = _messages(20)
+    run_event("checkpoint", _payload(old, session="race"), cfg=_cfg(server))
+    _write_window("race", old + _messages(5))
+    run_checkpoint_save('[{"content":"old window fact"}]', "race", cfg=_cfg(server))
+    assert _window_path("race").exists()
+    assert _state("race")["since_index"] == 40
+
+
+def test_ordinary_hook_write_preserves_checkpoint_progress(server):
+    server.replies["vault_remember"] = {"memory_id": 1}
+    run_event("checkpoint", _payload(_messages(20), session="merge"), cfg=_cfg(server))
+    stale = load_state("merge")
+    run_checkpoint_save('[{"content":"saved fact"}]', "merge", cfg=_cfg(server))
+    stale.calls += 1
+    stale.save()
+    assert load_state("merge").since_index == 40
+
+
+def test_same_session_busy_while_other_session_runs(isolated_home):
+    import fcntl
+
+    from neurostack.cli.hook import _lock_path
+    lock = _lock_path("held")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    cfg = ClientConfig(url="http://127.0.0.1:1/mcp", checkpoint_command="exit 9")
+    with lock.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        busy = run_checkpoint({"session": "held"}, cfg=cfg)
+        other = run_checkpoint({"session": "other"}, cfg=cfg)
+    assert "already running" in busy.text
+    assert other.text == ""
+
+
+def test_stale_lock_filename_does_not_block_recovery(server):
+    from neurostack.cli.hook import _lock_path
+    lock = _lock_path("stale")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text("dead process")
+    verdict = run_checkpoint(_payload(_messages(20), session="stale"), cfg=_cfg(
+        server, checkpoint_command=f"{sys.executable} -c \"print('[]')\""))
+    assert "skipped 0" in verdict.text
+
+
+def test_checkpoint_save_does_not_resurrect_settled_trigger(server):
+    state = load_state("trigger-race")
+    state.pending[7] = {"kind": "calling", "remaining": 1}
+    state.save()
+    checkpoint = load_state("trigger-race")
+    latest = load_state("trigger-race")
+    latest.pending.pop(7)
+    latest.save()
+    checkpoint.checkpoint_end = 4
+    checkpoint.save(checkpoint=True)
+    assert load_state("trigger-race").pending == {}
+
+
+def test_frozen_payload_survives_abandoned_runner(server):
+    state = load_state("frozen")
+    normalized = [m for m in (_messages(20))]
+    run_event("checkpoint", _payload(normalized, session="frozen"), cfg=_cfg(server))
+    state = load_state("frozen")
+    assert len(state.checkpoint_messages) == 40
+    state.offered_index = state.checkpoint_end
+    state.save(checkpoint=True)
+    server.replies["vault_remember"] = {"memory_id": 1}
+    command = f"{sys.executable} -c \"print('[]')\""
+    run_checkpoint({"session": "frozen"}, cfg=_cfg(server, checkpoint_command=command))
+    assert load_state("frozen").since_index == 40
+
+
+def test_checkpoint_state_with_transcript_is_owner_only(server):
+    run_event("checkpoint", _payload(_messages(20), session="private"), cfg=_cfg(server))
+    assert _state_path("private").stat().st_mode & 0o777 == 0o600
+
+
+def test_success_clears_reply_and_accepts_distinct_next_save(server):
+    server.replies["vault_remember"] = {"memory_id": 1}
+    run_event("checkpoint", _payload(_messages(20), session="next"), cfg=_cfg(server))
+    run_checkpoint_save('[{"content":"first fact"}]', "next", cfg=_cfg(server))
+    assert load_state("next").checkpoint_reply == ""
+    run_event("checkpoint", _payload(_messages(25), session="next"), cfg=_cfg(server))
+    run_checkpoint_save('[{"content":"second corrected fact"}]', "next", cfg=_cfg(server))
+    assert [call["content"] for call in _tool_calls(server, "vault_remember")] == [
+        "first fact", "second corrected fact"]

--- a/tests/test_learn_status.py
+++ b/tests/test_learn_status.py
@@ -60,9 +60,11 @@ def _messages(turns: int) -> list[dict]:
     return out
 
 
-def _save_two(server, session="s-learn", harness="omp"):
+def _save_two(server, session="s-learn", harness="omp", suffix=""):
     server.replies["vault_remember"] = {"memory_id": 4242}
-    return run_checkpoint_save(TWO_ITEMS, session, harness, cfg=_cfg(server))
+    reply = TWO_ITEMS.replace("attempt", f"attempt{suffix}").replace(
+        "brief", f"brief{suffix}")
+    return run_checkpoint_save(reply, session, harness, cfg=_cfg(server))
 
 
 def _fail_run(server, session="s-learn", harness="omp"):
@@ -88,8 +90,8 @@ def test_save_records_two_memories_and_no_error(server):
 
 
 def test_saves_accumulate_within_the_day(server):
-    _save_two(server)
-    _save_two(server)
+    _save_two(server, suffix="-one")
+    _save_two(server, suffix="-two")
 
     assert load_learn_status()["saved_today"] == 4
 
@@ -101,7 +103,7 @@ def test_a_count_from_yesterday_is_not_reported_as_today(server):
     status["last_ok_at"] = yesterday.isoformat(timespec="seconds")
     learn_status_path().write_text(json.dumps(status))
 
-    _save_two(server)
+    _save_two(server, suffix="-today")
 
     assert load_learn_status()["saved_today"] == 2
 
@@ -264,6 +266,27 @@ def test_status_prints_the_line_and_a_row_per_source(server, isolated_home):
     assert "Sessions behind: 0" in proc.stdout
 
 
+def test_concurrent_successes_keep_the_daily_total():
+    from concurrent.futures import ThreadPoolExecutor
+
+    from neurostack.cli.learn_status import record_ok
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda i: record_ok(f"session-{i}", "omp", 1), range(40)))
+    assert load_learn_status()["saved_today"] == 40
+
+
+def test_busy_attempt_is_distinct_from_failure():
+    from neurostack.cli.learn_status import record_busy, record_ok
+
+    record_ok("session-a", "omp", 2)
+    record_busy("session-a", "omp")
+    status = load_learn_status()
+    assert status["last_result"] == "busy"
+    assert status["last_error"] is None
+    assert status["saved_today"] == 2
+
+
 def test_status_says_so_when_the_server_has_no_counts(server, isolated_home):
     server.replies["vault_stats"] = {"memories": {"total": 9}}
 
@@ -352,7 +375,7 @@ def test_a_session_whose_transcript_outran_the_offer_counts_as_behind(isolated_h
     _transcript(isolated_home, "s-behind", 6)
     state = load_state("s-behind")
     state.offered_index = 2
-    state.save()
+    state.save(checkpoint=True)
 
     assert sessions_behind() == 1
 
@@ -361,7 +384,7 @@ def test_a_session_the_model_has_seen_is_not_behind(isolated_home):
     _transcript(isolated_home, "s-caught-up", 6)
     state = load_state("s-caught-up")
     state.offered_index = 6
-    state.save()
+    state.save(checkpoint=True)
 
     assert sessions_behind() == 0
 
@@ -370,7 +393,7 @@ def test_a_state_file_older_than_a_week_is_not_counted(isolated_home):
     _transcript(isolated_home, "s-old", 6)
     state = load_state("s-old")
     state.offered_index = 0
-    state.save()
+    state.save(checkpoint=True)
     old = _state_path("s-old")
     stale = os.stat(old).st_mtime - 8 * 86400
     os.utime(old, (stale, stale))


### PR DESCRIPTION
## What changed

- serialize checkpoint model and save work with a nonblocking OS lock per stable conversation ID
- persist frozen windows, model replies, per-window acknowledgements, and the 256 most recent exact redacted-content receipts per conversation
- preserve interactive hook state and monotonic settled cursors across overlapping events, process death, retries, and resumed omp conversations
- serialize short LEARN health updates without blocking independent conversations
- keep omp checkpoint work outside chat and retain brief `/save` busy or empty feedback

## Delivery limits

A confirmed `vault_remember` acknowledgement is not sent again. If the server commits and the network fails before the acknowledgement reaches the client, the retry can duplicate that item because the server has no idempotency-key contract. Receipts compare exact redacted content, so corrected facts remain distinct.

Existing synthetic omp session state and legacy `.window.json` files stay intact. Reinstalled adapters use the harness conversation ID; resumed conversations load the persisted cursor. Legacy files remain readable but are left in place to avoid unsafe publisher/deleter races.

## Verification

- `uv run ruff check src/ tests/` passed
- `uv run pytest -q` passed: 1009 tests, 1 pre-existing anyio warning
- `uv run python tests/checkpoint_lock_smoke.py` passed in 7.81 s against a controlled model command and fake MCP server
- the same smoke driver failed on base `ee294c2` at the expected missing same-session busy assertion

The smoke used no live Sonnet model and wrote no live vault, config, cache, or LEARN data.

Part of #163
