### PR TITLE
Fix trigger matching: command-style tags, MCP names, path selectors

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from ..client import ClientConfig, McpClient, load_client_config
 from ..memories import VALID_ENTITY_TYPES
 from ..redact import redact_secrets
-from ..triggers import is_broad_trigger, parse_trigger
+from ..triggers import is_broad_trigger, normalise_tool, parse_trigger
 from .events import post_event
 from .learn_status import cache_dir, learn_line, record_busy, record_error, record_ok
 from .queue import enqueue as queue_enqueue
@@ -324,27 +324,45 @@ def _xd_device(value: str) -> str | None:
     """
     if not value.startswith(_XD_PREFIX):
         return None
-    device = value[len(_XD_PREFIX):]
-    if not device.startswith("mcp__"):
-        return device or None
-    rest = device[len("mcp__"):]
-    sep = rest.find("_")
-    return rest[sep + 1:] if sep > 0 else rest or None
+    device = value[len(_XD_PREFIX):].strip("/")
+    return normalise_tool(device) or None
 
 
 def _tool_names(tool: str, tool_input) -> list[str]:
-    """Every name a `when-calling:` tag could plausibly be written as."""
+    """Every name a `when-calling:` tag could plausibly be written as.
+
+    A shell tool also yields its command line, so a tag naming a command
+    (`when-calling:az rest`) has something to match against (issue #178).
+    """
     names: list[str] = []
     device = _xd_device(tool)
     if device:
         names.append(device)
     elif tool:
         names.append(tool)
-        if isinstance(tool_input, dict) and isinstance(tool_input.get("path"), str):
-            nested = _xd_device(tool_input["path"])
-            if nested:
-                names.append(nested)
+        if isinstance(tool_input, dict):
+            nested = tool_input.get("path")
+            if isinstance(nested, str):
+                device = _xd_device(nested)
+                if device:
+                    names.append(device)
+            command = tool_input.get("command")
+            if isinstance(command, str) and command.strip():
+                names.append(command.strip())
     return list(dict.fromkeys(names))
+
+
+def _plain_path(value: str) -> str:
+    """A read selector or query string is not part of the file name.
+
+    `read` accepts `file.png?q=...`, `file.svg:img` and `a.py:10-40`; an
+    `when-editing:` glob is written against the path alone (issue #178).
+    """
+    path = value.split("?", 1)[0]
+    head, sep, tail = path.rpartition(":")
+    if sep and head and "/" not in tail:
+        path = head
+    return path.strip()
 
 
 def _edited_paths(payload: dict, tool: str, tool_input) -> list[str]:
@@ -353,20 +371,30 @@ def _edited_paths(payload: dict, tool: str, tool_input) -> list[str]:
     The harness may pass `paths` outright; otherwise derive them the way the
     write and edit tools carry them (`path`/`file_path`, or hashline section
     headers in an edit body) so an adapter stays a pure event mapping.
+    A `path` may hold a `;`-separated list and a read selector, so each entry
+    is split and reduced to the file name (issue #178).
     """
-    paths: list[str] = []
+    raw: list[str] = []
     given = payload.get("paths")
     if isinstance(given, list):
-        paths += [p for p in given if isinstance(p, str) and p]
+        raw += [p for p in given if isinstance(p, str) and p]
     if isinstance(tool_input, dict):
         for key in ("path", "file_path", "notebook_path"):
             value = tool_input.get(key)
             if isinstance(value, str) and value:
-                paths.append(value)
+                raw.append(value)
         body = tool_input.get("input")
         if tool == "edit" and isinstance(body, str):
-            paths += _HASHLINE_HEADER.findall(body)
-    return [p for p in dict.fromkeys(paths) if not p.startswith(_XD_PREFIX)]
+            raw += _HASHLINE_HEADER.findall(body)
+    paths: list[str] = []
+    for entry in raw:
+        if entry.startswith(_XD_PREFIX):
+            continue
+        for part in entry.split(";"):
+            plain = _plain_path(part)
+            if plain and not plain.startswith(_XD_PREFIX):
+                paths.append(plain)
+    return list(dict.fromkeys(paths))
 
 
 def _error_text(payload: dict) -> str:

--- a/src/neurostack/triggers.py
+++ b/src/neurostack/triggers.py
@@ -66,6 +66,31 @@ _GENERIC_ERRORS = frozenset({
     "invalid", "denied", "refused",
 })
 _MIN_ERROR_CHARS = 8
+# MCP servers whose tools a tag may name with the server glued on the front
+# (``neurostack_vault_search``). Only these prefixes are stripped, so a tool
+# genuinely called ``session_brief`` keeps its own first word.
+_MCP_SERVERS = frozenset({
+    "neurostack", "claude_context", "claude-context", "codebase_memory",
+    "codebase-memory", "n8n",
+})
+
+
+def normalise_tool(value: str) -> str:
+    """Bare tool name: lowercased, MCP server prefix dropped.
+
+    The same tool reaches us as ``Bash``, ``mcp__neurostack__vault_search`` or
+    ``neurostack_vault_search`` depending on the harness and on how the author
+    typed the tag. Triggers compare the bare name so all three agree.
+    """
+    name = value.strip().lower()
+    if name.startswith("mcp__"):
+        name = name[len("mcp__"):]
+        head, sep, rest = name.partition("__")
+        name = rest if sep and rest else name
+    head, sep, rest = name.partition("_")
+    if sep and rest and head in _MCP_SERVERS:
+        name = rest
+    return name
 
 
 def is_broad_trigger(tag: str) -> bool:
@@ -81,7 +106,7 @@ def is_broad_trigger(tag: str) -> bool:
     event, value = parsed
     value = value.strip().lower()
     if event == "calling":
-        return value in _GENERIC_TOOLS
+        return normalise_tool(value) in _GENERIC_TOOLS
     if event == "error":
         return (len(value) < _MIN_ERROR_CHARS or value.isdigit()
                 or value.rstrip(":") in _GENERIC_ERRORS
@@ -96,7 +121,12 @@ def _match(event: str, pattern: str, value: str) -> bool:
             return True
         return not pattern.startswith("/") and fnmatch.fnmatch(value, "*/" + pattern)
     if event == "calling":
-        return value.lower() == pattern.lower()
+        pat = normalise_tool(pattern)
+        if pat == normalise_tool(value):
+            return True
+        # A multi-word pattern names a command line, not a tool: the event
+        # carries the command text, so match the prefix the author wrote.
+        return " " in pat and pat in value.strip().lower()
     if event == "error":
         return pattern.lower() in value.lower()
     return False

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -138,3 +138,55 @@ def test_remember_args_coerces_unknown_entity_type():
     assert _remember_args(made_up, "omp", None)["entity_type"] == "observation"
     real = {"content": "x", "entity_type": "bug"}
     assert _remember_args(real, "omp", None)["entity_type"] == "bug"
+
+
+def test_calling_command_trigger_matches_the_command_line(db):
+    mid = _add_memory(db, "az rest needs --uri with an api-version",
+                      tags=["when-calling:az rest"])
+    hits = match_triggers(db, "calling", "az rest --method get --uri /subscriptions")
+    assert [h["memory_id"] for h in hits] == [mid]
+    # A different command, and the bare shell tool, stay quiet.
+    assert match_triggers(db, "calling", "az network watcher show") == []
+    assert match_triggers(db, "calling", "bash") == []
+
+
+def test_calling_matches_across_mcp_name_spellings(db):
+    mid = _add_memory(db, "vault_write_file commits and pushes",
+                      tags=["when-calling:mcp__neurostack__vault_write_file"])
+    for spelling in ("vault_write_file", "mcp__neurostack__vault_write_file",
+                     "neurostack_vault_write_file"):
+        assert [h["memory_id"] for h in match_triggers(db, "calling", spelling)] == [mid]
+    assert match_triggers(db, "calling", "vault_delete_file") == []
+
+
+def test_is_broad_trigger_sees_through_mcp_prefixes():
+    from neurostack.triggers import is_broad_trigger
+    assert is_broad_trigger("when-calling:mcp__neurostack__vault_read_file")
+    assert is_broad_trigger("when-calling:neurostack_vault_search")
+    assert not is_broad_trigger("when-calling:mcp__neurostack__vault_write_file")
+
+
+def test_edited_paths_drop_read_selectors_and_split_lists():
+    from neurostack.cli.hook import _edited_paths
+    assert _edited_paths({}, "read", {"path": "diagrams/a.png?q=is it clear"}) == [
+        "diagrams/a.png"]
+    assert _edited_paths({}, "read", {"path": "src/hook.py:335-360"}) == ["src/hook.py"]
+    assert _edited_paths({}, "grep", {"path": "src/a.py;tests/b.py"}) == [
+        "src/a.py", "tests/b.py"]
+    assert _edited_paths({}, "write", {"path": "xd://lsp"}) == []
+
+
+def test_editing_glob_matches_a_path_carrying_a_selector(db):
+    mid = _add_memory(db, "Helvetica on every cell",
+                      tags=["when-editing:*.drawio"])
+    from neurostack.cli.hook import _edited_paths
+    (path,) = _edited_paths({}, "read", {"path": "diagrams/knowledge.drawio:raw"})
+    assert [h["memory_id"] for h in match_triggers(db, "editing", path)] == [mid]
+
+
+def test_tool_names_include_the_shell_command():
+    from neurostack.cli.hook import _tool_names
+    assert _tool_names("bash", {"command": " az rest --uri /x "}) == [
+        "bash", "az rest --uri /x"]
+    assert _tool_names("write", {"path": "xd://mcp__neurostack__vault_remember"}) == [
+        "write", "vault_remember"]


### PR DESCRIPTION
126 of 152 trigger-tagged memories had never fired. Three separate matching gaps, all fixed here.

**Calling triggers were exact-match only.** `_match` compared the tag value with `==` against the event value, and the adapter only ever sends a tool name. Every command-style tag (18 of 58 stored calling tags, e.g. `when-calling:az rest`) was dead on arrival. A shell call now also offers its command line, and a multi-word pattern matches against it.

**MCP names only normalised on one side.** A tag written `when-calling:mcp__neurostack__vault_write_file` never equalled the bare name. Worse, `_xd_device` cut at the first `_` after the server segment and returned `_vault_remember`, so xd:// device calls matched nothing at all. Both sides now run through `normalise_tool`.

**Edited paths carried selectors.** `read` accepts `a.png?q=...`, `a.svg:img`, `a.py:10-40`, and `grep` takes `a.py;b.py`. Those strings reached the glob matcher verbatim, so `when-editing:*.drawio` missed a real edit. Paths are split on `;` and reduced to the file name.

Follow-on effect: `is_broad_trigger` now sees through MCP prefixes, so `when-calling:mcp__neurostack__vault_read_file` is refused at save time the same way `when-calling:bash` already was. That was the tagging bug in yesterday's checkpoint batch.

Part of #178

## Verification
- `uv run ruff check src/ tests/` clean.
- `uv run pytest -q` 1047 passed.
- 6 new tests: command-line match, three MCP spellings, broad-trigger prefixes, selector stripping, `;` splitting, command in tool names.
