### PR TITLE
prediction errors: separate coverage gaps from ranking misfits, and verify flags

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -702,11 +702,15 @@ def main():
         help="Show notes flagged as prediction errors"
         " (poor retrieval fit)",
     )
-    p.add_argument("--type", choices=["low_overlap", "contextual_mismatch"], default=None,
+    p.add_argument("--type", default=None,
+                   choices=["low_overlap", "coverage_gap", "contextual_mismatch"],
                    help="Filter by error type")
     p.add_argument("--limit", type=int, default=30, help="Max results to show")
     p.add_argument("--resolve", nargs="+", metavar="NOTE_PATH",
                    help="Mark note(s) as resolved")
+    p.add_argument("--verify", action="store_true",
+                   help="Re-run each flagged query and resolve flags whose note "
+                        "no longer tops the results")
     p.add_argument(
         "--workspace", "-w", default=None,
         help="Restrict results to vault subdirectory "

--- a/src/neurostack/cli/search.py
+++ b/src/neurostack/cli/search.py
@@ -837,6 +837,64 @@ def cmd_stats(args):
         print("Communities: \033[33mnot built\033[0m — run: neurostack communities build")
 
 
+def _verify_prediction_errors(conn, args) -> None:
+    """Re-run each flagged query and resolve flags that no longer reproduce.
+
+    A flag is a single observation frozen at search time. Re-indexing, a new
+    note or a ranking change can make it obsolete, and nothing re-checked it,
+    so the report filled with notes that no longer answer the query at all.
+    """
+    from ..search import PREDICTION_ERROR_SIM_THRESHOLD, hybrid_search
+
+    rows = conn.execute(
+        "SELECT error_id, note_path, query, context FROM prediction_errors"
+        " WHERE resolved_at IS NULL AND memory_id IS NULL"
+        " AND error_type IN ('low_overlap', 'coverage_gap', 'contextual_mismatch')"
+    ).fetchall()
+
+    stale, kept, failed = [], [], []
+    for r in rows:
+        try:
+            results = hybrid_search(r["query"], top_k=5, context=r["context"],
+                                    record=False)
+        except Exception as exc:
+            failed.append({"error_id": r["error_id"], "reason": str(exc)[:120]})
+            continue
+        paths = [res.note_path for res in results]
+        # The flag blamed the top hit. It only still holds if that note is
+        # still what the query pulls up first.
+        if paths[:1] == [r["note_path"]]:
+            kept.append(r["note_path"])
+        else:
+            stale.append({"error_id": r["error_id"], "note_path": r["note_path"],
+                          "query": r["query"],
+                          "top_now": paths[0] if paths else ""})
+
+    if stale:
+        conn.executemany(
+            "UPDATE prediction_errors SET resolved_at = datetime('now')"
+            " WHERE error_id = ?",
+            [(s["error_id"],) for s in stale],
+        )
+        conn.commit()
+
+    if args.json:
+        print(json.dumps({"checked": len(rows), "kept": len(kept),
+                          "resolved_stale": len(stale), "errors": failed,
+                          "stale": stale}, indent=2, default=str))
+        return
+
+    print(f"Verified {len(rows)} flag(s): {len(kept)} still reproduce, "
+          f"{len(stale)} resolved as stale.")
+    for s in stale:
+        print(f"  stale: {s['note_path']}")
+        print(f"    query \"{s['query'][:70]}\" now returns {s['top_now']}")
+    for f in failed:
+        print(f"  could not check flag {f['error_id']}: {f['reason']}")
+    if PREDICTION_ERROR_SIM_THRESHOLD and not rows:
+        print("No unresolved note flags to verify.")
+
+
 def cmd_prediction_errors(args):
     from ..schema import DB_PATH, get_db
     from ..search import PREDICTION_ERROR_MIN_OCCURRENCES, _normalize_workspace
@@ -858,6 +916,10 @@ def cmd_prediction_errors(args):
             return
         print(f"Resolved {len(paths)} note(s).")
         return
+    if args.verify:
+        _verify_prediction_errors(conn, args)
+        return
+
 
     # Note-centric only: memory_drift rows (memory_id set) are surfaced by the
     # vault_prediction_errors MCP tool, not this aggregated note view (issue #38).
@@ -937,7 +999,8 @@ def cmd_prediction_errors(args):
 
     for etype, entries in sorted(by_type.items()):
         label = {
-            "low_overlap": "LOW OVERLAP  \u2014 semantically distant from retrieval query",
+            "low_overlap": "LOW OVERLAP  \u2014 a closer note ranked below this one",
+            "coverage_gap": "COVERAGE GAP \u2014 no note fits the query; write one",
             "contextual_mismatch": "CONTEXT MISMATCH \u2014 surfaced outside expected domain",
         }.get(etype, etype.upper())
         print(f"\u25b6 {label}")
@@ -953,7 +1016,8 @@ def cmd_prediction_errors(args):
             print(f"    query: \"{sample}\"")
         print()
 
-    print("Resolve a note: cli.py prediction-errors --resolve <note_path>")
+    print("Resolve a note: neurostack prediction-errors --resolve <note_path>")
+    print("Drop flags that no longer reproduce: neurostack prediction-errors --verify")
 
 
 def cmd_record_usage(args):

--- a/src/neurostack/search.py
+++ b/src/neurostack/search.py
@@ -64,6 +64,36 @@ MAX_QUERY_ENTITIES = 50
 MAX_RESULT_ENTITIES = 40
 
 
+def classify_retrieval_error(
+    top_cosine: float,
+    best_cosine: float,
+    top_in_context: bool | None = None,
+) -> str | None:
+    """Name what went wrong when a search returned a semantically distant note.
+
+    A distant top hit has two causes needing opposite fixes, and recording both
+    as ``low_overlap`` made every flag unactionable — the live report was four
+    notes, three of them hub indexes that simply were the least-bad match for a
+    query with no home in the vault.
+
+    - ``coverage_gap``: nothing returned was close, so the vault lacks a note
+      for that query. Fix by writing one.
+    - ``low_overlap``: a closer note was returned below a distant one, so
+      ranking misfired. Fix the note or the ranking.
+    - ``contextual_mismatch``: the top hit sits outside the caller's context
+      while in-context notes exist.
+
+    ``top_in_context`` is None when the caller passed no context.
+    """
+    if top_cosine < PREDICTION_ERROR_SIM_THRESHOLD:
+        if best_cosine >= PREDICTION_ERROR_SIM_THRESHOLD:
+            return "low_overlap"
+        return "coverage_gap"
+    if top_in_context is False and top_cosine < CONTEXTUAL_MISMATCH_MAX_SIM:
+        return "contextual_mismatch"
+    return None
+
+
 def log_prediction_error(
     conn: sqlite3.Connection,
     note_path: str,
@@ -1253,22 +1283,21 @@ def hybrid_search(
             except Exception:
                 pass  # Never let reinforcement disrupt search
 
-        # Prediction error detection — check top result for high semantic distance
+        # Prediction error detection — see classify_retrieval_error.
         if deduped:
             top = deduped[0]
             top_cosine = top.get("cosine_sim", 1.0)
-            if top_cosine < PREDICTION_ERROR_SIM_THRESHOLD:
+            best_cosine = max(
+                (r.get("cosine_sim", 1.0) for r in deduped), default=top_cosine
+            )
+            in_context = (
+                None if not (context and in_context_notes)
+                else top["note_path"] in in_context_notes
+            )
+            error_type = classify_retrieval_error(top_cosine, best_cosine, in_context)
+            if error_type:
                 log_prediction_error(
-                    conn, top["note_path"], query, top_cosine, "low_overlap", context
-                )
-            elif (
-                context
-                and in_context_notes
-                and top["note_path"] not in in_context_notes
-                and top_cosine < CONTEXTUAL_MISMATCH_MAX_SIM
-            ):
-                log_prediction_error(
-                    conn, top["note_path"], query, top_cosine, "contextual_mismatch", context
+                    conn, top["note_path"], query, top_cosine, error_type, context
                 )
 
     return _to_search_results(conn, deduped)

--- a/tests/test_prediction_errors.py
+++ b/tests/test_prediction_errors.py
@@ -19,6 +19,7 @@ from neurostack.search import (
     CONTEXTUAL_MISMATCH_MAX_SIM,
     PREDICTION_ERROR_MIN_OCCURRENCES,
     PREDICTION_ERROR_SIM_THRESHOLD,
+    classify_retrieval_error,
     hybrid_search,
 )
 
@@ -91,7 +92,8 @@ class TestLowOverlapDetection:
 
         hybrid_search("predtoken", top_k=5, embed_url="http://fake")
 
-        rows = _errors(conn, "low_overlap")
+        # Nothing close was returned, so the query has no home in the vault.
+        rows = _errors(conn, "coverage_gap")
         assert len(rows) == 1
         assert rows[0]["note_path"] == "stale.md"
         # distance stored is 1 - sim
@@ -216,3 +218,104 @@ def test_thresholds_ordered():
     real band for contextual_mismatch to occupy, and occurrences gate is >= 2."""
     assert PREDICTION_ERROR_SIM_THRESHOLD < CONTEXTUAL_MISMATCH_MAX_SIM < 1.0
     assert PREDICTION_ERROR_MIN_OCCURRENCES >= 2
+
+
+class TestGapVersusMisfit:
+    """A distant top hit means either "no note fits" or "ranking misfired".
+    Those need different fixes, so they are recorded as different types."""
+
+    def test_all_results_distant_is_a_coverage_gap(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        _add_note(conn, "far-a.md", emb=_emb(*_LOW))
+        _add_note(conn, "far-b.md", emb=_emb(0.12, 0.99277))
+        _patch_search(monkeypatch, conn)
+
+        hybrid_search("predtoken", top_k=5, embed_url="http://fake")
+
+        rows = _errors(conn)
+        assert len(rows) == 1
+        assert rows[0]["error_type"] == "coverage_gap"
+
+    def test_close_note_ranked_below_a_distant_one_is_low_overlap(self):
+        # Ranking, not the classifier, decides order; feed the two cosines it
+        # would see when a closer note was returned below a distant winner.
+        assert classify_retrieval_error(0.10, 0.95) == "low_overlap"
+
+    def test_nothing_close_anywhere_is_a_gap(self):
+        assert classify_retrieval_error(0.10, 0.12) == "coverage_gap"
+
+    def test_close_top_hit_is_not_flagged(self):
+        assert classify_retrieval_error(0.95, 0.95) is None
+
+    def test_out_of_context_top_hit_in_the_band_is_a_mismatch(self):
+        assert classify_retrieval_error(0.40, 0.40, top_in_context=False) == (
+            "contextual_mismatch")
+
+    def test_no_context_means_no_mismatch_flag(self):
+        assert classify_retrieval_error(0.40, 0.40, top_in_context=None) is None
+
+
+class TestVerify:
+    """Flags are frozen observations. Re-indexing or a new note can make them
+    wrong, and nothing re-checked them, so the report filled with noise."""
+
+    class _Args:
+        json = False
+        verify = True
+
+    def _verify(self, conn, monkeypatch, results_by_query):
+        import neurostack.cli.search as cli_search
+
+        class R:
+            def __init__(self, path):
+                self.note_path = path
+
+        monkeypatch.setattr(
+            cli_search, "cmd_prediction_errors", cli_search.cmd_prediction_errors)
+        import neurostack.search as search_mod
+        monkeypatch.setattr(
+            search_mod, "hybrid_search",
+            lambda q, **kw: [R(p) for p in results_by_query.get(q, [])])
+        cli_search._verify_prediction_errors(conn, self._Args())
+
+    def test_flag_whose_note_no_longer_tops_the_query_is_resolved(
+        self, in_memory_db, monkeypatch, capsys
+    ):
+        conn = in_memory_db
+        conn.execute(
+            "INSERT INTO prediction_errors (note_path, query, cosine_distance, error_type)"
+            " VALUES ('index.md', 'herdr restart omp', 0.71, 'low_overlap')")
+        conn.commit()
+
+        self._verify(conn, monkeypatch, {"herdr restart omp": ["oh-my-pi-setup.md"]})
+
+        row = conn.execute(
+            "SELECT resolved_at FROM prediction_errors").fetchone()
+        assert row["resolved_at"] is not None
+        assert "oh-my-pi-setup.md" in capsys.readouterr().out
+
+    def test_reproducing_flag_is_kept(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        conn.execute(
+            "INSERT INTO prediction_errors (note_path, query, cosine_distance, error_type)"
+            " VALUES ('stale.md', 'some query', 0.71, 'coverage_gap')")
+        conn.commit()
+
+        self._verify(conn, monkeypatch, {"some query": ["stale.md", "other.md"]})
+
+        row = conn.execute("SELECT resolved_at FROM prediction_errors").fetchone()
+        assert row["resolved_at"] is None
+
+    def test_memory_drift_flags_are_left_alone(self, in_memory_db, monkeypatch):
+        conn = in_memory_db
+        conn.execute("INSERT INTO memories (content, entity_type) VALUES ('m', 'observation')")
+        mid = conn.execute("SELECT last_insert_rowid() AS i").fetchone()["i"]
+        conn.execute(
+            "INSERT INTO prediction_errors (note_path, memory_id, query, cosine_distance,"
+            " error_type) VALUES ('a.md', ?, 'q', 0.8, 'memory_drift')", (mid,))
+        conn.commit()
+
+        self._verify(conn, monkeypatch, {})
+
+        row = conn.execute("SELECT resolved_at FROM prediction_errors").fetchone()
+        assert row["resolved_at"] is None


### PR DESCRIPTION
`neurostack prediction-errors` listed four flags on the live vault. Re-running each flagged query showed the blamed note was no longer the top hit for any of them, and three of the four were hub `index.md` notes. The signal was pointing at the wrong thing and nothing ever re-checked it.

Two causes, both fixed here.

A distant top hit was always `low_overlap`. That merged two situations needing opposite fixes: nothing close was returned, meaning the vault has no note for that query, versus a closer note returned below a distant one, meaning ranking misfired. `classify_retrieval_error` now returns `coverage_gap`, `low_overlap`, `contextual_mismatch` or nothing, and the detection branch in `hybrid_search` calls it. Pulling the decision out of the branch also makes it testable directly, instead of arranging notes and hoping the ranker orders them a particular way.

A flag was a one-off write with no re-validation. `prediction-errors --verify` re-runs every unresolved note flag through `hybrid_search` and resolves the ones whose note no longer tops its query, printing what the query returns now. `memory_drift` rows are left alone; they are reconciled elsewhere.

Part of #186

## Verification
- `uv run ruff check src/ tests/` clean; `uv run pytest -q` 1072 passed.
- 9 tests: gap versus misfit classification across both thresholds, context band, no-context case, verify resolves a non-reproducing flag and reports the new top hit, verify keeps a reproducing flag, verify ignores memory_drift rows.
- One existing test updated: a single distant note is now a `coverage_gap`, not `low_overlap`.
