### PR TITLE
Reject broad trigger tags at checkpoint save

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 from ..client import ClientConfig, McpClient, load_client_config
 from ..redact import redact_secrets
-from ..triggers import parse_trigger
+from ..triggers import is_broad_trigger, parse_trigger
 from .events import post_event
 from .learn_status import cache_dir, learn_line, record_busy, record_error, record_ok
 
@@ -835,7 +835,11 @@ Reply with a JSON array, no prose around it:
 - trigger: optional, and only when the memory should surface on its own.
   "when-calling:<tool>" shows it before that tool runs, "when-editing:<glob>"
   before a matching file is edited, "when-error:<substring>" when a tool error
-  contains that text.
+  contains that text. Be specific: name the exact command ("az rest",
+  "vault_write_file"), a file name or narrow glob, or the distinctive part of
+  the error message. Never a generic tool (Bash, read, edit, vault_search), a
+  bare status code, "traceback", or "*": those fire on every call and are
+  dropped.
 - Reply with [] when nothing here is worth keeping.
 
 Pipe that JSON on stdin to:
@@ -976,19 +980,21 @@ def _remember_args(item: dict, harness: str, workspace: str | None) -> dict:
 
     A trigger is a tag, not a column (issue #131), so a well-formed `trigger`
     field joins `tags`; a malformed one is dropped rather than saved as a tag
-    that can never match.
+    that can never match, and a broad one (`when-calling:Bash`) is dropped
+    because it would match every call (issue #167).
     """
     content, _kinds = redact_secrets(item["content"])
     args: dict = {"content": content, "source_agent": f"checkpoint/{harness}"}
     entity_type = _first_str(item, "entity_type", "type")
     if entity_type:
         args["entity_type"] = entity_type
-    tags = [t for t in item.get("tags", []) if isinstance(t, str) and t] \
+    tags = [t for t in item.get("tags", [])
+            if isinstance(t, str) and t and not is_broad_trigger(t)] \
         if isinstance(item.get("tags"), list) else []
     trigger = _first_str(item, "trigger")
     if trigger:
         trigger, _kinds = redact_secrets(trigger)
-        if parse_trigger(trigger) and trigger not in tags:
+        if parse_trigger(trigger) and not is_broad_trigger(trigger) and trigger not in tags:
             tags.append(trigger)
     if tags:
         args["tags"] = tags

--- a/src/neurostack/triggers.py
+++ b/src/neurostack/triggers.py
@@ -52,6 +52,43 @@ def parse_trigger(tag: str) -> tuple[str, str] | None:
     return head, value
 
 
+# Tool names that a session calls dozens of times; a trigger on one of these
+# fires on nearly every call and only costs a retry (issue #167).
+_GENERIC_TOOLS = frozenset({
+    "bash", "read", "write", "edit", "glob", "grep", "eval", "task", "todo",
+    "ask", "hub", "ls", "cat", "curl", "ssh", "git", "python", "python3", "uv",
+    "az", "gh", "docker", "vault_search", "vault_remember", "vault_memories",
+    "vault_read_file", "search_code", "web_search",
+})
+_GENERIC_ERRORS = frozenset({
+    "error", "failed", "failure", "exception", "not found", "permission denied",
+    "timeout", "timed out", "traceback (most recent call last):", "migration",
+    "invalid", "denied", "refused",
+})
+_MIN_ERROR_CHARS = 8
+
+
+def is_broad_trigger(tag: str) -> bool:
+    """True when a well-formed trigger would match nearly everything.
+
+    Broad calling triggers name a generic tool; broad error triggers are
+    short, numeric, or a stock phrase; broad editing globs carry no literal
+    path text. Malformed tags are not triggers and return False.
+    """
+    parsed = parse_trigger(tag)
+    if parsed is None:
+        return False
+    event, value = parsed
+    value = value.strip().lower()
+    if event == "calling":
+        return value in _GENERIC_TOOLS
+    if event == "error":
+        return (len(value) < _MIN_ERROR_CHARS or value.isdigit()
+                or value.rstrip(":") in _GENERIC_ERRORS
+                or value in _GENERIC_ERRORS)
+    return not any(ch.isalnum() for ch in value)
+
+
 def _match(event: str, pattern: str, value: str) -> bool:
     if event == "editing":
         # fnmatch's ``*`` spans ``/``, so ``**`` needs no special casing.

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -101,3 +101,32 @@ def test_vault_remember_stores_trigger_tags_verbatim(db):
     assert "when-bogus:x" in tags
     hits = match_triggers(db, "calling", "vault_write_file")
     assert [h["memory_id"] for h in hits] == [m.memory_id]
+
+
+@pytest.mark.parametrize("tag", [
+    "when-calling:Bash", "when-calling:read", "when-calling:vault_search",
+    "when-error:404", "when-error:traceback (most recent call last):",
+    "when-error:error", "when-editing:*", "when-editing:**/*",
+])
+def test_is_broad_trigger_rejects_catch_alls(tag):
+    from neurostack.triggers import is_broad_trigger
+    assert is_broad_trigger(tag)
+
+
+@pytest.mark.parametrize("tag", [
+    "when-calling:az rest", "when-calling:vault_write_file",
+    "when-error:OAuth session expired", "when-editing:*.drawio",
+    "when-editing:models.yml", "plain-tag", "when-writing:x",
+])
+def test_is_broad_trigger_keeps_specific_and_non_triggers(tag):
+    from neurostack.triggers import is_broad_trigger
+    assert not is_broad_trigger(tag)
+
+
+def test_remember_args_drops_broad_triggers_from_field_and_tags():
+    from neurostack.cli.hook import _remember_args
+    item = {"content": "x", "tags": ["azure", "when-calling:Bash"],
+            "trigger": "when-error:404"}
+    assert _remember_args(item, "omp", None)["tags"] == ["azure"]
+    item = {"content": "x", "tags": ["azure"], "trigger": "when-calling:az rest"}
+    assert _remember_args(item, "omp", None)["tags"] == ["azure", "when-calling:az rest"]


### PR DESCRIPTION
Part of #167.

- `is_broad_trigger` in triggers.py; `_remember_args` drops broad triggers from both the `trigger` field and `tags`.
- Prompt rule tells the extractor to name exact commands, files or error text.
- 3 new tests; full suite green.
