### PR TITLE
hook checkpoint: an empty window reports success

### DIFF
--- a/src/neurostack/cli/hook.py
+++ b/src/neurostack/cli/hook.py
@@ -1272,7 +1272,12 @@ def run_checkpoint(payload: dict, harness: str = "cli",
                 state.save(checkpoint=True)
                 client.close()
             if not prompt.text:
-                return Verdict()
+                # Nothing new to summarise is a success, not a failure: a queue
+                # runner that treats a silent exit as broken retries forever.
+                return Verdict(data={"ok": True, "saved": 0, "found": 0,
+                                     "duplicates": 0,
+                                     "settled_through": state.since_index,
+                                     "error": ""})
             try:
                 proc = subprocess.run(
                     cfg.checkpoint_command, shell=True, input=prompt.text,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -970,3 +970,13 @@ def test_json_flag_prints_the_payload(server, capsys, monkeypatch):
     assert payload["saved"] == 3
     assert payload["settled_through"] == 120
     assert payload["text"].startswith("neurostack: saved 3 of 3")
+
+
+def test_nothing_to_save_is_reported_as_success(server, tmp_path):
+    """An empty window must not read as a failure, or the queue retries forever."""
+    verdict = run_checkpoint({"session": "cknoop", "messages": [], "since_index": 0},
+                             "omp", cfg=_cfg(server, checkpoint_command="cat"))
+
+    assert verdict.data["ok"] is True
+    assert verdict.data["saved"] == 0
+    assert verdict.data["error"] == ""


### PR DESCRIPTION
`run_checkpoint` returned a bare `Verdict()` when the window held nothing new. With `--json` that means no payload on stdout, so the queue runner cannot tell "nothing to save" from "the runner died" and marks the row failed. Verified live: a queued row came back `failed` with `no output` even though the command exited 0.

An empty window now reports `ok: true, saved: 0` with the settled index, matching what the save path returns.

Part of #188

## Verification
- `uv run ruff check src/ tests/` clean; `uv run pytest -q` 1076 passed.
- 1 test: a checkpoint with no messages reports success with zero saved and no error.
