### PR TITLE
synthesize: allow a shell command as the index LLM

### DIFF
--- a/src/neurostack/config.py
+++ b/src/neurostack/config.py
@@ -66,6 +66,12 @@ class Config:
     # phi3.5 is MIT licensed.
     index_llm_model: str = "phi3.5"
     index_llm_api_key: str = ""
+    # Shell command that answers a prompt on stdin and prints the reply on
+    # stdout, used instead of `index_llm_url` when set. It exists so a job can
+    # run through a subscription CLI (`claude -p --model haiku`), which has no
+    # HTTP endpoint, optionally over an SSH hop to the host holding the login.
+    index_llm_command: str = ""
+    index_llm_command_timeout_s: float = 300.0
     embed_api_key: str = ""
     session_dir: Path = field(default_factory=lambda: Path.home() / ".claude" / "projects")
     api_host: str = "127.0.0.1"
@@ -194,9 +200,12 @@ def load_config() -> Config:
             if key in data:
                 setattr(cfg, key, Path(os.path.expanduser(data[key])))
         for key in ("embed_url", "embed_model", "index_llm_url", "index_llm_model",
-                    "index_llm_api_key", "embed_api_key", "api_host", "api_key"):
+                    "index_llm_api_key", "index_llm_command", "embed_api_key",
+                    "api_host", "api_key"):
             if key in data:
                 setattr(cfg, key, data[key])
+        if "index_llm_command_timeout_s" in data:
+            cfg.index_llm_command_timeout_s = float(data["index_llm_command_timeout_s"])
         for old, new in _LEGACY_LLM_KEYS.items():
             if old not in data:
                 continue

