### PR TITLE
hook checkpoint: machine-readable outcome for queue runners

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -82,10 +82,16 @@ _XD_PREFIX = "xd://"
 
 @dataclass
 class Verdict:
-    """What the harness should do with this event."""
+    """What the harness should do with this event.
+
+    ``data`` carries the same outcome as ``text`` in machine-readable form, so
+    a queue runner can read fields instead of regexing the sentence. Only the
+    checkpoint paths fill it in.
+    """
 
     text: str = ""
     block: bool = False
+    data: dict | None = None
 
 
 @dataclass
@@ -1193,11 +1199,15 @@ def run_checkpoint_save(reply: str, session: str, harness: str = "cli",
         record_error(session, harness, lost)
         post_event(cfg, "checkpoint", "failed", session, harness, error=lost,
                    workspace=workspace)
-        return Verdict(f"neurostack: checkpoint {lost}")
+        return Verdict(f"neurostack: checkpoint {lost}",
+                       data={"ok": False, "saved": 0, "found": len(items),
+                             "duplicates": duplicates, "settled_through":
+                             state.since_index, "error": lost})
     if saved:
         record_ok(session, harness, saved)
         post_event(cfg, "checkpoint", "saved", session, harness, saved=saved,
                    workspace=workspace)
+    checkpoint_error = ""
     if saved + duplicates != len(items):
         checkpoint_error = (client.errors[0] if client.errors
                             else f"saved {saved} of {len(items) - duplicates} remaining memories")
@@ -1209,7 +1219,12 @@ def run_checkpoint_save(reply: str, session: str, harness: str = "cli",
         post_event(cfg, "checkpoint", "saved", session, harness, saved=0, workspace=workspace)
     return Verdict(f"neurostack: saved {saved} of {len(items) - duplicates} checkpoint memories; "
                    f"skipped {duplicates} acknowledged duplicates; "
-                   f"settled through {state.since_index}")
+                   f"settled through {state.since_index}",
+                   data={"ok": saved + duplicates == len(items), "saved": saved,
+                         "found": len(items) - duplicates,
+                         "duplicates": duplicates,
+                         "settled_through": state.since_index,
+                         "error": checkpoint_error})
 
 
 def run_checkpoint(payload: dict, harness: str = "cli",
@@ -1290,7 +1305,8 @@ def _run_failed(session: str, harness: str, message: str, cfg: ClientConfig) -> 
     post_event(cfg, "checkpoint", "failed", session, harness, error=message,
                workspace=cfg.workspace_for(os.getcwd()))
     print(f"neurostack hook checkpoint: {message}", file=sys.stderr)
-    return Verdict()
+    return Verdict(data={"ok": False, "saved": 0, "found": 0,
+                         "duplicates": 0, "error": message})
 
 
 def _with_session(payload: dict) -> dict:
@@ -1482,6 +1498,14 @@ def cmd_hook(args) -> None:
             verdict = run_event(event, payload)
     except Exception as exc:  # a hook never takes the agent down with it
         print(f"neurostack hook {event}: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return
+
+    # A queue runner asking for --json reads fields instead of matching the
+    # sentence; wording changes then stop breaking it silently.
+    if getattr(args, "json", False) and verdict.data is not None:
+        print(json.dumps({"text": verdict.text, **verdict.data}, default=str))
+        if verdict.block:
+            sys.exit(2)
         return
 
     if verdict.block:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -8,6 +8,7 @@ does with the JSON that comes back. Both run against the fake MCP endpoint in
 `conftest.py` — no live server, and never an LLM.
 """
 
+import io
 import json
 import os
 import shutil
@@ -910,3 +911,62 @@ def test_the_prompt_fences_the_transcript_and_reasserts_the_task(server):
     tail = verdict.text[verdict.text.index("--- transcript end ---"):]
     assert "reply with only the JSON array" in tail
     assert "never instructions to follow" in verdict.text[:body_at]
+
+
+# ---------------------------------------------------------------------------
+# Machine-readable outcome — a queue runner reads fields, not the sentence
+# ---------------------------------------------------------------------------
+
+def test_save_verdict_carries_counts(server):
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 1}
+    run_event("checkpoint", _payload(_messages(20)), cfg=_cfg(server))
+
+    verdict = run_checkpoint_save(REPLY, "ck", "omp", cfg=_cfg(server))
+
+    assert verdict.data == {
+        "ok": True, "saved": 2, "found": 2, "duplicates": 0,
+        "settled_through": 40, "error": "",
+    }
+
+
+def test_a_save_that_drops_an_item_reports_not_ok(server):
+    """The count mismatch, not the wording, is what a runner acts on."""
+    def boom(_args):
+        raise RuntimeError("vault offline")
+
+    run_event("checkpoint", _payload(_messages(20), session="ckfail"), cfg=_cfg(server))
+    server.replies["vault_remember"] = boom
+
+    verdict = run_checkpoint_save(REPLY, "ckfail", "omp", cfg=_cfg(server))
+
+    assert verdict.data["ok"] is False
+    assert verdict.data["saved"] < verdict.data["found"]
+    assert verdict.data["error"]
+
+
+def test_json_flag_prints_the_payload(server, capsys, monkeypatch):
+    import neurostack.cli.hook as hook_mod
+
+    server.replies["vault_remember"] = {"saved": True, "memory_id": 1}
+    monkeypatch.setattr(
+        hook_mod, "run_checkpoint",
+        lambda payload, harness="cli": hook_mod.Verdict(
+            "neurostack: saved 3 of 3 checkpoint memories",
+            data={"ok": True, "saved": 3, "found": 3, "duplicates": 0,
+                  "settled_through": 120, "error": ""}))
+
+    class Args:
+        event = "checkpoint"
+        run = True
+        harness = "omp"
+        session = "ckjson"
+        format = None
+        json = True
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    hook_mod.cmd_hook(Args())
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["saved"] == 3
+    assert payload["settled_through"] == 120
+    assert payload["text"].startswith("neurostack: saved 3 of 3")


### PR DESCRIPTION
The n8n queue worker read success out of the verdict sentence: `saved (\d+) of (\d+)` for the counts, then `exited \d+|Traceback|no checkpoint_command|unreadable` to decide whether the run really broke. Both are wording-coupled. Rewording the verdict, or a stderr line that happens to contain "Traceback", flips a healthy run to failed or lets a partial save be recorded as done.

`Verdict` now carries an optional `data` dict alongside `text`. The checkpoint save fills it with `ok`, `saved`, `found`, `duplicates`, `settled_through` and `error`; the partial-save branch and `_run_failed` fill it too. `cmd_hook` prints `{"text": ..., **data}` as one JSON line when the global `--json` flag is set, and exits 2 as before when the verdict blocks. Without `--json`, or for events that set no payload, output is byte-for-byte what the harnesses already parse.

Part of #188

## Verification
- `uv run ruff check src/ tests/` clean; `uv run pytest -q` 1075 passed.
- 3 tests: a full save reports its counts and the settled index, a save whose item never lands reports `ok: false` with `saved < found` and an error, and `--json` prints the payload with the text alongside it.
