### PR TITLE
harvest: pending list and single-transcript harvest for queue driving

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -889,6 +889,14 @@ def main():
         help="List available session providers and exit",
     )
     p.add_argument(
+        "--pending", action="store_true",
+        help="List transcripts not harvested yet and exit (queue schedulers)",
+    )
+    p.add_argument(
+        "--session", type=str, default=None, metavar="PATH",
+        help="Harvest exactly this transcript file",
+    )
+    p.add_argument(
         "--dry-run", "-n", action="store_true",
         help="Show what would be saved without saving",
     )

--- a/src/neurostack/cli/sessions.py
+++ b/src/neurostack/cli/sessions.py
@@ -153,19 +153,41 @@ def cmd_sessions(args):
 
 def cmd_harvest(args):
     """Extract insights from recent AI coding sessions."""
-    from ..harvest import get_provider_names, harvest_sessions
+    from ..harvest import (
+        get_provider_names,
+        harvest_session_file,
+        harvest_sessions,
+        pending_sessions,
+    )
 
     if getattr(args, "list_providers", False):
         for name in get_provider_names():
             print(f"  {name}")
         return
 
-    result = harvest_sessions(
-        n_sessions=args.sessions,
-        dry_run=args.dry_run,
-        embed_url=args.embed_url,
-        provider=getattr(args, "provider", None),
-    )
+    if getattr(args, "pending", False):
+        # A scan window of 1 is the harvest default; listing wants the backlog.
+        scan = args.sessions if args.sessions > 1 else 50
+        rows = pending_sessions(scan, provider=getattr(args, "provider", None))
+        if args.json:
+            print(json.dumps(rows, indent=2, default=str))
+            return
+        for row in rows:
+            print(f"  {row['provider']:<12} {row['path']}")
+        print(f"\n  {len(rows)} transcript(s) pending of {scan} scanned")
+        return
+
+    if getattr(args, "session", None):
+        result = harvest_session_file(
+            args.session, dry_run=args.dry_run, embed_url=args.embed_url,
+        )
+    else:
+        result = harvest_sessions(
+            n_sessions=args.sessions,
+            dry_run=args.dry_run,
+            embed_url=args.embed_url,
+            provider=getattr(args, "provider", None),
+        )
 
     if args.json:
         print(json.dumps(result, indent=2, default=str))

