### PR TITLE
queue: own checkpoint and harvest queue state in the CLI

### DIFF
--- a/src/neurostack/cli/__init__.py
+++ b/src/neurostack/cli/__init__.py
@@ -13,6 +13,7 @@ from .api import cmd_api, cmd_bundle, cmd_serve
 from .hook import EVENTS as HOOK_EVENTS
 from .hook import cmd_hook
 from .index import cmd_backfill, cmd_export, cmd_index, cmd_reembed_chunks, cmd_watch
+from .jobqueue import cmd_queue
 from .memories import cmd_consolidate, cmd_memories, cmd_promote, cmd_synthesize
 from .search import (
     cmd_ask,
@@ -868,6 +869,31 @@ def main():
     p.add_argument("--demote", action="store_true",
                    help="Demote dormant notes to status=dormant in note_metadata")
     p.set_defaults(func=cmd_decay)
+
+    # queue — the scheduler-facing job queue (issue #191)
+    p = sub.add_parser("queue", help="Job queue for background extraction work")
+    p.add_argument("queue_action", nargs="?", default="list",
+                   choices=["add", "claim", "finish", "reap", "list"],
+                   help="What to do (default: list)")
+    p.add_argument("--queue", default=None,
+                   help="Queue name, e.g. checkpoint or harvest")
+    p.add_argument("--key", default=None,
+                   help="Dedupe key: the session id or transcript path")
+    p.add_argument("--payload", default=None,
+                   help="JSON object stored with the job")
+    p.add_argument("--job-id", type=int, default=0, help="Job to finish")
+    p.add_argument("--saved", type=int, default=0, help="Memories saved")
+    p.add_argument("--output", default=None, help="Outcome text to record")
+    p.add_argument("--failed", action="store_true", help="Finish as failed")
+    p.add_argument("--cap", type=int, default=0,
+                   help="Max jobs finished per day, 0 for uncapped")
+    p.add_argument("--stale-minutes", type=int, default=30,
+                   help="Age at which a running job counts as abandoned")
+    p.add_argument("--concurrency", type=int, default=1,
+                   help="Jobs allowed to run at once")
+    p.add_argument("--status", default=None, help="Filter the listing")
+    p.add_argument("--limit", type=int, default=50, help="Max rows to list")
+    p.set_defaults(func=cmd_queue)
 
     # cooccurrence
     p = sub.add_parser("cooccurrence", help="Inspect entity co-occurrence pairs")

--- a/src/neurostack/cli/jobqueue.py
+++ b/src/neurostack/cli/jobqueue.py
@@ -1,0 +1,86 @@
+"""`neurostack queue` — the job queue a scheduler drives (issue #191).
+
+The transport-side client that asks a remote queue for a slot is cli/queue.py;
+this module owns the local queue itself.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _limits(args):
+    from ..queue import QueueLimits
+
+    return QueueLimits(
+        cap_per_day=args.cap,
+        stale_minutes=args.stale_minutes,
+        concurrency=args.concurrency,
+    )
+
+
+def cmd_queue(args) -> None:
+    """Dispatch one queue action, printing JSON when asked."""
+    from .. import queue as q
+    from ..schema import DB_PATH, get_db
+
+    conn = get_db(DB_PATH)
+    action = args.queue_action
+
+    if action == "add":
+        payload = json.loads(args.payload) if args.payload else {}
+        result = q.add(conn, args.queue, args.key, payload, _limits(args))
+        if args.json:
+            print(json.dumps(result))
+        elif result.get("duplicate"):
+            print(f"  already queued: {args.key}")
+        elif result["ok"]:
+            print(f"  queued at position {result['position']}: {args.key}")
+        else:
+            print(f"  refused: {result['reason']}")
+        if not result["ok"]:
+            sys.exit(1)
+        return
+
+    if action == "claim":
+        result = q.claim(conn, args.queue, _limits(args))
+        if args.json:
+            print(json.dumps(result))
+        elif result["claimed"]:
+            job = result["job"]
+            print(f"  claimed job {job['job_id']}: {job['key']}")
+        else:
+            print(f"  nothing claimed: {result['reason']}")
+        return
+
+    if action == "finish":
+        result = q.finish(conn, args.job_id, ok=not args.failed,
+                          saved=args.saved, output=args.output or "")
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(f"  job {result['job_id']} {result['status']}")
+        return
+
+    if action == "reap":
+        reaped = q.reap(conn, args.queue, _limits(args))
+        if args.json:
+            print(json.dumps({"reaped": reaped}))
+        else:
+            print(f"  reaped {len(reaped)} stale job(s)")
+            for r in reaped:
+                print(f"    {r['job_id']} {r['key']}")
+        return
+
+    result = q.listing(conn, queue=args.queue, status=args.status, limit=args.limit)
+    if args.json:
+        print(json.dumps(result))
+        return
+    counts = ", ".join(f"{k} {v}" for k, v in sorted(result["counts"].items()))
+    print(f"  {counts or 'empty'}")
+    for job in result["jobs"]:
+        stamp = (job["finished_at"] or job["started_at"] or job["requested_at"])[:19]
+        print(f"    {job['job_id']:<5} {job['status']:<8} {stamp}  {job['key']}")
+        if job["output"]:
+            print(f"          {job['output'][:100]}")

--- a/src/neurostack/queue.py
+++ b/src/neurostack/queue.py
@@ -1,0 +1,209 @@
+"""Job queue for background extraction work (issue #191).
+
+The checkpoint and harvest queues used to live in the orchestrator: n8n held
+dedupe, the daily cap, claiming and stale reaping as per-node JavaScript, one
+copy per queue. That cost two real bugs — a filter whose conditions were ORed
+so a fresh row was failed as stale, and a `lt` comparison that silently never
+matched a string column, leaving a crashed worker blocking its queue forever.
+
+Everything a scheduler needs is here instead:
+
+- ``add`` refuses a duplicate while one is live, and refuses past the daily cap.
+- ``claim`` hands out at most ``concurrency`` jobs, atomically.
+- ``finish`` records the outcome.
+- ``reap`` fails jobs whose runner went away.
+
+A scheduler then only calls ``neurostack queue …`` and reads JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+LIVE = ("queued", "running")
+
+
+@dataclass
+class QueueLimits:
+    """Per-queue policy. Defaults match what the n8n workflows enforced."""
+
+    cap_per_day: int = 0          # 0 = uncapped
+    stale_minutes: int = 30
+    concurrency: int = 1
+    extra: dict = field(default_factory=dict)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(moment: datetime) -> str:
+    return moment.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _row(row: sqlite3.Row) -> dict:
+    out = dict(row)
+    try:
+        out["payload"] = json.loads(out.get("payload") or "{}")
+    except ValueError:
+        out["payload"] = {}
+    return out
+
+
+def _settled_today(conn: sqlite3.Connection, queue: str) -> int:
+    """Jobs that finished since local midnight — the cap counts attempts made."""
+    midnight = _now().astimezone().replace(hour=0, minute=0, second=0, microsecond=0)
+    return conn.execute(
+        "SELECT COUNT(*) FROM job_queue WHERE queue = ? AND finished_at >= ?",
+        (queue, _iso(midnight.astimezone(timezone.utc))),
+    ).fetchone()[0]
+
+
+def add(conn: sqlite3.Connection, queue: str, key: str,
+        payload: dict | None = None, limits: QueueLimits | None = None) -> dict:
+    """Queue one job. Idempotent per key while a job for it is still live."""
+    limits = limits or QueueLimits()
+    if not queue or not key:
+        raise ValueError("queue and key are required")
+
+    live = conn.execute(
+        f"SELECT job_id FROM job_queue WHERE queue = ? AND key = ?"
+        f" AND status IN ({','.join('?' * len(LIVE))})",
+        (queue, key, *LIVE),
+    ).fetchone()
+    if live:
+        return {"ok": True, "duplicate": True, "job_id": live["job_id"],
+                "position": 0, "queue": queue, "key": key}
+
+    if limits.cap_per_day and _settled_today(conn, queue) >= limits.cap_per_day:
+        return {"ok": False, "duplicate": False, "reason": "daily cap reached",
+                "cap": limits.cap_per_day, "queue": queue, "key": key}
+
+    cur = conn.execute(
+        "INSERT INTO job_queue (queue, key, payload, requested_at)"
+        " VALUES (?, ?, ?, ?)",
+        (queue, key, json.dumps(payload or {}), _iso(_now())),
+    )
+    conn.commit()
+    waiting = conn.execute(
+        "SELECT COUNT(*) FROM job_queue WHERE queue = ? AND status = 'queued'",
+        (queue,),
+    ).fetchone()[0]
+    return {"ok": True, "duplicate": False, "job_id": cur.lastrowid,
+            "position": waiting, "queue": queue, "key": key}
+
+
+def reap(conn: sqlite3.Connection, queue: str,
+         limits: QueueLimits | None = None) -> list[dict]:
+    """Fail running jobs whose runner went away. Returns what it reaped."""
+    limits = limits or QueueLimits()
+    cutoff = _iso(_now() - timedelta(minutes=limits.stale_minutes))
+    rows = conn.execute(
+        "SELECT * FROM job_queue WHERE queue = ? AND status = 'running'",
+        (queue,),
+    ).fetchall()
+    # Compared in Python, not SQL: started_at is text, and a missing stamp has
+    # to count as stale rather than sort itself out of the comparison.
+    stale = [r for r in rows if not r["started_at"] or r["started_at"] < cutoff]
+    for r in stale:
+        conn.execute(
+            "UPDATE job_queue SET status = 'failed', finished_at = ?, output = ?"
+            " WHERE job_id = ?",
+            (_iso(_now()), f"runner went stale after {limits.stale_minutes} minutes",
+             r["job_id"]),
+        )
+    if stale:
+        conn.commit()
+    return [_row(r) for r in stale]
+
+
+def claim(conn: sqlite3.Connection, queue: str,
+          limits: QueueLimits | None = None) -> dict | None:
+    """Take the oldest queued job, or return None with the reason it waits.
+
+    Reaps first, so one crashed runner cannot wedge the queue until a human
+    notices.
+    """
+    limits = limits or QueueLimits()
+    reaped = reap(conn, queue, limits)
+
+    running = conn.execute(
+        "SELECT COUNT(*) FROM job_queue WHERE queue = ? AND status = 'running'",
+        (queue,),
+    ).fetchone()[0]
+    if running >= limits.concurrency:
+        return {"claimed": False, "reason": f"{running} already running",
+                "reaped": reaped}
+
+    if limits.cap_per_day:
+        done_today = _settled_today(conn, queue)
+        if done_today >= limits.cap_per_day:
+            return {"claimed": False,
+                    "reason": f"daily cap {done_today}/{limits.cap_per_day}",
+                    "reaped": reaped}
+
+    # One statement, so two workers racing cannot both win the same row.
+    started = _iso(_now())
+    cur = conn.execute(
+        "UPDATE job_queue SET status = 'running', started_at = ?"
+        " WHERE job_id = (SELECT job_id FROM job_queue WHERE queue = ?"
+        "   AND status = 'queued' ORDER BY job_id LIMIT 1)",
+        (started, queue),
+    )
+    conn.commit()
+    if not cur.rowcount:
+        return {"claimed": False, "reason": "queue empty", "reaped": reaped}
+
+    row = conn.execute(
+        "SELECT * FROM job_queue WHERE queue = ? AND status = 'running'"
+        " AND started_at = ? ORDER BY job_id DESC LIMIT 1",
+        (queue, started),
+    ).fetchone()
+    return {"claimed": True, "reaped": reaped, "job": _row(row)}
+
+
+def finish(conn: sqlite3.Connection, job_id: int, ok: bool,
+           saved: int = 0, output: str = "") -> dict:
+    """Record how a claimed job ended."""
+    row = conn.execute(
+        "SELECT * FROM job_queue WHERE job_id = ?", (job_id,)
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"no job {job_id}")
+    conn.execute(
+        "UPDATE job_queue SET status = ?, saved = ?, output = ?, finished_at = ?"
+        " WHERE job_id = ?",
+        ("done" if ok else "failed", int(saved), output[:2000],
+         _iso(_now()), job_id),
+    )
+    conn.commit()
+    return _row(conn.execute(
+        "SELECT * FROM job_queue WHERE job_id = ?", (job_id,)).fetchone())
+
+
+def listing(conn: sqlite3.Connection, queue: str | None = None,
+            status: str | None = None, limit: int = 50) -> dict:
+    """Rows plus per-status counts, for a report or a health check."""
+    where, params = [], []
+    if queue:
+        where.append("queue = ?")
+        params.append(queue)
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    clause = f"WHERE {' AND '.join(where)}" if where else ""
+
+    rows = conn.execute(
+        f"SELECT * FROM job_queue {clause} ORDER BY job_id DESC LIMIT ?",
+        (*params, limit),
+    ).fetchall()
+    counts = {
+        r["status"]: r["n"] for r in conn.execute(
+            f"SELECT status, COUNT(*) AS n FROM job_queue {clause} GROUP BY status",
+            params,
+        ).fetchall()
+    }
+    return {"counts": counts, "jobs": [_row(r) for r in rows]}

--- a/src/neurostack/schema.py
+++ b/src/neurostack/schema.py
@@ -32,7 +32,30 @@ def __getattr__(name: str):
         return _db_path()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
+
+# One row per queued job. The orchestrator (n8n, cron, anything) only calls
+# `neurostack queue`; dedupe, the daily cap, claiming and stale reaping live
+# here so they are tested once instead of reimplemented per scheduler.
+JOB_QUEUE_SQL = """
+CREATE TABLE IF NOT EXISTS job_queue (
+    job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    queue TEXT NOT NULL,
+    key TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued',
+    saved INTEGER NOT NULL DEFAULT 0,
+    output TEXT NOT NULL DEFAULT '',
+    requested_at TEXT NOT NULL DEFAULT (datetime('now')),
+    started_at TEXT,
+    finished_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_job_queue_pick ON job_queue(queue, status, job_id);
+CREATE INDEX IF NOT EXISTS idx_job_queue_finished ON job_queue(queue, finished_at);
+-- Dedupe is a constraint, not a scan: one live job per key per queue.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_job_queue_live
+    ON job_queue(queue, key) WHERE status IN ('queued', 'running');
+"""
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -417,6 +440,8 @@ CREATE TABLE IF NOT EXISTS triple_extraction_failed (
 CREATE INDEX IF NOT EXISTS idx_triple_failed_retry
     ON triple_extraction_failed(next_retry_at);
 """
+
+SCHEMA_SQL += JOB_QUEUE_SQL
 
 # Migration from v1 to v2: add triples tables
 MIGRATION_V2 = """
@@ -1240,6 +1265,16 @@ def _run_migrations(conn: sqlite3.Connection):
         conn.execute("INSERT OR REPLACE INTO schema_version VALUES (26)")
         conn.commit()
         log.info("Migration to v26 complete.")
+
+    if current < 27:
+        log.info(
+            "Migrating schema v26 -> v27: job_queue — checkpoint and harvest "
+            "queue state moves out of the orchestrator (issue #191)..."
+        )
+        conn.executescript(JOB_QUEUE_SQL)
+        conn.execute("INSERT OR REPLACE INTO schema_version VALUES (27)")
+        conn.commit()
+        log.info("Migration to v27 complete.")
 
 
 def get_db(db_path: Path | None = None) -> sqlite3.Connection:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,169 +1,188 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024-2026 Raphael Southall
-"""Tests for the checkpoint queue client (issue #176).
+"""Tests for the job queue (issue #191).
 
-`enqueue` never runs a checkpoint — it POSTs one request and relays what the
-queue answers. `urlopen` is monkeypatched instead of touching the network:
-deterministic, and it proves the request shape and every reply the queue's
-contract defines (queued, duplicate, cap reached, unreachable) without a
-live receiver.
+These pin the four rules the orchestrator used to own, each of which broke at
+least once while it lived in n8n JavaScript: one live job per key, a daily cap
+on finished jobs, a job claimed by exactly one worker, and a running job whose
+runner vanished getting failed instead of wedging the queue.
 """
 
-import io
-import json
-import urllib.error
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
-import neurostack.cli.queue as queue_mod
-from neurostack.cli.queue import enqueue
-from neurostack.client import ClientConfig
+from neurostack.queue import QueueLimits, add, claim, finish, listing, reap
 
 
-def _cfg(**kwargs):
-    return ClientConfig(queue_url="http://queue.test/webhook/checkpoint-request", **kwargs)
+def _iso(moment):
+    return moment.replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _body(request) -> dict:
-    return json.loads(request.data.decode("utf-8"))
-
-
-class _FakeResponse:
-    def __init__(self, body: dict):
-        self._body = json.dumps(body).encode("utf-8")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-    def read(self):
-        return self._body
-
-
-def _capture(monkeypatch, body: dict):
-    """Patch `urlopen` to record the request and answer with `body`."""
-    calls = []
-
-    def _fake_urlopen(request, timeout=None):
-        calls.append((request, timeout))
-        return _FakeResponse(body)
-
-    monkeypatch.setattr(queue_mod.urllib.request, "urlopen", _fake_urlopen)
-    return calls
-
-
-def _raise(monkeypatch, exc: Exception):
-    def _fake_urlopen(request, timeout=None):
-        raise exc
-
-    monkeypatch.setattr(queue_mod.urllib.request, "urlopen", _fake_urlopen)
-
-
-def _http_error(code: int, body: dict) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(
-        "http://queue.test/webhook/checkpoint-request", code, "error", {},
-        io.BytesIO(json.dumps(body).encode("utf-8")),
+def _age(conn, job_id, minutes):
+    """Backdate a running job's start, the way a crashed runner leaves it."""
+    conn.execute(
+        "UPDATE job_queue SET started_at = ? WHERE job_id = ?",
+        (_iso(datetime.now(timezone.utc) - timedelta(minutes=minutes)), job_id),
     )
+    conn.commit()
 
 
-def test_no_call_when_queue_url_unset(monkeypatch):
-    calls = _capture(monkeypatch, {"ok": True, "position": 1})
-    code, line = enqueue(ClientConfig(), "s1", "omp", None)
-    assert calls == []
-    assert code == 1
-    assert "no queue_url" in line
+class TestAdd:
+    def test_second_request_for_a_live_key_is_a_duplicate(self, in_memory_db):
+        first = add(in_memory_db, "checkpoint", "sess-1")
+        second = add(in_memory_db, "checkpoint", "sess-1")
+
+        assert first["job_id"] == second["job_id"]
+        assert second["duplicate"] is True
+        assert listing(in_memory_db, "checkpoint")["counts"] == {"queued": 1}
+
+    def test_a_settled_key_can_be_queued_again(self, in_memory_db):
+        job = add(in_memory_db, "checkpoint", "sess-1")
+        claim(in_memory_db, "checkpoint")
+        finish(in_memory_db, job["job_id"], ok=True)
+
+        again = add(in_memory_db, "checkpoint", "sess-1")
+
+        assert again["duplicate"] is False
+        assert again["job_id"] != job["job_id"]
+
+    def test_the_same_key_in_another_queue_is_independent(self, in_memory_db):
+        add(in_memory_db, "checkpoint", "shared")
+        other = add(in_memory_db, "harvest", "shared")
+
+        assert other["duplicate"] is False
+
+    def test_position_counts_the_jobs_ahead(self, in_memory_db):
+        add(in_memory_db, "checkpoint", "a")
+        add(in_memory_db, "checkpoint", "b")
+
+        assert add(in_memory_db, "checkpoint", "c")["position"] == 3
+
+    def test_cap_refuses_once_enough_finished_today(self, in_memory_db):
+        limits = QueueLimits(cap_per_day=2)
+        for key in ("a", "b"):
+            job = add(in_memory_db, "harvest", key, limits=limits)
+            claim(in_memory_db, "harvest", limits)
+            finish(in_memory_db, job["job_id"], ok=True)
+
+        refused = add(in_memory_db, "harvest", "c", limits=limits)
+
+        assert refused["ok"] is False
+        assert "cap" in refused["reason"]
+
+    def test_a_missing_key_is_rejected(self, in_memory_db):
+        with pytest.raises(ValueError):
+            add(in_memory_db, "checkpoint", "")
 
 
-def test_queued_body_shape(monkeypatch):
-    calls = _capture(monkeypatch, {"ok": True, "position": 3})
-    code, line = enqueue(_cfg(), "s1", "omp", "home/projects/x")
-    assert code == 0
-    assert "queued (position 3)" in line
-    assert len(calls) == 1
-    request, timeout = calls[0]
-    assert request.full_url == "http://queue.test/webhook/checkpoint-request"
-    assert request.get_header("Content-type") == "application/json"
-    assert timeout == 2.0
-    body = _body(request)
-    assert body == {
-        "session": "s1", "harness": "omp", "workspace": "home/projects/x",
-        "host": body["host"], "requested_at": body["requested_at"],
-    }
-    assert body["host"]
-    assert body["requested_at"][-6] in "+-" or body["requested_at"].endswith("Z")
+class TestClaim:
+    def test_oldest_queued_job_is_claimed_first(self, in_memory_db):
+        add(in_memory_db, "checkpoint", "first")
+        add(in_memory_db, "checkpoint", "second")
+
+        assert claim(in_memory_db, "checkpoint")["job"]["key"] == "first"
+
+    def test_a_job_is_claimed_only_once(self, in_memory_db):
+        add(in_memory_db, "checkpoint", "only")
+        add(in_memory_db, "checkpoint", "next")
+
+        first = claim(in_memory_db, "checkpoint")
+        second = claim(in_memory_db, "checkpoint")
+
+        assert first["claimed"] is True
+        assert second["claimed"] is False
+        assert second["reason"] == "1 already running"
+
+    def test_concurrency_allows_more_than_one(self, in_memory_db):
+        limits = QueueLimits(concurrency=2)
+        for key in ("a", "b", "c"):
+            add(in_memory_db, "checkpoint", key)
+
+        assert claim(in_memory_db, "checkpoint", limits)["claimed"] is True
+        assert claim(in_memory_db, "checkpoint", limits)["claimed"] is True
+        assert claim(in_memory_db, "checkpoint", limits)["claimed"] is False
+
+    def test_empty_queue_says_so(self, in_memory_db):
+        assert claim(in_memory_db, "checkpoint")["reason"] == "queue empty"
+
+    def test_cap_blocks_claiming_too(self, in_memory_db):
+        limits = QueueLimits(cap_per_day=1)
+        job = add(in_memory_db, "harvest", "a", limits=limits)
+        claim(in_memory_db, "harvest", limits)
+        finish(in_memory_db, job["job_id"], ok=True)
+        in_memory_db.execute(
+            "INSERT INTO job_queue (queue, key) VALUES ('harvest', 'b')")
+        in_memory_db.commit()
+
+        result = claim(in_memory_db, "harvest", limits)
+
+        assert result["claimed"] is False
+        assert "daily cap 1/1" in result["reason"]
 
 
-def test_timeout_never_exceeds_two_seconds(monkeypatch):
-    calls = _capture(monkeypatch, {"ok": True, "position": 1})
-    enqueue(_cfg(timeout_s=30.0), "s1", "cli", None)
-    assert calls[0][1] == 2.0
+class TestReap:
+    def test_a_stale_running_job_is_failed_and_unblocks_the_queue(self, in_memory_db):
+        """The bug this replaces: a crashed runner held its queue for good."""
+        stuck = add(in_memory_db, "checkpoint", "stuck")
+        claim(in_memory_db, "checkpoint")
+        _age(in_memory_db, stuck["job_id"], minutes=31)
+        add(in_memory_db, "checkpoint", "waiting")
+
+        result = claim(in_memory_db, "checkpoint")
+
+        assert [r["key"] for r in result["reaped"]] == ["stuck"]
+        assert result["job"]["key"] == "waiting"
+        row = in_memory_db.execute(
+            "SELECT status, output FROM job_queue WHERE job_id = ?",
+            (stuck["job_id"],)).fetchone()
+        assert row["status"] == "failed"
+        assert "stale" in row["output"]
+
+    def test_a_fresh_running_job_is_left_alone(self, in_memory_db):
+        add(in_memory_db, "checkpoint", "busy")
+        claim(in_memory_db, "checkpoint")
+
+        assert reap(in_memory_db, "checkpoint") == []
+
+    def test_a_running_job_with_no_start_stamp_counts_as_stale(self, in_memory_db):
+        in_memory_db.execute(
+            "INSERT INTO job_queue (queue, key, status) "
+            "VALUES ('checkpoint', 'orphan', 'running')")
+        in_memory_db.commit()
+
+        assert [r["key"] for r in reap(in_memory_db, "checkpoint")] == ["orphan"]
+
+    def test_only_the_named_queue_is_reaped(self, in_memory_db):
+        other = add(in_memory_db, "harvest", "other")
+        claim(in_memory_db, "harvest")
+        _age(in_memory_db, other["job_id"], minutes=90)
+
+        assert reap(in_memory_db, "checkpoint") == []
 
 
-def test_duplicate_is_still_a_success(monkeypatch):
-    _capture(monkeypatch, {"ok": True, "position": 0, "duplicate": True})
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 0
-    assert "already queued" in line
+class TestFinish:
+    def test_outcome_and_counts_are_recorded(self, in_memory_db):
+        job = add(in_memory_db, "harvest", "t.jsonl", {"provider": "omp"})
+        claim(in_memory_db, "harvest")
 
+        done = finish(in_memory_db, job["job_id"], ok=True, saved=3,
+                      output="haiku saved 3 of 3")
 
-def test_daily_cap_reached_is_exit_one(monkeypatch):
-    _raise(monkeypatch, _http_error(429, {"ok": False, "reason": "daily cap reached"}))
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "daily cap reached" in line
+        assert done["status"] == "done"
+        assert done["saved"] == 3
+        assert done["finished_at"]
+        assert done["payload"] == {"provider": "omp"}
 
+    def test_failure_is_recorded_as_failed(self, in_memory_db):
+        job = add(in_memory_db, "harvest", "t.jsonl")
+        claim(in_memory_db, "harvest")
 
-def test_daily_cap_with_no_reason_still_says_cap(monkeypatch):
-    _raise(monkeypatch, _http_error(429, {"ok": False}))
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "cap" in line
+        done = finish(in_memory_db, job["job_id"], ok=False, output="vault offline")
 
+        assert done["status"] == "failed"
+        assert done["output"] == "vault offline"
 
-def test_unreachable_on_connection_failure(monkeypatch):
-    _raise(monkeypatch, OSError("connection refused"))
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "unreachable" in line
-
-
-def test_unreachable_on_an_unexpected_status(monkeypatch):
-    _raise(monkeypatch, _http_error(500, {}))
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "unreachable" in line
-
-
-def test_unreachable_on_a_reply_outside_the_contract(monkeypatch):
-    _capture(monkeypatch, {"ok": True})  # no position, no duplicate — still queued
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 0
-    assert "queued" in line
-
-    _capture(monkeypatch, {"unexpected": "shape"})
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "unreachable" in line
-
-
-@pytest.mark.parametrize("bad_json", [b"not json", b"[]", b'"a string"'])
-def test_unreachable_on_malformed_json(monkeypatch, bad_json):
-    class _BadResponse:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *exc):
-            return False
-
-        def read(self):
-            return bad_json
-
-    def _fake_urlopen(request, timeout=None):
-        return _BadResponse()
-
-    monkeypatch.setattr(queue_mod.urllib.request, "urlopen", _fake_urlopen)
-    code, line = enqueue(_cfg(), "s1", "omp", None)
-    assert code == 1
-    assert "unreachable" in line
+    def test_an_unknown_job_raises(self, in_memory_db):
+        with pytest.raises(ValueError):
+            finish(in_memory_db, 999, ok=True)


### PR DESCRIPTION
Queue state sat in the orchestrator. n8n carried dedupe, the daily cap, the claim step and stale reaping as per-node JavaScript, duplicated across the checkpoint and harvest queues, with no tests. Both bugs found in one session came from exactly that: conditions ORed instead of ANDed, which failed a freshly queued row as stale, and a `lt` comparison against a string column that matched nothing, so a crashed worker held its queue indefinitely.

`job_queue` (schema v27) and `neurostack queue add|claim|finish|reap|list` move the rules into code:

- `add` is idempotent per key while a job is live, enforced by a unique partial index rather than a scan, and refuses once the daily cap of finished jobs is reached.
- `claim` reaps stale jobs first, respects a `--concurrency` ceiling, and takes the oldest queued row in one `UPDATE` so two workers racing cannot both win it.
- `reap` compares ages in Python because `started_at` is text and a missing stamp has to count as stale.
- `finish` records status, saved count and output.

Every subcommand prints JSON with the global `--json`, so a scheduler reads fields instead of parsing prose.

Part of #191

## Verification
- `uv run ruff check src/ tests/` clean; `uv run pytest -q` 1082 passed.
- 18 tests: duplicate while live, requeue after settling, same key in another queue, position, cap refusing adds and claims, oldest first, claimed once, concurrency above one, empty queue, stale job reaped and queue unblocked, fresh job untouched, missing start stamp treated as stale, reaping scoped per queue, outcome recorded, failure recorded, unknown job rejected.
- Smoke run: add, duplicate add, claim, blocked second claim, finish, list — all correct against a real database.
