### PR TITLE
Consolidate: never extend an archived note

### DIFF
--- a/src/neurostack/consolidate.py
+++ b/src/neurostack/consolidate.py
@@ -93,9 +93,10 @@ def _slugify(title: str) -> str:
 
 
 def _existing_note(filename: str, preferred_folder: str) -> str | None:
-    """Vault-relative path of a note already named ``filename``, if any.
+    """Vault-relative path of a live note already named ``filename``, if any.
 
     The preferred folder wins; otherwise the first match walking the vault.
+    Archived notes never count: extending one resurrects retired content.
     """
     from .tools import file_tools
 
@@ -104,7 +105,8 @@ def _existing_note(filename: str, preferred_folder: str) -> str | None:
     if candidate.is_file():
         return f"{preferred_folder}/{filename}"
     for path in sorted(root.rglob(filename)):
-        if any(part.startswith(".") for part in path.relative_to(root).parts):
+        parts = path.relative_to(root).parts
+        if any(part.startswith(".") for part in parts) or "archive" in parts:
             continue
         return path.relative_to(root).as_posix()
     return None

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -243,6 +243,9 @@ class TestRealRun:
         conn, cid, a, b = vault_db
         writes = self._patch_write(monkeypatch, tmp_path)
         self._patch_llm(monkeypatch)
+        archived = tmp_path / "archive" / "inbox" / "2026-08"
+        archived.mkdir(parents=True)
+        (archived / "synth-title.md").write_text("---\ndate: 2026-08-01\n---\n\nretired\n")
         (tmp_path / "inbox").mkdir()
         (tmp_path / "inbox" / "synth-title.md").write_text(
             "---\ndate: 2026-01-01\n---\n\n# Synth Title\n\nearlier digest\n")
@@ -252,6 +255,7 @@ class TestRealRun:
         assert report["skipped"] == []
         paths = {w["path"] for w in writes}
         assert "homelab/synth-title.md" not in paths
+        assert not any("archive/" in p for p in paths)
         twin = next(w for w in writes if w["path"] == "inbox/synth-title.md")
         assert "earlier digest" in twin["content"]
         assert "## Synth Title (consolidated" in twin["content"]


### PR DESCRIPTION
- `_existing_note` skips any path containing an `archive` segment.
- Test now plants an archived decoy and asserts it is not written.