--- a/src/neurostack/harvest.py
+++ b/src/neurostack/harvest.py
@@ -1169,16 +1169,7 @@ def harvest_sessions(
     if not all_sessions:
         return {"error": "No sessions found", "saved": [], "skipped": [], "counts": {}}
 
-    # Filter out sessions already harvested at their current mtime
-    harvest_state = _load_harvest_state()
-    sessions = []
-    for s in all_sessions:
-        prev_mtime = harvest_state.get(str(s.path))
-        # `mcp:` keys hold a transcript hash, never an mtime — compare numbers only.
-        if isinstance(prev_mtime, (int, float)) and prev_mtime == s.mtime:
-            log.debug("Skipping already-harvested session: %s (%s)", s.path.name, s.provider)
-            continue
-        sessions.append(s)
+    sessions = _unharvested(all_sessions)
 
     if not sessions:
         return {"sessions_scanned": 0, "counts": {}, "saved": [], "skipped": [],
@@ -1194,8 +1185,8 @@ def harvest_sessions(
             saved=saved, skipped=skipped, counts=counts,
         )
 
-    # Record harvested sessions (skip on dry run)
     if not dry_run:
+        harvest_state = _load_harvest_state()
         for s in sessions:
             harvest_state[str(s.path)] = s.mtime
         _save_harvest_state(harvest_state)
@@ -1203,6 +1194,88 @@ def harvest_sessions(
     return {
         "sessions_scanned": len(sessions),
         "providers": list({s.provider for s in sessions}),
+        "counts": counts,
+        "saved": saved,
+        "skipped": skipped,
+        "dry_run": dry_run,
+    }
+
+
+def _unharvested(sessions: list[SessionFile]) -> list[SessionFile]:
+    """Sessions whose current mtime has not been harvested yet.
+
+    ``mcp:`` keys hold a transcript hash, never an mtime, so only numeric
+    state values count as a previous harvest of this file.
+    """
+    state = _load_harvest_state()
+    fresh = []
+    for s in sessions:
+        seen = state.get(str(s.path))
+        if isinstance(seen, (int, float)) and seen == s.mtime:
+            continue
+        fresh.append(s)
+    return fresh
+
+
+def pending_sessions(n_sessions: int = 50, provider: str | None = None) -> list[dict]:
+    """Transcripts waiting to be harvested, newest first (issue #180).
+
+    A queue scheduler enqueues these; nothing is read or written here beyond
+    the state file, so calling it is cheap and repeatable.
+    """
+    return [
+        {
+            "path": str(s.path),
+            "provider": s.provider,
+            "mtime": s.mtime,
+            "session_id": s.path.stem,
+        }
+        for s in _unharvested(find_recent_sessions(n_sessions, provider=provider))
+    ]
+
+
+def harvest_session_file(
+    path: str,
+    dry_run: bool = False,
+    embed_url: str | None = None,
+    use_llm: bool = True,
+    scan: int = 200,
+) -> dict:
+    """Harvest exactly one transcript, addressed by path (issue #180).
+
+    The provider registry owns format detection, so the path must be one the
+    registry already discovers; an unknown path is an error rather than a
+    guess at its shape.
+    """
+    from .config import get_config
+    from .schema import DB_PATH, get_db
+
+    target = Path(path).expanduser()
+    match = next(
+        (s for s in find_recent_sessions(scan) if s.path == target), None,
+    )
+    if match is None:
+        return {"error": f"No provider owns transcript {target}",
+                "saved": [], "skipped": [], "counts": {}}
+
+    cfg = get_config()
+    conn = get_db(DB_PATH)
+    saved: list[dict] = []
+    skipped: list[dict] = []
+    counts: dict[str, int] = {}
+    _harvest_messages(
+        conn, extract_messages(match), match.provider,
+        cfg=cfg, embed_url=embed_url or cfg.embed_url, dry_run=dry_run,
+        use_llm=use_llm, saved=saved, skipped=skipped, counts=counts,
+    )
+    if not dry_run:
+        state = _load_harvest_state()
+        state[str(match.path)] = match.mtime
+        _save_harvest_state(state)
+    return {
+        "sessions_scanned": 1,
+        "providers": [match.provider],
+        "path": str(match.path),
         "counts": counts,
         "saved": saved,
         "skipped": skipped,

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1299,3 +1299,94 @@ class TestHarvestTriggers:
         assert [r["status"] for r in report["saved"]] == ["saved"]
         assert "trigger" not in report["saved"][0]
         assert not [t for t in self._tags(in_memory_db)[0] if t.startswith("when-")]
+
+
+# ---------------------------------------------------------------------------
+# pending_sessions / harvest_session_file — queue driving (issue #180)
+# ---------------------------------------------------------------------------
+
+class TestHarvestQueueEntryPoints:
+    """A queue scheduler lists what is outstanding, then harvests one path."""
+
+    def _sessions(self, tmp_path):
+        from neurostack.harvest import SessionFile
+        return [
+            SessionFile(path=tmp_path / "new.jsonl", mtime=200.0, provider="omp"),
+            SessionFile(path=tmp_path / "old.jsonl", mtime=100.0, provider="claude-code"),
+        ]
+
+    def _wire(self, tmp_path, monkeypatch, sessions):
+        import neurostack.harvest as harvest_mod
+        monkeypatch.setattr(harvest_mod, "find_recent_sessions",
+                            lambda *a, **k: sessions)
+        monkeypatch.setattr(harvest_mod, "_harvest_state_path",
+                            lambda: tmp_path / "state.json")
+
+    def test_pending_excludes_sessions_already_harvested_at_that_mtime(
+            self, tmp_path, monkeypatch):
+        from neurostack.harvest import _save_harvest_state, pending_sessions
+        sessions = self._sessions(tmp_path)
+        self._wire(tmp_path, monkeypatch, sessions)
+        assert [r["provider"] for r in pending_sessions()] == ["omp", "claude-code"]
+
+        _save_harvest_state({str(tmp_path / "old.jsonl"): 100.0})
+        assert [r["path"] for r in pending_sessions()] == [str(tmp_path / "new.jsonl")]
+
+        # A changed mtime makes a harvested transcript pending again.
+        _save_harvest_state({str(tmp_path / "old.jsonl"): 99.0})
+        assert len(pending_sessions()) == 2
+
+    def test_pending_ignores_posted_transcript_hashes(self, tmp_path, monkeypatch):
+        from neurostack.harvest import _save_harvest_state, pending_sessions
+        sessions = self._sessions(tmp_path)
+        self._wire(tmp_path, monkeypatch, sessions)
+        _save_harvest_state({"mcp:abc": "deadbeef",
+                             str(tmp_path / "new.jsonl"): "not-a-number"})
+        assert len(pending_sessions()) == 2
+
+    def test_harvest_session_file_rejects_a_path_no_provider_owns(
+            self, tmp_path, monkeypatch):
+        from neurostack.harvest import harvest_session_file
+        self._wire(tmp_path, monkeypatch, self._sessions(tmp_path))
+        out = harvest_session_file(str(tmp_path / "stray.jsonl"))
+        assert "No provider owns" in out["error"]
+        assert out["saved"] == []
+
+    def test_harvest_session_file_marks_only_that_transcript_harvested(
+            self, in_memory_db, tmp_path, monkeypatch):
+        import json as _json
+
+        import neurostack.harvest as harvest_mod
+        from neurostack.harvest import harvest_session_file
+        sessions = self._sessions(tmp_path)
+        self._wire(tmp_path, monkeypatch, sessions)
+        monkeypatch.setattr(harvest_mod, "extract_messages", lambda s: [])
+        monkeypatch.setattr(harvest_mod, "_harvest_messages",
+                            lambda *a, **k: None)
+        monkeypatch.setattr("neurostack.schema.get_db", lambda path: in_memory_db)
+        cfg = SimpleNamespace(embed_url="http://embed.test",
+                              index_llm_url="http://llm.test", index_llm_model="m",
+                              index_llm_api_key=None, writeback_enabled=False)
+        monkeypatch.setattr("neurostack.config.get_config", lambda: cfg)
+
+        out = harvest_session_file(str(tmp_path / "new.jsonl"))
+        assert out["providers"] == ["omp"]
+        state = _json.loads((tmp_path / "state.json").read_text())
+        assert state == {str(tmp_path / "new.jsonl"): 200.0}
+
+    def test_dry_run_leaves_the_transcript_pending(
+            self, in_memory_db, tmp_path, monkeypatch):
+        import neurostack.harvest as harvest_mod
+        from neurostack.harvest import harvest_session_file, pending_sessions
+        sessions = self._sessions(tmp_path)
+        self._wire(tmp_path, monkeypatch, sessions)
+        monkeypatch.setattr(harvest_mod, "extract_messages", lambda s: [])
+        monkeypatch.setattr(harvest_mod, "_harvest_messages", lambda *a, **k: None)
+        monkeypatch.setattr("neurostack.schema.get_db", lambda path: in_memory_db)
+        cfg = SimpleNamespace(embed_url="http://embed.test",
+                              index_llm_url="http://llm.test", index_llm_model="m",
+                              index_llm_api_key=None, writeback_enabled=False)
+        monkeypatch.setattr("neurostack.config.get_config", lambda: cfg)
+
+        harvest_session_file(str(tmp_path / "new.jsonl"), dry_run=True)
+        assert str(tmp_path / "new.jsonl") in [r["path"] for r in pending_sessions()]


### PR DESCRIPTION
Harvest could only be asked for "the N most recent sessions". Driving it from a queue needs two things the CLI did not expose.

**List the backlog.** `harvest_sessions` already filtered `find_recent_sessions` against `harvest_state.json` and threw the list away. That filter is now `_unharvested`, shared by both callers, and `pending_sessions` returns path, provider, mtime and session id. `--pending` defaults to a 50-session scan window, since the harvest default of 1 makes no sense for a listing.

**Harvest one transcript.** `harvest_session_file(path)` resolves the path through the provider registry, harvests that file alone, then records its mtime in the same state file. An unknown path is an error, not a guess at the file format, so format detection stays in the providers.

Both entry points share `_harvest_messages`, so redaction, dedup and per-type TTL behave exactly as before.

Part of #180

## Verification
- `uv run ruff check src/ tests/` clean.
- `uv run pytest -q` 1052 passed.
- 5 new tests: mtime filtering, posted-transcript hash keys ignored, unknown path refused, only the named transcript marked harvested, dry run leaves it pending.
- Live: `neurostack harvest --pending` listed 50 transcripts; `--session <path> --dry-run` found 41 candidates in one omp session and saved nothing.
