### PR TITLE
Checkpoint save: coerce unknown entity_type to observation

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..client import ClientConfig, McpClient, load_client_config
+from ..memories import VALID_ENTITY_TYPES
 from ..redact import redact_secrets
 from ..triggers import is_broad_trigger, parse_trigger
 from .events import post_event
@@ -1000,9 +1001,11 @@ def _remember_args(item: dict, harness: str, workspace: str | None) -> dict:
     """
     content, _kinds = redact_secrets(item["content"])
     args: dict = {"content": content, "source_agent": f"checkpoint/{harness}"}
+    # The extractor sometimes invents a type ("correction"); the server would
+    # reject the whole item with a plain-text error, so fall back to observation.
     entity_type = _first_str(item, "entity_type", "type")
     if entity_type:
-        args["entity_type"] = entity_type
+        args["entity_type"] = entity_type if entity_type in VALID_ENTITY_TYPES else "observation"
     tags = [t for t in item.get("tags", [])
             if isinstance(t, str) and t and not is_broad_trigger(t)] \
         if isinstance(item.get("tags"), list) else []

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -130,3 +130,11 @@ def test_remember_args_drops_broad_triggers_from_field_and_tags():
     assert _remember_args(item, "omp", None)["tags"] == ["azure"]
     item = {"content": "x", "tags": ["azure"], "trigger": "when-calling:az rest"}
     assert _remember_args(item, "omp", None)["tags"] == ["azure", "when-calling:az rest"]
+
+
+def test_remember_args_coerces_unknown_entity_type():
+    from neurostack.cli.hook import _remember_args
+    made_up = {"content": "x", "entity_type": "correction"}
+    assert _remember_args(made_up, "omp", None)["entity_type"] == "observation"
+    real = {"content": "x", "entity_type": "bug"}
+    assert _remember_args(real, "omp", None)["entity_type"] == "bug"


### PR DESCRIPTION
- Unknown `entity_type` from the extractor becomes `observation` instead of failing the item.
- Root cause of today 20:03 LEARN FAILING (`vault_remember: reply was not JSON`).