--- a/src/neurostack/synthesize.py
+++ b/src/neurostack/synthesize.py
@@ -168,11 +168,31 @@ def cluster_observations(
     return clusters, no_embedding
 
 
+def run_index_llm(prompt: str, command: str, timeout_s: float) -> str:
+    """Answer ``prompt`` with a shell command: stdin in, stdout out.
+
+    The escape hatch for a model with no HTTP endpoint — a subscription CLI,
+    or an SSH hop to the host that holds its login (issue #184).
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        command, shell=True, input=prompt, capture_output=True, text=True,
+        timeout=timeout_s,
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
+        raise RuntimeError(f"index_llm_command exited {proc.returncode}: {tail[0]}")
+    return proc.stdout
+
+
 def _synthesize(
     members: list[dict],
     index_llm_url: str,
     index_llm_model: str,
     api_key: str = "",
+    command: str = "",
+    command_timeout_s: float = 300.0,
 ) -> str:
     """One LLM synthesis for a cluster. Raises on failure — caller skips cluster."""
     import httpx
@@ -187,20 +207,23 @@ def _synthesize(
         )
     prompt = _SYNTH_PROMPT.format(n=len(members), observations="\n\n".join(blocks))
 
-    resp = httpx.post(
-        f"{index_llm_url}/v1/chat/completions",
-        headers=_auth_headers(api_key),
-        json={
-            "model": index_llm_model,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": False,
-            "temperature": 0.2,
-            "max_tokens": 1000,
-        },
-        timeout=300.0,
-    )
-    resp.raise_for_status()
-    content = _strip_fences(resp.json()["choices"][0]["message"]["content"])
+    if command:
+        content = _strip_fences(run_index_llm(prompt, command, command_timeout_s))
+    else:
+        resp = httpx.post(
+            f"{index_llm_url}/v1/chat/completions",
+            headers=_auth_headers(api_key),
+            json={
+                "model": index_llm_model,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": False,
+                "temperature": 0.2,
+                "max_tokens": 1000,
+            },
+            timeout=300.0,
+        )
+        resp.raise_for_status()
+        content = _strip_fences(resp.json()["choices"][0]["message"]["content"])
     if not content:
         raise ValueError("LLM returned an empty synthesis")
     return content
@@ -314,7 +337,11 @@ def synthesize_observations(
         plan = _plan(cluster)
         members = cluster["members"]
         try:
-            learning = _synthesize(members, index_llm_url, index_llm_model, cfg.index_llm_api_key)
+            learning = _synthesize(
+                members, index_llm_url, index_llm_model, cfg.index_llm_api_key,
+                command=cfg.index_llm_command,
+                command_timeout_s=cfg.index_llm_command_timeout_s,
+            )
         except Exception as exc:
             plan["error"] = f"synthesis failed: {exc}"
             report["skipped"].append(plan)

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -291,3 +291,64 @@ class TestRealRun:
                 "SELECT tags FROM memories WHERE memory_id = ?", (mid,)
             ).fetchone()["tags"]
             assert "superseded_by" not in tags
+
+
+class TestIndexLlmCommand:
+    """A subscription CLI has no HTTP endpoint, so the prompt goes to a shell
+    command on stdin and the reply comes back on stdout (issue #184)."""
+
+    def test_command_answers_instead_of_http(self):
+        members = [{"memory_id": 1, "created_at": "2026-09-01", "content": "a fact"}]
+        out = synth_mod._synthesize(
+            members, "http://unused.invalid", "ignored",
+            command="cat >/dev/null; printf 'the synthesised learning'",
+        )
+        assert out == "the synthesised learning"
+
+    def test_command_receives_the_prompt_on_stdin(self, tmp_path):
+        seen = tmp_path / "prompt.txt"
+        members = [{"memory_id": 7, "created_at": "2026-09-01",
+                    "content": "BASSnet needs 8000 MB"}]
+        synth_mod._synthesize(
+            members, "http://unused.invalid", "ignored",
+            command=f"tee {seen} >/dev/null; printf 'ok'",
+        )
+        prompt = seen.read_text()
+        assert "BASSnet needs 8000 MB" in prompt
+        assert "memory 7" in prompt
+
+    def test_a_failing_command_raises_so_the_cluster_is_skipped(self):
+        members = [{"memory_id": 1, "created_at": "2026-09-01", "content": "a fact"}]
+        with pytest.raises(RuntimeError, match="exited 3"):
+            synth_mod._synthesize(
+                members, "http://unused.invalid", "ignored",
+                command="echo 'session limit reached' >&2; exit 3",
+            )
+
+    def test_an_empty_reply_still_raises(self):
+        members = [{"memory_id": 1, "created_at": "2026-09-01", "content": "a fact"}]
+        with pytest.raises(ValueError, match="empty synthesis"):
+            synth_mod._synthesize(
+                members, "http://unused.invalid", "ignored", command="true",
+            )
+
+    def test_fences_are_stripped_from_a_cli_reply(self):
+        members = [{"memory_id": 1, "created_at": "2026-09-01", "content": "a fact"}]
+        out = synth_mod._synthesize(
+            members, "http://unused.invalid", "ignored",
+            command="printf '```\\nthe learning\\n```'",
+        )
+        assert out == "the learning"
+
+
+def test_config_reads_index_llm_command(tmp_path, monkeypatch):
+    import neurostack.config as cfgmod
+    path = tmp_path / "config.toml"
+    path.write_text('index_llm_command = "claude -p --model haiku"\n'
+                    'index_llm_command_timeout_s = 120\n')
+    monkeypatch.setattr(cfgmod, "CONFIG_PATH", path)
+    cfgmod._config = None
+    cfg = cfgmod.get_config()
+    assert cfg.index_llm_command == "claude -p --model haiku"
+    assert cfg.index_llm_command_timeout_s == 120.0
+    cfgmod._config = None


### PR DESCRIPTION
Synthesize builds its prompt, POSTs it to `{index_llm_url}/v1/chat/completions`, and reads `choices[0].message.content`. That shuts out any model without an HTTP endpoint, which is exactly where a Claude subscription sits: the only way in is the `claude` CLI, and its login lives on the harness host rather than on the server running the job.

`index_llm_command` adds the missing shape. When set, the prompt goes to that command on stdin and the reply is read from stdout, so the command can be `claude -p --model haiku` locally or an `ssh` hop to the machine that holds the login. Unset leaves the HTTP request exactly as it was, including the API key header.

`run_index_llm` is a named function rather than an inline `subprocess.run`, so the other index-time jobs (summaries, triples, consolidate) can adopt the same escape hatch without copying it.

Part of #184

## Verification
- `uv run ruff check src/ tests/` clean; `uv run pytest -q` 1063 passed.
- 6 new tests: the command answers instead of HTTP, the prompt reaches stdin with its memory ids, a non-zero exit raises so the cluster is skipped and the run continues, an empty reply still raises, fences are stripped, config reads both keys.
