### PR TITLE
Refuse checkpoints from an outdated omp adapter

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -470,6 +470,8 @@ def _observe_error(client: McpClient, state: SessionState, text: str) -> None:
             _report_outcome(client, state, memory_id, False, "same error recurred")
 
 
+# `omp-<base36 ms>-<pid>`: the per-process fallback id older adapters used.
+_LEGACY_OMP_SESSION = re.compile(r"^omp-[0-9a-z]{6,10}-\d+$")
 _WHY = {"calling": "before calling", "editing": "before editing", "error": "on error"}
 
 
@@ -1114,6 +1116,11 @@ def run_checkpoint(payload: dict, harness: str = "cli",
     cfg = cfg or load_client_config()
     payload = _with_session(payload)
     session = _session_id(payload)
+    if harness == "omp" and _LEGACY_OMP_SESSION.match(session):
+        # The adapter that minted per-process ids predates the per-conversation
+        # lock and receipts (#163); left running, it re-saves the same window.
+        return _run_failed(session, harness,
+                           "outdated omp adapter in this window; restart omp", cfg)
     try:
         lock = _file_lock(_lock_path(session), blocking=False)
         with lock as acquired:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -556,6 +556,17 @@ def test_run_without_a_command_says_so(server, capsys):
     assert _tool_calls(server, "vault_remember") == []
 
 
+def test_run_refuses_an_outdated_omp_adapter_session(server, capsys):
+    """A per-process `omp-<ts>-<pid>` id means the adapter predates #163: no
+    lock, no receipts, so it re-saves the same window. Refuse and say why."""
+    payload = {**_payload(_messages(20)), "session": "omp-mtsryxg2-437813"}
+    verdict = run_checkpoint(payload, "omp", cfg=_cfg(server, checkpoint_command="cat"))
+    assert verdict.text == ""
+    assert "restart omp" in capsys.readouterr().err
+    assert "outdated omp adapter" in load_learn_status()["last_error"]
+    assert _tool_calls(server, "vault_remember") == []
+
+
 def test_run_reads_legacy_window_once_and_leaves_file(server, tmp_path):
     server.replies["vault_remember"] = {"saved": True, "memory_id": 4}
     window = _write_window("s1", _messages(20))


### PR DESCRIPTION
- `checkpoint --run` with harness omp and a legacy `omp-<ts>-<pid>` session id fails fast: LEARN shows `outdated omp adapter in this window; restart omp`.
- Stops triple saves from windows still running the pre-#163 adapter.
- One regression test; full suite green.
