### PR TITLE
Consolidate: extend a same-named note instead of creating a twin

### DIFF
--- a/src/neurostack/consolidate.py
+++ b/src/neurostack/consolidate.py
@@ -92,6 +92,24 @@ def _slugify(title: str) -> str:
     return slug[:60] or "consolidated"
 
 
+def _existing_note(filename: str, preferred_folder: str) -> str | None:
+    """Vault-relative path of a note already named ``filename``, if any.
+
+    The preferred folder wins; otherwise the first match walking the vault.
+    """
+    from .tools import file_tools
+
+    root = file_tools._vault_root()
+    candidate = root / preferred_folder / filename
+    if candidate.is_file():
+        return f"{preferred_folder}/{filename}"
+    for path in sorted(root.rglob(filename)):
+        if any(part.startswith(".") for part in path.relative_to(root).parts):
+            continue
+        return path.relative_to(root).as_posix()
+    return None
+
+
 def _memory_rows(conn: sqlite3.Connection, memory_ids: list[int]) -> list[dict]:
     if not memory_ids:
         return []
@@ -320,6 +338,15 @@ def consolidate_replay(
             report["skipped"].append(plan)
             continue
 
+        if cluster["action"] != "extend":
+            slug = f"{_slugify(synth['title'])}.md"
+            twin = _existing_note(slug, cluster["target_folder"])
+            if twin:
+                # A note with this name already exists somewhere: the folder
+                # vote drifts night to night, so extend that one rather than
+                # leave twins in inbox/ and the project folder.
+                cluster["action"] = "extend"
+                cluster["target"] = twin
         if cluster["action"] == "extend":
             target = cluster["target"]
             abs_path = file_tools._vault_root() / target

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -236,6 +236,26 @@ class TestRealRun:
         assert reasons[a] == "promoted:covered.md"
         assert reasons[b] == "promoted:homelab/synth-title.md"
 
+    def test_same_slug_elsewhere_extends_it_instead_of_a_twin(self, vault_db, tmp_path,
+                                                              monkeypatch):
+        """The folder vote drifts night to night; a note that already carries
+        the slug in another folder is extended, never duplicated."""
+        conn, cid, a, b = vault_db
+        writes = self._patch_write(monkeypatch, tmp_path)
+        self._patch_llm(monkeypatch)
+        (tmp_path / "inbox").mkdir()
+        (tmp_path / "inbox" / "synth-title.md").write_text(
+            "---\ndate: 2026-01-01\n---\n\n# Synth Title\n\nearlier digest\n")
+
+        report = consolidate_replay(conn, dry_run=False)
+
+        assert report["skipped"] == []
+        paths = {w["path"] for w in writes}
+        assert "homelab/synth-title.md" not in paths
+        twin = next(w for w in writes if w["path"] == "inbox/synth-title.md")
+        assert "earlier digest" in twin["content"]
+        assert "## Synth Title (consolidated" in twin["content"]
+
     def test_failed_push_skips_and_keeps_memories(self, vault_db, tmp_path,
                                                   monkeypatch):
         conn, cid, a, b = vault_db


### PR DESCRIPTION
- `_existing_note` finds a same-named note anywhere under the vault; the cluster becomes an extend onto it.
- Stops the inbox/ vs project-folder twins that vault-heal flagged on 2026-09-09.
- One regression test; full suite green.
